### PR TITLE
Fix scrolling issues of the tables

### DIFF
--- a/src/app/AppLayout/AppLayout.tsx
+++ b/src/app/AppLayout/AppLayout.tsx
@@ -165,7 +165,7 @@ const AppLayout: React.FunctionComponent<IAppLayout> = ({ children }) => {
       })}
       <NavGroup title="Other sites" key="external">
         <li className="pf-c-nav__item">
-          <a className="pf-c-nav__link"  href="/dashboard">Dashboard</a>
+          <a className="pf-c-nav__link" href="/dashboard">Dashboard</a>
         </li>
       </NavGroup>
     </Nav>
@@ -173,17 +173,20 @@ const AppLayout: React.FunctionComponent<IAppLayout> = ({ children }) => {
   const Sidebar = <PageSidebar nav={Navigation} isNavOpen={isMobileView ? isNavOpenMobile : isNavOpen} theme="dark" />;
   const PageSkipToContent = <SkipToContent href="#primary-app-container">Skip to Content</SkipToContent>;
   return (
-    <Page
-      breadcrumb={<PageBreadcrumb />}
-      mainContainerId="primary-app-container"
-      header={Header}
-      sidebar={Sidebar}
-      onPageResize={onPageResize}
-      skipToContent={PageSkipToContent}
-    >
+    <React.Fragment>
       <SimpleBackgroundImage />
-      {children}
-    </Page>
+      <Page
+        breadcrumb={<PageBreadcrumb />}
+        mainContainerId="primary-app-container"
+        header={Header}
+        sidebar={Sidebar}
+        onPageResize={onPageResize}
+        skipToContent={PageSkipToContent}
+        style={{ backgroundColor: "transparent" }}
+      >
+        {children}
+      </Page>
+    </React.Fragment>
   );
 };
 

--- a/src/app/ServiceCatalog/CatalogDataList.tsx
+++ b/src/app/ServiceCatalog/CatalogDataList.tsx
@@ -61,5 +61,5 @@ export const CatalogDataList: React.FunctionComponent<{ services?: IServiceModel
       index >= 0 ? [...expanded.slice(0, index), ...expanded.slice(index + 1, expanded.length)] : [...expanded, id];
     setExpanded(newExpanded);
   };
-  return <DataList aria-label="Expandable data list example">{serviceItems}</DataList>;
+  return <DataList aria-label="List of service entities" className="horizontally-scrollable">{serviceItems}</DataList>;
 };

--- a/src/app/ServiceInventory/ServiceInventory.tsx
+++ b/src/app/ServiceInventory/ServiceInventory.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { PageSection, Title, Alert, Card, CardFooter, Toolbar, ToolbarGroup, AlertActionCloseButton } from '@patternfly/react-core';
+import { PageSection, Alert, Card, CardFooter, Toolbar, ToolbarGroup, AlertActionCloseButton } from '@patternfly/react-core';
 import { useStoreState, State, useStoreDispatch } from 'easy-peasy';
 import { IStoreModel } from '@app/Models/CoreModels';
 import { InventoryTable } from './InventoryTable';
@@ -31,15 +31,15 @@ const ServiceInventory: React.FunctionComponent<any> = props => {
       {serviceEntity && <InventoryContext.Provider value={{ attributes: serviceEntity.attributes, environmentId, inventoryUrl, setErrorMessage: setInstanceErrorMessage }} >
         {errorMessage && <Alert variant='danger' title={errorMessage} action={<AlertActionCloseButton onClose={() => setErrorMessage('')} />} />}
         {instanceErrorMessage && <Alert variant='danger' title={instanceErrorMessage} action={<AlertActionCloseButton onClose={() => setInstanceErrorMessage('')} />} />}
-        <Card>
+        <Card className={"horizontally-scrollable"}>
           <CardFooter><Toolbar>
             <ToolbarGroup> Showing instances of {serviceName} </ToolbarGroup>
             <ToolbarGroup>
               <InstanceModal buttonType={ButtonType.add} serviceName={serviceEntity.name} />
             </ToolbarGroup>
           </Toolbar></CardFooter>
-        </Card>
         {instancesOfCurrentService.length > 0 && <InventoryTable instances={instancesOfCurrentService} />}
+        </Card>
       </InventoryContext.Provider>}
     </PageSection>
   );

--- a/src/app/app.css
+++ b/src/app/app.css
@@ -11,3 +11,7 @@ html, body, #root {
 .pf-c-page__header-nav {
   align-self: auto;
 }
+
+.horizontally-scrollable {
+  overflow-x: auto;
+}


### PR DESCRIPTION
The vertical scrollbar was one layer below the background image, blocking the mouse clicks on Chrome and completely hiding the scrollbar when using Firefox.
Also added optional horizontal scrollbars to the container elements of potentially large tables.
Closes #68 