### PR TITLE
Fix default value of dictionaries in service instance forms

### DIFF
--- a/changelogs/unreleased/3087-fix-dictionary-default-value.yml
+++ b/changelogs/unreleased/3087-fix-dictionary-default-value.yml
@@ -1,0 +1,4 @@
+description: Fix default value of dictionaries in service instance forms
+issue-nr: 3087
+change-type: patch
+destination-branches: [master, iso5, iso4]

--- a/src/Test/Data/Field.ts
+++ b/src/Test/Data/Field.ts
@@ -50,6 +50,16 @@ export const number: TextField = {
   type: "float?",
 };
 
+export const dictionary: TextField = {
+  kind: "Text",
+  name: "dictionary_field",
+  description: "description",
+  isOptional: false,
+  defaultValue: {},
+  inputType: TextInputTypes.text,
+  type: "dict",
+};
+
 export const nested = (fields?: Field[]): NestedField => ({
   kind: "Nested",
   name: "nested_field",

--- a/src/UI/Components/ServiceInstanceForm/Helpers/createFormState.spec.ts
+++ b/src/UI/Components/ServiceInstanceForm/Helpers/createFormState.spec.ts
@@ -13,6 +13,14 @@ test("GIVEN fieldsToFormState WHEN passed a DictListField THEN creates formState
   });
 });
 
+test("GIVEN createFormState WHEN passed a dict field with a default value THEN creates formState correctly", () => {
+  const fields = [Field.dictionary];
+  const formState = createFormState(fields);
+  expect(formState).toEqual({
+    [Field.dictionary.name]: "{}",
+  });
+});
+
 test("Given fieldsToFormState WHEN passed editable nested fields and current state THEN creates formState correctly", () => {
   const formState = createEditFormState(
     Field.nestedEditable,

--- a/src/UI/Components/ServiceInstanceForm/Helpers/createFormState.ts
+++ b/src/UI/Components/ServiceInstanceForm/Helpers/createFormState.ts
@@ -7,7 +7,9 @@ export const createFormState = (fields: Field[]): InstanceAttributeModel => {
       case "Boolean":
       case "Enum":
       case "Text": {
-        acc[curr.name] = curr.defaultValue;
+        acc[curr.name] = curr.type.includes("dict")
+          ? JSON.stringify(curr.defaultValue)
+          : curr.defaultValue;
         return acc;
       }
 


### PR DESCRIPTION
# Description

closes #3087 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Code is clear and sufficiently documented
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
