### PR TITLE
Issue/2699 empty api url

### DIFF
--- a/changelogs/unreleased/2699-fix-empty-api-url.yml
+++ b/changelogs/unreleased/2699-fix-empty-api-url.yml
@@ -1,0 +1,4 @@
+description: Fix empty api url by including origin in BaseUrlManager
+issue-nr: 2699
+change-type: patch
+destination-branches: [master, iso5]

--- a/src/Core/Contracts/BaseUrlManager.ts
+++ b/src/Core/Contracts/BaseUrlManager.ts
@@ -1,4 +1,12 @@
 export interface BaseUrlManager {
-  getConsoleBaseUrl(): string;
+  /**
+   * @returns pathname (includes anchor, excludes origin)
+   */
+  getBasePathname(): string;
+
+  /**
+   * @param forcedUrl for development purposes, a different url can be provided
+   * @returns url (includes origin and pathname, excludes anchor)
+   */
   getBaseUrl(forcedUrl?: string): string;
 }

--- a/src/Injector.tsx
+++ b/src/Injector.tsx
@@ -45,10 +45,13 @@ export const Injector: React.FC<Props> = ({ store, children }) => {
     globalThis && globalThis.auth,
     process.env.KEYCLOAK_URL
   );
-  const baseUrlManager = new PrimaryBaseUrlManager(location.pathname);
-  const consoleBaseUrl = baseUrlManager.getConsoleBaseUrl();
+  const baseUrlManager = new PrimaryBaseUrlManager(
+    globalThis.location.origin,
+    location.pathname
+  );
+  const basePathname = baseUrlManager.getBasePathname();
   const baseUrl = baseUrlManager.getBaseUrl(process.env.API_BASEURL);
-  const routeManager = new PrimaryRouteManager(consoleBaseUrl);
+  const routeManager = new PrimaryRouteManager(basePathname);
   const apiHelper = new BaseApiHelper(
     featureManager.getJsonParser() === "BigInt"
       ? new BigIntJsonParser()

--- a/src/UI/Routing/PrimaryBaseUrlManager.test.ts
+++ b/src/UI/Routing/PrimaryBaseUrlManager.test.ts
@@ -1,37 +1,46 @@
 import { PrimaryBaseUrlManager } from "./PrimaryBaseUrlManager";
 
 test.each`
-  fullUrl                         | returnText                      | returnValue
-  ${""}                           | ${"/console"}                   | ${"/console"}
-  ${"/"}                          | ${"/console"}                   | ${"/console"}
-  ${"/sub1"}                      | ${"/console"}                   | ${"/console"}
-  ${"/console/something"}         | ${"/console"}                   | ${"/console"}
-  ${"/something/console"}         | ${"/something/console"}         | ${"/something/console"}
-  ${"/something/andmore/console"} | ${"/something/andmore/console"} | ${"/something/andmore/console"}
-  ${"/something/console/wrong"}   | ${"/something/console"}         | ${"/something/console"}
+  origin                       | pathname                        | basePathname
+  ${""}                        | ${""}                           | ${"/console"}
+  ${""}                        | ${"/"}                          | ${"/console"}
+  ${""}                        | ${"/sub1"}                      | ${"/console"}
+  ${""}                        | ${"/console/something"}         | ${"/console"}
+  ${""}                        | ${"/something/console"}         | ${"/something/console"}
+  ${""}                        | ${"/something/andmore/console"} | ${"/something/andmore/console"}
+  ${"http://example.com:8888"} | ${""}                           | ${"/console"}
+  ${"http://example.com:8888"} | ${"/console/something"}         | ${"/console"}
+  ${"http://example.com:8888"} | ${"/something/console"}         | ${"/something/console"}
 `(
-  "GIVEN BaseUrlFinder WHEN url = $fullUrl THEN returns $returnText",
-  ({ fullUrl, returnValue }) => {
-    expect(new PrimaryBaseUrlManager(fullUrl).getConsoleBaseUrl()).toEqual(
-      returnValue
-    );
+  "GIVEN BaseUrlFinder.getBasePathname WHEN ($origin,$pathname) THEN returns $returnText",
+  ({ origin, pathname, basePathname }) => {
+    expect(
+      new PrimaryBaseUrlManager(origin, pathname).getBasePathname()
+    ).toEqual(basePathname);
   }
 );
 
 test.each`
-  fullUrl                         | returnText              | returnValue
-  ${""}                           | ${""}                   | ${""}
-  ${"/"}                          | ${""}                   | ${""}
-  ${"/sub1"}                      | ${""}                   | ${""}
-  ${"/console/something"}         | ${""}                   | ${""}
-  ${"/something/console"}         | ${"/something"}         | ${"/something"}
-  ${"/something/andmore/console"} | ${"/something/andmore"} | ${"/something/andmore"}
-  ${"/something/console/wrong"}   | ${"/something"}         | ${"/something"}
+  origin                       | pathname                        | baseUrl
+  ${""}                        | ${""}                           | ${""}
+  ${""}                        | ${"/"}                          | ${""}
+  ${""}                        | ${"/sub1"}                      | ${""}
+  ${""}                        | ${"/console/something"}         | ${""}
+  ${""}                        | ${"/something/console"}         | ${"/something"}
+  ${""}                        | ${"/something/andmore/console"} | ${"/something/andmore"}
+  ${""}                        | ${"/something/console/after"}   | ${"/something"}
+  ${"http://example.com:8888"} | ${""}                           | ${"http://example.com:8888"}
+  ${"http://example.com:8888"} | ${"/"}                          | ${"http://example.com:8888"}
+  ${"http://example.com:8888"} | ${"/sub1"}                      | ${"http://example.com:8888"}
+  ${"http://example.com:8888"} | ${"/console/something"}         | ${"http://example.com:8888"}
+  ${"http://example.com:8888"} | ${"/something/console"}         | ${"http://example.com:8888/something"}
+  ${"http://example.com:8888"} | ${"/something/andmore/console"} | ${"http://example.com:8888/something/andmore"}
+  ${"http://example.com:8888"} | ${"/something/console/after"}   | ${"http://example.com:8888/something"}
 `(
   "GIVEN BaseUrlFinder WHEN url = $fullUrl THEN returns $returnText",
-  ({ fullUrl, returnValue }) => {
-    expect(new PrimaryBaseUrlManager(fullUrl).getBaseUrl()).toEqual(
-      returnValue
+  ({ origin, pathname, baseUrl }) => {
+    expect(new PrimaryBaseUrlManager(origin, pathname).getBaseUrl()).toEqual(
+      baseUrl
     );
   }
 );

--- a/src/UI/Routing/PrimaryBaseUrlManager.ts
+++ b/src/UI/Routing/PrimaryBaseUrlManager.ts
@@ -1,19 +1,24 @@
 import { BaseUrlManager } from "@/Core";
 
 export class PrimaryBaseUrlManager implements BaseUrlManager {
-  private readonly ANCHOR = "/console";
+  private readonly anchor = "/console";
 
-  constructor(private readonly url: string) {}
+  constructor(
+    private readonly origin: string,
+    private readonly pathname: string
+  ) {}
 
-  getConsoleBaseUrl(): string {
-    const { ANCHOR, url } = this;
-    if (!url.includes(ANCHOR)) return ANCHOR;
-    if (url.split(ANCHOR).length > 2) return ANCHOR;
-    const [pre] = this.url.split(ANCHOR);
-    return `${pre}${ANCHOR}`;
+  getBasePathname(): string {
+    const { pathname, anchor } = this;
+    if (!pathname.includes(anchor)) return anchor;
+    if (pathname.split(anchor).length > 2) return anchor;
+    const [pre] = pathname.split(anchor);
+    return `${pre}${anchor}`;
   }
 
   getBaseUrl(forcedUrl?: string): string {
-    return forcedUrl || this.getConsoleBaseUrl().replace(this.ANCHOR, "");
+    const { anchor, origin } = this;
+    const basePathname = this.getBasePathname().replace(anchor, "");
+    return forcedUrl || `${origin}${basePathname}`;
   }
 }


### PR DESCRIPTION
# Description

I have changed the PrimaryBaseUrlManager to also use the origin in finding out the baseUrl.
This is only used for the API. Not for routing.
Routing now uses the `basePathname`.
Routing can't use the `baseUrl`, since the baseUrl contains the origin, and the origin can contain a port.
Routing would fail on the port because it thinks `:8888` is a path param.

closes #2699 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Code is clear and sufficiently documented
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
