### PR TITLE
Fix for environment selector when multiple envs have the same name

### DIFF
--- a/src/app/AppLayout/AppLayout.tsx
+++ b/src/app/AppLayout/AppLayout.tsx
@@ -17,7 +17,7 @@ import {
 import { routes } from '@app/routes';
 import Logo from '!react-svg-loader!@images/logo.svg';
 import AvatarImg from '!url-loader!@assets/images/img_avatar.svg';
-import { EnvironmentSelector } from './Toolbar/EnvironmentSelector';
+import { EnvironmentSelector, IEnvironmentSelectorItem } from './Toolbar/EnvironmentSelector';
 import { SimpleNotificationBadge } from './Toolbar/SimpleNotificationBadge';
 import { IconDropdown } from './Toolbar/IconDropdown';
 import { AngleDownIcon, CogIcon } from '@patternfly/react-icons';
@@ -35,6 +35,15 @@ interface IAppLayout {
   setErrorMessage: React.Dispatch<string>;
   shouldUseAuth: boolean;
 }
+export const getEnvironmentNamesWithSeparator = (project: IProjectModel) => {
+  if (project.environments) {
+    return project.environments.map(environment => {
+      const envSelectorItem: IEnvironmentSelectorItem = { displayName: project.name + ' / ' + environment.name, projectId: project.id, environmentId: environment.id };
+      return envSelectorItem;
+    });
+  }
+  return [{ displayName: project.name, projectId: project.id }];
+};
 
 const AppLayout: React.FunctionComponent<IAppLayout> = ({ keycloak, children, setErrorMessage, shouldUseAuth }) => {
   const logoProps = {
@@ -64,22 +73,14 @@ const AppLayout: React.FunctionComponent<IAppLayout> = ({ keycloak, children, se
     setIsMobileView(props.mobileView);
   };
 
-  const getEnvironmentNamesWithSeparator = (project: IProjectModel) => {
-    if (project.environments) {
-      return project.environments.map(environment => project.name + ' / ' + environment.name);
-    }
-    return [project.name];
-  };
-
   const projects: IProjectModel[] = useStoreState((state: State<IStoreModel>) => state.projects.projects.getAllProjects);
   const environments = _.flatMap(projects, project => getEnvironmentNamesWithSeparator(project));
-
   const inmantaLogo = <Logo alt="Inmanta Logo" aria-label="Inmanta Logo" />;
 
   const Login = () => {
     const [name, setName] = React.useState('inmanta2');
     if (keycloak && keycloak.profile && keycloak.profile.username !== name) {
-        setName(keycloak.profile.username as string);
+      setName(keycloak.profile.username as string);
     }
 
     return <TextContent>{name}</TextContent>;

--- a/src/app/AppLayout/Toolbar/EnvironmentSelector.tsx
+++ b/src/app/AppLayout/Toolbar/EnvironmentSelector.tsx
@@ -3,10 +3,17 @@ import { ContextSelector, ContextSelectorItem } from '@patternfly/react-core';
 import { IStoreModel } from '@app/Models/CoreModels';
 import { useStoreDispatch, useStoreState, State } from 'easy-peasy';
 
-export const EnvironmentSelector = (props: { items: string[] }) => {
+export interface IEnvironmentSelectorItem {
+  displayName: string;
+  projectId: string;
+  environmentId?: string;
+}
+
+export const EnvironmentSelector = (props: { items: IEnvironmentSelectorItem[] }) => {
   const items = props.items;
+  const environmentNames = items.map(item => item.displayName);
   const [open, setOpen] = React.useState(false);
-  const [filteredItems, setFilteredItems] = React.useState(items);
+  const [filteredItems, setFilteredItems] = React.useState(environmentNames);
   const [searchValue, setSearchValue] = React.useState('');
   const store = useStoreState((state: State<IStoreModel>) => state.projects);
   const selectedProject = store.projects.getSelectedProject;
@@ -22,11 +29,13 @@ export const EnvironmentSelector = (props: { items: string[] }) => {
 
   const onSelect = (event: any, value: any) => {
     setOpen(!open);
-    const projectAndEnvironment = value.split('/').map(part => part.trim());
-    dispatch.projects.selectProjectAndEnvironment({
-      environment: projectAndEnvironment[1],
-      project: projectAndEnvironment[0],
-    });
+    const matchingEnvItem = items.find(envItem => envItem.displayName === value);
+    if (matchingEnvItem && matchingEnvItem.environmentId) {
+      dispatch.projects.selectProjectAndEnvironment({
+        environment: matchingEnvItem.environmentId,
+        project: matchingEnvItem.projectId,
+      });
+    }
   };
   const onSearchInputChange = (value: any) => {
     setSearchValue(value);
@@ -40,12 +49,12 @@ export const EnvironmentSelector = (props: { items: string[] }) => {
   }, [searchValue]);
 
   React.useEffect(() => {
-    setFilteredItems(items);
+    setFilteredItems(environmentNames);
   }, [items]);
 
   const filterItems = () => {
     const filtered =
-      searchValue === '' ? items : items.filter(str => str.toLowerCase().indexOf(searchValue.toLowerCase()) !== -1);
+      searchValue === '' ? environmentNames : environmentNames.filter(envName => envName.toLowerCase().indexOf(searchValue.toLowerCase()) !== -1);
     setFilteredItems(filtered || []);
   };
   return (

--- a/src/app/Models/CoreModels.tsx
+++ b/src/app/Models/CoreModels.tsx
@@ -24,6 +24,7 @@ export interface IProjectDictState {
   getAllProjects: Computed<IProjectDictState, IProjectModel[]>,
   getSelectedProject: Computed<IProjectDictState, Partial<IProjectModel>>,
   selectedProjectId: string,
+  selectProjectById: Action<IProjectDictState, string>,
   selectProjectByName: Action<IProjectDictState, string>,
 }
 
@@ -36,6 +37,7 @@ export interface IEnvironmentDictState {
   byId: IEnvironmentDict,
   getSelectedEnvironment: Computed<IEnvironmentDictState, Partial<IEnvironmentModel>>,
   selectedEnvironmentId: string,
+  selectEnvironmentById: Action<IEnvironmentDictState, string>,
   selectEnvironmentByName: Action<IEnvironmentDictState, string>,
 }
 
@@ -62,6 +64,9 @@ export const environmentState: IEnvironmentDictState = {
     }
     return {} as IProjectModel;
   }),
+  selectEnvironmentById: action((state, payload) => {
+    state.selectedEnvironmentId = payload;
+  }),
   selectEnvironmentByName: action((state, payload) => {
     const environmentWithName = Object.values(state.byId).find(item => item.name === payload);
     if (environmentWithName) {
@@ -82,6 +87,9 @@ export const projectState: IProjectDictState = {
       return state.byId[state.selectedProjectId];
     }
     return {} as IProjectModel;
+  }),
+  selectProjectById: action((state, payload) => {
+    state.selectedProjectId = payload;
   }),
   selectProjectByName: action((state, payload) => {
     const projectWithName = Object.values(state.byId).find(item => item.name === payload);
@@ -113,8 +121,8 @@ export const project: IProjectStoreModel = {
   projects: projectState,
   resources: resourceDictState,
   selectProjectAndEnvironment: thunk((actions, payload) => {
-    actions.projects.selectProjectByName(payload.project);
-    actions.environments.selectEnvironmentByName(payload.environment);
+    actions.projects.selectProjectById(payload.project);
+    actions.environments.selectEnvironmentById(payload.environment);
   }),
   serviceInstances: instanceDictState,
   services: serviceDictState,

--- a/src/app/ServiceInventory/InstanceForm.tsx
+++ b/src/app/ServiceInventory/InstanceForm.tsx
@@ -98,7 +98,6 @@ async function submitUpdate(requestParams: IRequestParams, attributeValue: IInst
   requestParams.method = "PATCH";
   const parsedAttributes = parseAttributes(attributeValue, attributeModels);
   const updatedAttributes = getChangedAttributesOnly(parsedAttributes, originalAttributes);
-  // const parsedAttributes = parseAttributes(updatedAttributes, attributeModels);
   requestParams.data = { attributes: updatedAttributes };
   await fetchInmantaApi(requestParams);
 }

--- a/src/app/ServiceInventory/ServiceInventory.tsx
+++ b/src/app/ServiceInventory/ServiceInventory.tsx
@@ -28,7 +28,9 @@ const ServiceInventory: React.FunctionComponent<any> = props => {
   const dispatchUpdateInstances = (data) => storeDispatch.projects.serviceInstances.updateInstances({ serviceName, instances: data });
   const requestParams = { urlEndpoint: inventoryUrl, dispatch: dispatchUpdateInstances, isEnvironmentIdRequired: true, environmentId, setErrorMessage, keycloak };
   const dispatchEntity = (data) => storeDispatch.projects.services.addSingleService(data);
-  ensureServiceEntityIsLoaded(projectStore, serviceName, { urlEndpoint: `/lsm/v1/service_catalog/${serviceName}`, dispatch: dispatchEntity, isEnvironmentIdRequired: true, environmentId, setErrorMessage, keycloak });
+  React.useEffect(() => {
+    ensureServiceEntityIsLoaded(projectStore, serviceName, { urlEndpoint: `/lsm/v1/service_catalog/${serviceName}`, dispatch: dispatchEntity, isEnvironmentIdRequired: true, environmentId, setErrorMessage, keycloak });
+  }, [serviceName, environmentId]);
   React.useEffect(() => {
     fetchInmantaApi(requestParams);
   }, [storeDispatch, serviceName, instancesOfCurrentService, requestParams]);


### PR DESCRIPTION
Ids are used instead of names when selecting the environment in the state store now

Closes #96 