### PR TITLE
Add explicit default to sorting of instances

### DIFF
--- a/changelogs/unreleased/instance-sorting-default.yml
+++ b/changelogs/unreleased/instance-sorting-default.yml
@@ -1,0 +1,3 @@
+description: Add explicit default to sorting of instances
+change-type: patch
+destination-branches: [master, iso4]

--- a/src/UI/Pages/ServiceInventory/ServiceInventory.tsx
+++ b/src/UI/Pages/ServiceInventory/ServiceInventory.tsx
@@ -76,8 +76,10 @@ export const ServiceInventory: React.FunctionComponent<{
   }
 
   const { dataProvider } = useContext(DependencyContext);
-  const [sortColumn, setSortColumn] = useState<string | undefined>(undefined);
-  const [order, setOrder] = useState<SortDirection | undefined>(undefined);
+  const [sortColumn, setSortColumn] = useState<string | undefined>(
+    "created_at"
+  );
+  const [order, setOrder] = useState<SortDirection | undefined>("desc");
   const sort =
     sortColumn && order ? { name: sortColumn, order: order } : undefined;
   const [data, retry] = dataProvider.useContinuous<"ServiceInstances">({


### PR DESCRIPTION
# Description

Make the default sorting explicit

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] ~Attached issue to pull request~
- [x] Changelog entry
- [x] Code is clear and sufficiently documented
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] ~Correct, in line with design~
- [ ] ~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
