### PR TITLE
Show warning when no attributes for EditInstance page

### DIFF
--- a/changelogs/unreleased/2865-edit-instance-no-attributes.yml
+++ b/changelogs/unreleased/2865-edit-instance-no-attributes.yml
@@ -1,0 +1,4 @@
+description: Show warning when no attributes for edit instance page
+issue-nr: 2865
+change-type: patch
+destination-branches: [master, iso5, iso4]

--- a/src/UI/Components/ServiceInstanceForm/ServiceInstanceForm.tsx
+++ b/src/UI/Components/ServiceInstanceForm/ServiceInstanceForm.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { ActionGroup, Button, Form } from "@patternfly/react-core";
+import { ActionGroup, Alert, Button, Form } from "@patternfly/react-core";
 import { set } from "lodash-es";
 import styled from "styled-components";
 import { InstanceAttributeModel, Field } from "@/Core";
@@ -54,6 +54,14 @@ export const ServiceInstanceForm: React.FC<Props> = ({
           path={null}
         />
       ))}
+
+      {fields.length <= 0 && (
+        <Alert
+          variant="info"
+          isInline
+          title={words("inventory.editInstance.noAttributes")}
+        />
+      )}
 
       <ActionGroup>
         <ActionDisabledTooltip

--- a/src/UI/Pages/EditInstance/EditForm.tsx
+++ b/src/UI/Pages/EditInstance/EditForm.tsx
@@ -67,7 +67,7 @@ export const EditForm: React.FC<Props> = ({ serviceEntity, instance }) => {
         fields={fields}
         onSubmit={onSubmit}
         onCancel={handleRedirect}
-        isSubmitDisabled={fields.length > 0 && isHalted}
+        isSubmitDisabled={isHalted}
         originalAttributes={currentAttributes ? currentAttributes : undefined}
       />
     </>

--- a/src/UI/Pages/EditInstance/EditForm.tsx
+++ b/src/UI/Pages/EditInstance/EditForm.tsx
@@ -67,7 +67,7 @@ export const EditForm: React.FC<Props> = ({ serviceEntity, instance }) => {
         fields={fields}
         onSubmit={onSubmit}
         onCancel={handleRedirect}
-        isSubmitDisabled={isHalted}
+        isSubmitDisabled={fields.length > 0 && isHalted}
         originalAttributes={currentAttributes ? currentAttributes : undefined}
       />
     </>

--- a/src/UI/words.ts
+++ b/src/UI/words.ts
@@ -121,6 +121,8 @@ const dict = {
   "inventory.editInstance.button": "Edit",
   "inventory.editInstance.title": "Edit instance",
   "inventory.editInstance.failed": "Editing instance failed",
+  "inventory.editInstance.noAttributes":
+    "There are no attributes to edit. Click confirm to move into the update state",
   "inventory.editInstance.header": (instanceId: string) =>
     `Change attributes of instance ${instanceId}`,
   "inventory.form.typeHint.list": (listBaseType: string) =>


### PR DESCRIPTION
# Description

I am not really sure about enabling the confirm button when the environment is halted. Is this correct?
I am missing some context as to what this actually means.

closes #2865 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Code is clear and sufficiently documented
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
