### PR TITLE
Show resource id without version in resources table

### DIFF
--- a/changelogs/unreleased/2870-resource-id-in-table.yml
+++ b/changelogs/unreleased/2870-resource-id-in-table.yml
@@ -1,0 +1,4 @@
+description: Show resource id without version in resources table
+issue-nr: 2870
+change-type: patch
+destination-branches: [master, iso5]

--- a/src/UI/Components/ResourceTable/ResourceTable.tsx
+++ b/src/UI/Components/ResourceTable/ResourceTable.tsx
@@ -12,19 +12,13 @@ interface Props {
 }
 
 export const ResourceTable: React.FC<Props> = ({ resources, id, ...props }) => {
-  const columns = ["Resource Id", "State"];
+  const columns = ["Resource", "State"];
   const rows = resources.map((resource) => {
+    const resourceId = getResourceIdFromResourceVersionId(resource.resource_id);
     return {
       cells: [
         {
-          title: (
-            <ResourceLink
-              resourceId={getResourceIdFromResourceVersionId(
-                resource.resource_id
-              )}
-              linkText={resource.resource_id}
-            />
-          ),
+          title: <ResourceLink resourceId={resourceId} linkText={resourceId} />,
         },
         { title: <ResourceStatusLabel status={resource.resource_state} /> },
       ],

--- a/src/UI/Components/ResourceTable/ResourceTable.tsx
+++ b/src/UI/Components/ResourceTable/ResourceTable.tsx
@@ -18,7 +18,7 @@ export const ResourceTable: React.FC<Props> = ({ resources, id, ...props }) => {
     return {
       cells: [
         {
-          title: <ResourceLink resourceId={resourceId} linkText={resourceId} />,
+          title: <ResourceLink resourceId={resourceId} />,
         },
         { title: <ResourceStatusLabel status={resource.resource_state} /> },
       ],

--- a/src/UI/Pages/ServiceInventory/InventoryTable.test.tsx
+++ b/src/UI/Pages/ServiceInventory/InventoryTable.test.tsx
@@ -119,7 +119,7 @@ test("ServiceInventory can show resources for instance", async () => {
     await screen.findByRole("grid", { name: "ResourceTable-Success" })
   ).toBeInTheDocument();
 
-  expect(screen.getByText("resource_id_1,v=1")).toBeInTheDocument();
+  expect(screen.getByText("resource_id_1")).toBeInTheDocument();
 });
 
 test("ServiceInventory shows service identity if it's defined", async () => {

--- a/src/UI/Pages/ServiceInventory/ServiceInventory.test.tsx
+++ b/src/UI/Pages/ServiceInventory/ServiceInventory.test.tsx
@@ -218,7 +218,7 @@ test("GIVEN ResourcesView fetches resources for new instance after instance upda
   });
 
   expect(
-    screen.getByRole("cell", { name: InstanceResource.listA[0].resource_id })
+    screen.getByRole("cell", { name: "resource_id_a" })
   ).toBeInTheDocument();
 
   scheduler.executeAll();


### PR DESCRIPTION
# Description

closes #2870 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Code is clear and sufficiently documented
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
