### PR TITLE
Fix security alerts

### DIFF
--- a/changelogs/unreleased/2378-security-alerts.yml
+++ b/changelogs/unreleased/2378-security-alerts.yml
@@ -1,0 +1,4 @@
+description: Fix security alerts
+issue-nr: 2378
+change-type: patch
+destination-branches: [master, iso4]

--- a/changelogs/unreleased/2378-security-alerts.yml
+++ b/changelogs/unreleased/2378-security-alerts.yml
@@ -1,4 +1,4 @@
 description: Fix security alerts
 issue-nr: 2378
 change-type: patch
-destination-branches: [master, iso4]
+destination-branches: [master, iso4, iso5]

--- a/package.json
+++ b/package.json
@@ -162,7 +162,8 @@
     "ansi-regex": "^5.0.1",
     "nth-check": "^2.0.1",
     "browserslist": "^4.16.5",
-    "json-schema": "^0.4.0"
+    "json-schema": "^0.4.0",
+    "node-forge": "^1.0.0"
   },
   "madge": {
     "fileExtensions": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -11224,10 +11224,10 @@ node-fetch@^3.1.1:
     fetch-blob "^3.1.3"
     formdata-polyfill "^4.0.10"
 
-node-forge@^0.10.0:
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.10.0.tgz#32dea2afb3e9926f02ee5ce8794902691a676bf3"
-  integrity sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==
+node-forge@^0.10.0, node-forge@^1.0.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.2.1.tgz#82794919071ef2eb5c509293325cec8afd0fd53c"
+  integrity sha512-Fcvtbb+zBcZXbTTVwqGA5W+MKBj56UjVRevvchv5XrcyXbmNdesfZL37nlcWOfpgHhgmxApw3tQbTr4CqNmX4w==
 
 node-int64@^0.4.0:
   version "0.4.0"


### PR DESCRIPTION
# Description

The 2 active security alerts (at the time of writing) were:

1. `node-forge` which is only used transitively by the version 4 `webpack-dev-server` by storybook. This is mitigated by using the `resolutions` field to enforce using a fixed version
2. `post-css`, where vulnerable versions are also only used transitively by storybook. Forcing the use of a newer version causes errors when running storybook. Since no production code is impacted, I'll dismiss the alert.
![Screenshot from 2022-01-19 14-42-50.png](https://images.zenhubusercontent.com/5d760d77eb71d10001e8187e/7a6a3c6f-3930-4d6e-99c3-98923a4b7fb9)

closes #2378

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Code is clear and sufficiently documented
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
