### PR TITLE
Build(deps-dev): Bump mini-css-extract-plugin from 2.5.2 to 2.5.3 (#2500)

### DIFF
--- a/changelogs/unreleased/2500-dependabot.yml
+++ b/changelogs/unreleased/2500-dependabot.yml
@@ -1,0 +1,7 @@
+change-type: patch
+description: 'Build(deps-dev): Bump mini-css-extract-plugin from 2.5.2 to 2.5.3'
+destination-branches:
+- master
+- iso5
+- iso4
+sections: {}

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "jest-junit": "^13.0.0",
     "lint-staged": "^12.3.1",
     "madge": "^5.0.1",
-    "mini-css-extract-plugin": "^2.5.2",
+    "mini-css-extract-plugin": "^2.5.3",
     "mocha": "^9.2.0",
     "mocha-junit-reporter": "^2.0.2",
     "mochawesome": "^7.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10906,10 +10906,10 @@ min-indent@^1.0.0:
   resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
   integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
 
-mini-css-extract-plugin@^2.5.2:
-  version "2.5.2"
-  resolved "https://registry.yarnpkg.com/mini-css-extract-plugin/-/mini-css-extract-plugin-2.5.2.tgz#b3b9b98320c2c054d92c16f6a94ddfdbbba13755"
-  integrity sha512-Lwgq9qLNyBK6yNLgzssXnq4r2+mB9Mz3cJWlM8kseysHIvTicFhDNimFgY94jjqlwhNzLPsq8wv4X+vOHtMdYA==
+mini-css-extract-plugin@^2.5.3:
+  version "2.5.3"
+  resolved "https://registry.yarnpkg.com/mini-css-extract-plugin/-/mini-css-extract-plugin-2.5.3.tgz#c5c79f9b22ce9b4f164e9492267358dbe35376d9"
+  integrity sha512-YseMB8cs8U/KCaAGQoqYmfUuhhGW0a9p9XvWXrxVOkE3/IiISTLw4ALNt7JR5B2eYauFM+PQGSbXMDmVbR7Tfw==
   dependencies:
     schema-utils "^4.0.0"
 


### PR DESCRIPTION
Pull request opened by the merge tool on behalf of #2500