### PR TITLE
Improve visual consistency of desired state resources table

### DIFF
--- a/changelogs/unreleased/3009-desired-state-resource-table-styling.yml
+++ b/changelogs/unreleased/3009-desired-state-resource-table-styling.yml
@@ -1,0 +1,4 @@
+description: Improve visual consistency of desired state resources table
+issue-nr: 3009
+change-type: patch
+destination-branches: [master, iso5, iso4]

--- a/src/UI/Pages/DesiredStateDetails/Row.tsx
+++ b/src/UI/Pages/DesiredStateDetails/Row.tsx
@@ -1,6 +1,5 @@
 import React, { useContext } from "react";
 import { Button } from "@patternfly/react-core";
-import { InfoCircleIcon } from "@patternfly/react-icons";
 import { Tbody, Tr, Td } from "@patternfly/react-table";
 import { Resource } from "@/Core";
 import { Link } from "@/UI/Components";
@@ -23,16 +22,14 @@ export const Row: React.FC<Props> = ({ row, version }) => {
         <Td dataLabel={words("resources.column.requires")}>
           {row.numberOfDependencies}
         </Td>
-        <Td>
+        <Td width={10}>
           <Link
             pathname={routeManager.getUrl("DesiredStateResourceDetails", {
               resourceId: row.id,
               version,
             })}
           >
-            <Button variant="secondary" isSmall icon={<InfoCircleIcon />}>
-              {words("compileReports.links.details")}
-            </Button>
+            <Button variant="link">{words("resources.link.details")}</Button>
           </Link>
         </Td>
       </Tr>

--- a/src/UI/Pages/DesiredStateDetails/Row.tsx
+++ b/src/UI/Pages/DesiredStateDetails/Row.tsx
@@ -22,7 +22,7 @@ export const Row: React.FC<Props> = ({ row, version }) => {
         <Td dataLabel={words("resources.column.requires")}>
           {row.numberOfDependencies}
         </Td>
-        <Td width={10}>
+        <Td modifier="fitContent" isActionCell>
           <Link
             pathname={routeManager.getUrl("DesiredStateResourceDetails", {
               resourceId: row.id,

--- a/src/UI/Pages/DesiredStateDetails/VersionResourceTablePresenter.ts
+++ b/src/UI/Pages/DesiredStateDetails/VersionResourceTablePresenter.ts
@@ -23,12 +23,8 @@ export class VersionResourceTablePresenter
         displayName: words("resources.column.requires"),
         apiName: "requires",
       },
-      {
-        displayName: words("compileReports.columns.actions"),
-        apiName: "",
-      },
     ];
-    this.numberOfColumns = this.columnHeads.length + 1;
+    this.numberOfColumns = this.columnHeads.length + 2;
   }
 
   createRows(sourceData: Resource.FromVersion[]): Resource.RowFromVersion[] {


### PR DESCRIPTION
# Description

closes #3009

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Code is clear and sufficiently documented
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
