### PR TITLE
Update easy-peasy to v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "@patternfly/react-table": "^4.16.7",
     "@patternfly/react-tokens": "^4.9.6",
     "dotenv-webpack": "^1.7.0",
-    "easy-peasy": "^3.1.0",
+    "easy-peasy": "^4.0.1",
     "keycloak-js": "6.0.1",
     "lodash": "^4.17.19",
     "moment": "^2.24.0",

--- a/src/app/Models/LsmModels.test.tsx
+++ b/src/app/Models/LsmModels.test.tsx
@@ -1,5 +1,12 @@
-import { createStore } from "easy-peasy";
-import { serviceDictState, IServiceModel, IServiceInstanceModel, instanceDictState, resourceDictState, IResourceModel } from "./LsmModels";
+import { createStore } from 'easy-peasy';
+import {
+  serviceDictState,
+  IServiceModel,
+  IServiceInstanceModel,
+  instanceDictState,
+  resourceDictState,
+  IResourceModel
+} from './LsmModels';
 
 describe('Lsm models', () => {
   describe('Service store', () => {
@@ -8,20 +15,20 @@ describe('Lsm models', () => {
         attributes: [],
         environment: 'env-id',
         lifecycle: { initialState: '', states: [], transfers: [] },
-        name: 'test_service',
+        name: 'test_service'
       },
       {
         attributes: [],
         environment: 'env-id',
         lifecycle: { initialState: '', states: [], transfers: [] },
-        name: 'another_test_service',
-      },
+        name: 'another_test_service'
+      }
     ];
     const initialState = {
       allIds: ['test_service', 'another_test_service'],
       byId: {
         another_test_service: serviceModels[1],
-        test_service: serviceModels[0],
+        test_service: serviceModels[0]
       }
     };
 
@@ -30,27 +37,29 @@ describe('Lsm models', () => {
       store.getActions().addServices(serviceModels);
       expect(store.getState().allIds).toEqual(['test_service', 'another_test_service']);
     });
+
     it('Should update services if updated content is different', () => {
       const updatedContent = [
         {
           attributes: [],
           environment: 'env-id',
           lifecycle: { initialState: 'initial_state', states: [], transfers: [] },
-          name: 'test_service',
-        },
+          name: 'test_service'
+        }
       ];
       const store = createStore(serviceDictState, { initialState });
       store.getActions().updateServices(updatedContent);
       expect(store.getState().allIds).toEqual(['test_service']);
       expect(Object.keys(store.getState().byId)).toEqual(['test_service']);
     });
+
     it('Should not update services if updated content is the same', () => {
       const store = createStore(serviceDictState, { initialState, mockActions: true });
       store.getActions().updateServices(serviceModels);
+
       expect(store.getMockedActions()).toEqual([
         { type: '@thunk.updateServices(start)', payload: serviceModels },
-        { type: '@thunk.updateServices(success)', payload: serviceModels },
-        { type: '@thunk.updateServices', payload: serviceModels },
+        { type: '@thunk.updateServices(success)', payload: serviceModels }
       ]);
     });
     it('Should remove service from the store', () => {
@@ -94,7 +103,7 @@ describe('Lsm models', () => {
       allIds: ['instance', 'anotherInstance'],
       byId: {
         anotherInstance: instances[1],
-        instance: instances[0],
+        instance: instances[0]
       }
     };
     it('Should add instances', () => {
@@ -105,53 +114,58 @@ describe('Lsm models', () => {
     it('Should update instances', () => {
       const store = createStore(instanceDictState, { initialState });
       store.getActions().updateInstances({
-        instances: [{
-          active_attributes: {},
-          callback: [],
-          candidate_attributes: {},
-          deleted: false,
-          environment: 'env-id',
-          id: 'instance',
-          last_updated: '2019-10-16T11:43:16.748302',
-          rollback_attributes: {},
-          service_entity: 'test-service',
-          state: 'up',
-          version: 3
-        }],
-        serviceName: 'test-service',
+        instances: [
+          {
+            active_attributes: {},
+            callback: [],
+            candidate_attributes: {},
+            deleted: false,
+            environment: 'env-id',
+            id: 'instance',
+            last_updated: '2019-10-16T11:43:16.748302',
+            rollback_attributes: {},
+            service_entity: 'test-service',
+            state: 'up',
+            version: 3
+          }
+        ],
+        serviceName: 'test-service'
       });
       expect(store.getState().byId.instance.state).toEqual('up');
     });
     it('Should not update instances, if the content is the same', () => {
       const store = createStore(instanceDictState, { initialState, mockActions: true });
-      const payload = { serviceName: 'test-service', instances }
+      const payload = { serviceName: 'test-service', instances };
       store.getActions().updateInstances(payload);
       expect(store.getMockedActions()).toEqual([
         { type: '@thunk.updateInstances(start)', payload },
-        { type: '@thunk.updateInstances(success)', payload },
-        { type: '@thunk.updateInstances', payload },
+        { type: '@thunk.updateInstances(success)', payload }
       ]);
-    })
+    });
   });
   describe('Resource store', () => {
-    const resources: IResourceModel[] = [{
-      instanceId: 'instance',
-      resource_id: 'fortigate::Config[fg101,config_id=system_dhcp_server_1],v=469',
-      resource_state: 'deployed',
-    },
-    {
-      instanceId: 'anotherInstance',
-      resource_id: 'openstack::VirtualMachine[openstack,name=fg101],v=469',
-      resource_state: 'deployed',
-    }
+    const resources: IResourceModel[] = [
+      {
+        instanceId: 'instance',
+        resource_id: 'fortigate::Config[fg101,config_id=system_dhcp_server_1],v=469',
+        resource_state: 'deployed'
+      },
+      {
+        instanceId: 'anotherInstance',
+        resource_id: 'openstack::VirtualMachine[openstack,name=fg101],v=469',
+        resource_state: 'deployed'
+      }
     ];
     const initialState = {
-      allIds: ['fortigate::Config[fg101,config_id=system_dhcp_server_1],v=469', 'openstack::VirtualMachine[openstack,name=fg101],v=469'],
+      allIds: [
+        'fortigate::Config[fg101,config_id=system_dhcp_server_1],v=469',
+        'openstack::VirtualMachine[openstack,name=fg101],v=469'
+      ],
       byId: {
         'fortigate::Config[fg101,config_id=system_dhcp_server_1],v=469': resources[0],
         'openstack::VirtualMachine[openstack,name=fg101],v=469': resources[1]
       }
-    }
+    };
     it('Should add resources', () => {
       const store = createStore(resourceDictState);
       const singleResource: IResourceModel[] = [resources[0]];
@@ -166,7 +180,7 @@ describe('Lsm models', () => {
       const refreshedResource = {
         instanceId: 'instance',
         resource_id: 'fortigate::Config[fg101,config_id=system_dhcp_server_1],v=471',
-        resource_state: 'deployed',
+        resource_state: 'deployed'
       };
       const store = createStore(resourceDictState);
       const singleResource: IResourceModel[] = [resources[0]];
@@ -177,16 +191,18 @@ describe('Lsm models', () => {
       expect(store.getState().allIds).toHaveLength(1);
     });
     it('Should refresh multiple resources', () => {
-      const updatedResources = [{
-        instanceId: 'instance',
-        resource_id: 'fortigate::Config[fg101,config_id=system_dhcp_server_1],v=471',
-        resource_state: 'deployed',
-      },
-      {
-        instanceId: 'instance',
-        resource_id: 'openstack::VirtualMachine[openstack,name=fg101],v=471',
-        resource_state: 'deployed',
-      }];
+      const updatedResources = [
+        {
+          instanceId: 'instance',
+          resource_id: 'fortigate::Config[fg101,config_id=system_dhcp_server_1],v=471',
+          resource_state: 'deployed'
+        },
+        {
+          instanceId: 'instance',
+          resource_id: 'openstack::VirtualMachine[openstack,name=fg101],v=471',
+          resource_state: 'deployed'
+        }
+      ];
       const store = createStore(resourceDictState);
       const singleResource: IResourceModel[] = [resources[0]];
       store.getActions().addResources({ instanceId: 'instance', resources: singleResource });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3156,11 +3156,6 @@ dateformat@^3.0.2:
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
   integrity sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==
 
-debounce@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.2.0.tgz#44a540abc0ea9943018dc0eaa95cce87f65cd131"
-  integrity sha512-mYtLl1xfZLi1m4RtQYlZgJUNQjl4ZxVnHzIR8nLLgi4q1YT8o/WM+MK/f8yfcc9s5Ir5zRaPZyZU6xs1Syoocg==
-
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -3507,20 +3502,19 @@ duplexify@^3.4.2, duplexify@^3.6.0:
     readable-stream "^2.0.0"
     stream-shift "^1.0.0"
 
-easy-peasy@^3.1.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/easy-peasy/-/easy-peasy-3.3.0.tgz#1ae7cbaa834dad5aa404f1437726fb8c0eed3cef"
-  integrity sha512-wkTDAG+nRy+4g8Z3/k1vuTyrhxet19oY5MCmuRgOObm8dtZ2m+g5Mk/sdf3UWPuyx/sKIYH5Fy/HXab8iNKjTQ==
+easy-peasy@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/easy-peasy/-/easy-peasy-4.0.1.tgz#8b3ab1ebb43509a62dc2c37b4269a9141e33d918"
+  integrity sha512-aTvB48M2ej6dM/wllUm1F7CTWGnYOYh82SHBkvJtOZhJ/9L8Gmg/nIVqDPwJeojOWZe+gbLtpyi8DhN6fPNBYg==
   dependencies:
-    debounce "^1.2.0"
-    immer-peasy "3.1.3"
-    is-plain-object "^3.0.0"
+    immer "7.0.9"
+    is-plain-object "^5.0.0"
     memoizerific "^1.11.3"
-    prop-types "^15.6.2"
     redux "^4.0.5"
     redux-thunk "^2.3.0"
-    symbol-observable "^1.2.0"
-    ts-toolbelt "^6.1.6"
+    symbol-observable "^2.0.3"
+    ts-toolbelt "^8.0.7"
+    use-memo-one "^1.1.1"
 
 ecc-jsbn@~0.1.1:
   version "0.1.2"
@@ -4978,10 +4972,10 @@ imagemin@^7.0.0:
     p-pipe "^3.0.0"
     replace-ext "^1.0.0"
 
-immer-peasy@3.1.3:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/immer-peasy/-/immer-peasy-3.1.3.tgz#d0ea8d388f47ec6b15ab2ca19ffb9f0bf4310110"
-  integrity sha512-WzoZ96A93jOmcDOLNChMWAqy+ZU8vEYQx2DcKjgo7P5SToiJs+GL+5yQbWzH8X02Lhvv6xrGgVNa1xbki66Eow==
+immer@7.0.9:
+  version "7.0.9"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-7.0.9.tgz#28e7552c21d39dd76feccd2b800b7bc86ee4a62e"
+  integrity sha512-Vs/gxoM4DqNAYR7pugIxi0Xc8XAun/uy7AQu4fLLqaTBHxjOP9pJ266Q9MWA/ly4z6rAFZbvViOtihxUZ7O28A==
 
 import-fresh@^2.0.0:
   version "2.0.0"
@@ -5355,12 +5349,10 @@ is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   dependencies:
     isobject "^3.0.1"
 
-is-plain-object@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-3.0.0.tgz#47bfc5da1b5d50d64110806c199359482e75a928"
-  integrity sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==
-  dependencies:
-    isobject "^4.0.0"
+is-plain-object@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-5.0.0.tgz#4427f50ab3429e9025ea7d52e9043a9ef4159344"
+  integrity sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==
 
 is-potential-custom-element-name@^1.0.0:
   version "1.0.0"
@@ -5466,11 +5458,6 @@ isobject@^3.0.0, isobject@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
-
-isobject@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/isobject/-/isobject-4.0.0.tgz#3f1c9155e73b192022a80819bacd0343711697b0"
-  integrity sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==
 
 isstream@~0.1.2:
   version "0.1.2"
@@ -9454,6 +9441,11 @@ symbol-observable@^1.1.0, symbol-observable@^1.2.0:
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
   integrity sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==
 
+symbol-observable@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-2.0.3.tgz#5b521d3d07a43c351055fa43b8355b62d33fd16a"
+  integrity sha512-sQV7phh2WCYAn81oAkakC5qjq2Ml0g8ozqz03wOGnx9dDlG1de6yrF+0RAzSJD8fPUow3PTSMf2SAbOGxb93BA==
+
 symbol-tree@^3.2.4:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
@@ -9707,10 +9699,10 @@ ts-loader@^6.2.0:
     micromatch "^4.0.0"
     semver "^6.0.0"
 
-ts-toolbelt@^6.1.6:
-  version "6.3.12"
-  resolved "https://registry.yarnpkg.com/ts-toolbelt/-/ts-toolbelt-6.3.12.tgz#2a9eb22759ef65d2ee3e01544f68059ea80917bf"
-  integrity sha512-hxX5rMtZRLGdRrz0LpEJO37K/SiSBoT/P1xx3WW1vON3P8FMqsCHIxrbynyWlEWHQOsLENwKV9AfEBTBNcv4eg==
+ts-toolbelt@^8.0.7:
+  version "8.0.7"
+  resolved "https://registry.yarnpkg.com/ts-toolbelt/-/ts-toolbelt-8.0.7.tgz#4dad2928831a811ee17dbdab6eb1919fc0a295bf"
+  integrity sha512-KICHyKxc5Nu34kyoODrEe2+zvuQQaubTJz7pnC5RQ19TH/Jged1xv+h8LBrouaSD310m75oAljYs59LNHkLDkQ==
 
 tsconfig-paths-webpack-plugin@^3.2.0:
   version "3.2.0"
@@ -9990,6 +9982,11 @@ url@0.11.0, url@^0.11.0:
   dependencies:
     punycode "1.3.2"
     querystring "0.2.0"
+
+use-memo-one@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/use-memo-one/-/use-memo-one-1.1.1.tgz#39e6f08fe27e422a7d7b234b5f9056af313bd22c"
+  integrity sha512-oFfsyun+bP7RX8X2AskHNTxu+R3QdE/RC5IefMbqptmACAA/gfol1KDD5KRzPsGMa62sWxGZw+Ui43u6x4ddoQ==
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
- Fix breaking test for LsmModels

# Description

According to the v4 release notes, `@thunk.actionName` action should not be triggered anymore after thunk completion.
Only the start, success & fail actions should be triggered (like `@thunk.actionName(start)`).
But the code examples in the testing docs of v4 still show the actions being triggered.
This is probably an outdated example. So we can assume this action is no longer triggered.
We are not really relying on these actions. Only the test was relying on it.

e.g. actions triggered in v3
```js
[
{ type: '@thunk.updateInstances(start)', payload },
{ type: '@thunk.updateInstances(success)', payload },
{ type: '@thunk.updateInstances', payload }
]
```

e.g. actions triggered in v4
```js
[
{ type: '@thunk.updateInstances(start)', payload },
{ type: '@thunk.updateInstances(success)', payload }
]
```

closes https://github.com/inmanta/web-console/issues/146

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] ~~Changelog entry~~
- [x] ~~Code is clear and sufficiently documented~~
- [x] ~~Sufficient test cases (reproduces the bug/tests the requested feature)~~
- [x] Correct, in line with design
- [x] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
