### PR TITLE
Show commit hash on the status page

### DIFF
--- a/changelogs/unreleased/679-show-hash.yml
+++ b/changelogs/unreleased/679-show-hash.yml
@@ -1,0 +1,4 @@
+description: Show commit hash on the status page
+issue-nr: 679
+change-type: minor
+destination-branches: [master, iso4]

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -50,4 +50,9 @@ module.exports = {
 
   // The react-syntax-highlighter esm modules have to be handled by jest
   transformIgnorePatterns: ["node_modules/(?!react-syntax-highlighter)"],
+
+  // Provide a dummy value of the commit hash injected by webpack for testing
+  globals: {
+    COMMITHASH: "abcde123456789",
+  },
 };

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "eslint-plugin-testing-library": "^5.0.3",
     "fetch-mock": "^9.11.0",
     "file-loader": "^6.2.0",
+    "git-revision-webpack-plugin": "^5.0.0",
     "html-webpack-plugin": "^5.5.0",
     "husky": "^7.0.4",
     "imagemin": "^8.0.1",

--- a/src/UI/Pages/Status/StatusList.tsx
+++ b/src/UI/Pages/Status/StatusList.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { List } from "@patternfly/react-core";
 import {
   ClusterIcon,
+  DesktopIcon,
   IntegrationIcon,
   ModuleIcon,
   TagIcon,
@@ -41,6 +42,11 @@ export const StatusList: React.FC<Props> = ({
       name="API"
       details={[["url", apiUrl]]}
       icon={<ClusterIcon color="var(--pf-global--palette--blue-500)" />}
+    />
+    <StatusItem
+      name="Web Console"
+      details={[["version", COMMITHASH]]}
+      icon={<DesktopIcon color="var(--pf-global--palette--blue-500)" />}
     />
     {status.extensions.map((extension) => (
       <StatusItem

--- a/src/UI/Pages/Status/StatusList.tsx
+++ b/src/UI/Pages/Status/StatusList.tsx
@@ -45,7 +45,7 @@ export const StatusList: React.FC<Props> = ({
     />
     <StatusItem
       name="Web Console"
-      details={[["version", COMMITHASH]]}
+      details={[["commit hash", COMMITHASH]]}
       icon={<DesktopIcon color="var(--pf-global--palette--blue-500)" />}
     />
     {status.extensions.map((extension) => (

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -10,3 +10,4 @@ declare module "*.m4a";
 declare module "*.rdf";
 declare module "*.ttl";
 declare module "*.pdf";
+declare const COMMITHASH: string;

--- a/webpack.common.cjs
+++ b/webpack.common.cjs
@@ -1,8 +1,8 @@
 const path = require("path");
 const CopyPlugin = require("copy-webpack-plugin");
+const { GitRevisionPlugin } = require("git-revision-webpack-plugin");
 const TsconfigPathsPlugin = require("tsconfig-paths-webpack-plugin");
 const webpack = require("webpack");
-const { GitRevisionPlugin } = require("git-revision-webpack-plugin");
 const gitRevisionPlugin = new GitRevisionPlugin();
 
 module.exports = {

--- a/webpack.common.cjs
+++ b/webpack.common.cjs
@@ -2,6 +2,8 @@ const path = require("path");
 const CopyPlugin = require("copy-webpack-plugin");
 const TsconfigPathsPlugin = require("tsconfig-paths-webpack-plugin");
 const webpack = require("webpack");
+const { GitRevisionPlugin } = require("git-revision-webpack-plugin");
+const gitRevisionPlugin = new GitRevisionPlugin();
 
 module.exports = {
   entry: {
@@ -12,6 +14,10 @@ module.exports = {
     new CopyPlugin({ patterns: [{ from: "src/config.js", to: "" }] }),
     new webpack.ProvidePlugin({
       process: "process/browser",
+    }),
+    gitRevisionPlugin,
+    new webpack.DefinePlugin({
+      COMMITHASH: JSON.stringify(gitRevisionPlugin.commithash()),
     }),
   ],
   module: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8219,6 +8219,11 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
+git-revision-webpack-plugin@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/git-revision-webpack-plugin/-/git-revision-webpack-plugin-5.0.0.tgz#0683a6a110ece618499880431cd89e1eb597b536"
+  integrity sha512-RptQN/4UKcEPkCBmRy8kLPo5i8MnF8+XfAgFYN9gbwmKLTLx4YHsQw726H+C5+sIGDixDkmGL3IxPA2gKo+u4w==
+
 github-slugger@^1.0.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/github-slugger/-/github-slugger-1.3.0.tgz#9bd0a95c5efdfc46005e82a906ef8e2a059124c9"


### PR DESCRIPTION
# Description

It was added to the status page:
![Screenshot from 2022-01-17 09-20-36](https://user-images.githubusercontent.com/55082127/149733290-eeb02faa-aabc-43ab-be52-b68d50a06009.png)
Is it ok like this, or should it say something like `hash` or `commit hash` instead?

closes #679 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Code is clear and sufficiently documented
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
