### PR TITLE
Issue/2877 compare widget font size

### DIFF
--- a/changelogs/unreleased/2877-refactor-compare-selection-widget.yml
+++ b/changelogs/unreleased/2877-refactor-compare-selection-widget.yml
@@ -1,0 +1,4 @@
+description: Refactor CompareSelectionWidget
+issue-nr: 2877
+change-type: patch
+destination-branches: [master, iso5, iso4]

--- a/src/UI/Pages/DesiredState/Components/CompareSelectionLabel.tsx
+++ b/src/UI/Pages/DesiredState/Components/CompareSelectionLabel.tsx
@@ -1,0 +1,65 @@
+import React from "react";
+import { Button } from "@patternfly/react-core";
+import { TimesIcon } from "@patternfly/react-icons";
+import styled from "styled-components";
+import { Maybe } from "@/Core";
+import { words } from "@/UI/words";
+import { CompareSelection } from "../Utils";
+
+interface Props {
+  onDelete(): void;
+  selection: CompareSelection;
+}
+
+export const CompareSelectionLabel: React.FC<Props> = ({
+  selection,
+  onDelete,
+}) => (
+  <Container>
+    <Title>{words("desiredState.compare.selectionLabel")}</Title>
+    <Selection>
+      <SelectionText>
+        {Maybe.isSome(selection) && (
+          <>
+            <b>{selection.value}</b> &amp;
+          </>
+        )}{" "}
+        ...
+      </SelectionText>
+      {Maybe.isSome(selection) && (
+        <SelectionAction onClick={onDelete} variant="plain">
+          <TimesIcon size="sm" />
+        </SelectionAction>
+      )}
+    </Selection>
+  </Container>
+);
+
+const Container = styled.div`
+  display: inline-flex;
+  font-size: var(--pf-global--FontSize--md);
+  line-height: 24px;
+  height: 36px;
+  padding: 6px 6px 6px 8px;
+  background-color: var(--pf-global--BackgroundColor--200);
+`;
+
+const Title = styled.span`
+  display: inline-block;
+  margin-right: 8px;
+`;
+
+const Selection = styled.div`
+  background-color: var(--pf-global--BackgroundColor--100);
+  border-radius: 3px;
+  font-size: var(--pf-global--FontSize--sm);
+`;
+
+const SelectionText = styled.span`
+  padding: 0 4px;
+`;
+
+const SelectionAction = styled(Button)`
+  padding: 0 4px;
+  line-height: 24px;
+`;

--- a/src/UI/Pages/DesiredState/Components/CompareSelectionWidget.stories.tsx
+++ b/src/UI/Pages/DesiredState/Components/CompareSelectionWidget.stories.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import { Maybe } from "@/Core";
+import { Spacer } from "@/UI/Components";
+import { CompareSelectionLabel } from "./CompareSelectionLabel";
+
+export default {
+  title: "DesiredState/CompareSelectionLabel",
+  component: CompareSelectionLabel,
+};
+
+export const Default = () => (
+  <>
+    <CompareSelectionLabel
+      onDelete={() => alert("onDelete")}
+      selection={Maybe.none()}
+    />
+    <Spacer />
+    <CompareSelectionLabel
+      onDelete={() => alert("onDelete")}
+      selection={Maybe.some(123)}
+    />
+    <Spacer />
+    <CompareSelectionLabel
+      onDelete={() => alert("onDelete")}
+      selection={Maybe.some(987654321888888)}
+    />
+  </>
+);

--- a/src/UI/Pages/DesiredState/Components/CompareSelectionWidget.tsx
+++ b/src/UI/Pages/DesiredState/Components/CompareSelectionWidget.tsx
@@ -1,8 +1,7 @@
 import React, { useContext } from "react";
-import { Chip, ChipGroup } from "@patternfly/react-core";
 import { Maybe } from "@/Core";
 import { GetDesiredStatesContext } from "@/UI/Pages/DesiredState/GetDesiredStatesContext";
-import { words } from "@/UI/words";
+import { CompareSelectionLabel } from "./CompareSelectionLabel";
 
 export const CompareSelectionWidget: React.FC = () => {
   const { compareSelection: selection, setCompareSelection } = useContext(
@@ -13,15 +12,5 @@ export const CompareSelectionWidget: React.FC = () => {
     setCompareSelection(Maybe.none());
   };
 
-  return (
-    <ChipGroup categoryName={words("desiredState.compare.selectionLabel")}>
-      {Maybe.isNone(selection) ? (
-        <Chip isReadOnly>...</Chip>
-      ) : (
-        <Chip onClick={onDelete}>
-          <b>{selection.value}</b> &amp; ...
-        </Chip>
-      )}
-    </ChipGroup>
-  );
+  return <CompareSelectionLabel selection={selection} onDelete={onDelete} />;
 };


### PR DESCRIPTION
# Description

The original implementation was a ChipGroup. Increasing the fontsize broke the alignment a bit. So I just created it from scratch. Semantics wise, it never was a chip group. So I think it is fine for this to be a custom component.

closes #2877 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Code is clear and sufficiently documented
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
