### PR TITLE
Fix broken styling

### DIFF
--- a/changelogs/unreleased/1892-fix-broken-styling.yml
+++ b/changelogs/unreleased/1892-fix-broken-styling.yml
@@ -1,0 +1,4 @@
+description: Fix broken styling
+issue-nr: 1892
+change-type: patch
+destination-branches: [master, iso4]

--- a/src/UI/Root/app.tsx
+++ b/src/UI/Root/app.tsx
@@ -1,5 +1,4 @@
 import React, { useContext } from "react";
-import "@patternfly/react-core/dist/styles/base.css";
 import { KeycloakProvider } from "react-keycloak";
 import { Route, Routes } from "react-router-dom";
 import { Spinner, Bullseye } from "@patternfly/react-core";

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,3 +1,4 @@
+import "@patternfly/react-core/dist/styles/base.css";
 import React from "react";
 import ReactDOM from "react-dom";
 import { BrowserRouter as Router } from "react-router-dom";


### PR DESCRIPTION
# Description

The problem was not related to dependency updates, but to the reordering of the imports. The custom styling of the components were overwritten by the `base` styling from Patternfly. Importing the `base` from further up the tree seems to have fixed the issue.

closes #1892 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Code is clear and sufficiently documented
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
