### PR TITLE
Encode path parameters for facts query

### DIFF
--- a/changelogs/unreleased/2623-encode-facts-path-params.yml
+++ b/changelogs/unreleased/2623-encode-facts-path-params.yml
@@ -1,0 +1,4 @@
+description: Encode path parameters for facts query
+issue-nr: 2623
+change-type: patch
+destination-branches: [master, iso5]

--- a/src/Core/Language/EncodableParam/EncodableParam.test.ts
+++ b/src/Core/Language/EncodableParam/EncodableParam.test.ts
@@ -1,0 +1,8 @@
+import { EncodableParam } from "./EncodableParam";
+
+test("Given parameter with slashes When used as a string Then returns the url encoded version", () => {
+  const param = new EncodableParam("/tmp/dir/1");
+  expect(`${param}`).toEqual("%2Ftmp%2Fdir%2F1");
+  expect(param.toString()).toEqual("%2Ftmp%2Fdir%2F1");
+  expect(`${new EncodableParam("")}`).toEqual("");
+});

--- a/src/Core/Language/EncodableParam/EncodableParam.ts
+++ b/src/Core/Language/EncodableParam/EncodableParam.ts
@@ -1,0 +1,6 @@
+export class EncodableParam {
+  constructor(private value: string) {}
+  toString() {
+    return encodeURIComponent(this.value);
+  }
+}

--- a/src/Core/Language/EncodableParam/index.ts
+++ b/src/Core/Language/EncodableParam/index.ts
@@ -1,0 +1,1 @@
+export * from "./EncodableParam";

--- a/src/Core/Language/index.ts
+++ b/src/Core/Language/index.ts
@@ -7,3 +7,4 @@ export * from "./TreeNode";
 export * from "./Utils";
 export * from "./Dictionary";
 export * from "./Scheduler";
+export * from "./EncodableParam";

--- a/src/Core/Query/GetResourceFacts.ts
+++ b/src/Core/Query/GetResourceFacts.ts
@@ -1,8 +1,9 @@
 import { Fact } from "@/Core/Domain";
+import { EncodableParam } from "..";
 
 export interface GetResourceFacts {
   kind: "GetResourceFacts";
-  resourceId: string;
+  resourceId: EncodableParam;
 }
 
 export interface GetResourceFactsManifest {

--- a/src/Data/Managers/GetResourceFacts/QueryManager.ts
+++ b/src/Data/Managers/GetResourceFacts/QueryManager.ts
@@ -13,7 +13,7 @@ export class GetResourceFactsQueryManager extends PrimaryContinuousQueryManagerW
       stateHelper,
       scheduler,
       ({ kind, resourceId }) => `${kind}_${resourceId}`,
-      ({ resourceId }) => [resourceId],
+      ({ resourceId }) => [resourceId.toString()],
       "GetResourceFacts",
       ({ resourceId }) => `/api/v2/resource/${resourceId}/facts`,
       identity

--- a/src/UI/Pages/ResourceDetails/Tabs/FactsTab/FactsTab.tsx
+++ b/src/UI/Pages/ResourceDetails/Tabs/FactsTab/FactsTab.tsx
@@ -1,4 +1,5 @@
 import React, { useContext } from "react";
+import { EncodableParam } from "@/Core";
 import { RemoteDataView } from "@/UI/Components";
 import { DependencyContext } from "@/UI/Dependency";
 import { FactsTable } from "./FactsTable";
@@ -12,7 +13,7 @@ export const FactsTab: React.FC<Props> = ({ resourceId }) => {
 
   const [data] = queryResolver.useContinuous<"GetResourceFacts">({
     kind: "GetResourceFacts",
-    resourceId,
+    resourceId: new EncodableParam(resourceId),
   });
 
   return (


### PR DESCRIPTION
# Description

Some notes:
- The query parameters are already encoded everywhere with `qs`, the problem was only present for path parameters.
- Changing the `ApiHelper` interface would cause some discrepancy when using it with from a `QueryManager` vs using it with a link provided when paging
- I opted for the alternative to have a class to handle this as it's well encapsulated.
- Another alternative is to handle this before/after the `getUrl` calls, by defining the path parameters of a query differently


closes  #2623 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Code is clear and sufficiently documented
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
