### PR TITLE
Fix diagnose ui when a rejection doesn't have error information (#373)

### DIFF
--- a/changelogs/unreleased/333-diagnose-rejected-fix.yml
+++ b/changelogs/unreleased/333-diagnose-rejected-fix.yml
@@ -1,0 +1,4 @@
+description: Fix diagnose ui when a rejection doesn't have error information
+issue-nr: 333
+change-type: patch
+destination-branches: [master, iso4]

--- a/src/Core/Domain/Diagnostics.ts
+++ b/src/Core/Domain/Diagnostics.ts
@@ -25,7 +25,7 @@ export interface Rejection {
   instance_version: number;
   model_version?: number;
   compile_id: string;
-  error: CompileError;
+  error?: CompileError;
   trace?: string;
 }
 

--- a/src/UI/Data/Diagnostics/StateHelper.ts
+++ b/src/UI/Data/Diagnostics/StateHelper.ts
@@ -13,8 +13,12 @@ export class DiagnosticsStateHelper implements StateHelper<"Diagnostics"> {
       return {
         failures: data.data.failures,
         rejections: data.data.rejections.map((rejection) => {
-          // The backend always returns only one error
-          return { ...rejection, error: rejection.errors[0] };
+          // The backend always returns maximum one error
+          return {
+            ...rejection,
+            error:
+              rejection.errors.length > 0 ? rejection.errors[0] : undefined,
+          };
         }),
       };
     }, data);

--- a/src/UI/Pages/Diagnose/RejectionCard.tsx
+++ b/src/UI/Pages/Diagnose/RejectionCard.tsx
@@ -65,9 +65,11 @@ export const RejectionCard: React.FC<Props> = ({
           />
         </CardActions>
       </CardHeader>
-      <CardTitle className="patternfly-text-gray">{error.type}</CardTitle>
+      {error && (
+        <CardTitle className="patternfly-text-gray">{error.type}</CardTitle>
+      )}
       <CardBody>
-        <pre>{error.message}</pre>
+        {error && <pre>{error.message}</pre>}
         {rejection.trace && <Traceback trace={rejection.trace} />}
       </CardBody>
     </Card>


### PR DESCRIPTION
Pull request opened by the merge tool on behalf of #373