### PR TITLE
Fix parsing long list of items saved to url

### DIFF
--- a/changelogs/unreleased/2680-parse-long-list-url.yml
+++ b/changelogs/unreleased/2680-parse-long-list-url.yml
@@ -1,0 +1,4 @@
+description: Fix parsing long list of items saved to url
+issue-nr: 2680
+change-type: patch
+destination-branches: [master, iso5, iso4]

--- a/src/UI/Routing/SearchHelper/SearchHelper.spec.ts
+++ b/src/UI/Routing/SearchHelper/SearchHelper.spec.ts
@@ -5,3 +5,17 @@ const helper = new SearchHelper();
 test("GIVEN helper.keepEnvOnly WHEN search with env and other values THEN search with only env is returned", () => {
   expect(helper.keepEnvOnly("?abc=def&env=123")).toMatch("?env=123");
 });
+
+test("GIVEN a very long query string with more than 20 elements in an array WHEN parsing the query string THEN parses the array as an array, not an object", () => {
+  let query = "?env=d2dbf117-14be-42c5-94e2-183f3e2fc51e";
+  const expectedKeys: string[] = [];
+  for (let i = 0; i < 25; i++) {
+    const key = `val${i}`;
+    query += `&state.ResourceDetails.logs-expansion[${i}]=${key}`;
+    expectedKeys.push(key);
+  }
+  expect(
+    (helper.parse(query).state as Record<string, Record<string, string>>)
+      .ResourceDetails["logs-expansion"]
+  ).toEqual(expectedKeys);
+});

--- a/src/UI/Routing/SearchHelper/SearchHelper.ts
+++ b/src/UI/Routing/SearchHelper/SearchHelper.ts
@@ -15,7 +15,10 @@ export class SearchHelper {
    * The search string can have a leading question mark.
    */
   parse(search: string): Record<string, unknown> {
-    return qs.parse(this.clearQuestionMark(search), { allowDots: true });
+    return qs.parse(this.clearQuestionMark(search), {
+      allowDots: true,
+      arrayLimit: 200,
+    });
   }
 
   /**


### PR DESCRIPTION
# Description

The issue was caused by the default option of `arrayLimit` on `qs` which caused arrays that are longer than 20 items to be parsed as an object instead of an array. (https://github.com/ljharb/qs#parsing-arrays)

closes #2680 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Code is clear and sufficiently documented
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
