### PR TITLE
Fix issue when the resource progress bar doesn't update automatically

### DIFF
--- a/changelogs/unreleased/3242-resource-progress-bar-stale.yml
+++ b/changelogs/unreleased/3242-resource-progress-bar-stale.yml
@@ -1,0 +1,4 @@
+description: Fix issue when the resource progress bar doesn't update automatically
+issue-nr: 3242
+change-type: patch
+destination-branches: [master, iso5, iso4]

--- a/src/Slices/Resource/UI/ResourcesPage/Page.test.tsx
+++ b/src/Slices/Resource/UI/ResourcesPage/Page.test.tsx
@@ -437,6 +437,69 @@ test("GIVEN ResourcesView WHEN data is loading for next page THEN shows toolbar"
   ).toHaveAttribute("data-value", "2");
 });
 
+test("GIVEN ResourcesView WHEN data is auto-updated THEN shows updated toolbar", async () => {
+  const { component, apiHelper, scheduler } = setup();
+  render(component);
+
+  expect(
+    await screen.findByRole("generic", { name: "ResourcesView-Loading" })
+  ).toBeInTheDocument();
+
+  apiHelper.resolve(
+    Either.right({
+      ...Resource.response,
+      links: { ...Resource.response.links, next: "/fake-link" },
+    })
+  );
+
+  expect(
+    await screen.findByRole("grid", { name: "ResourcesView-Success" })
+  ).toBeInTheDocument();
+
+  expect(
+    await screen.findByRole("generic", { name: "Deployment state summary" })
+  ).toBeInTheDocument();
+
+  expect(
+    screen.getByRole("generic", {
+      name: "LegendItem-available",
+    })
+  ).toHaveAttribute("data-value", "1");
+
+  scheduler.executeAll();
+
+  expect(
+    screen.getByRole("generic", { name: "Deployment state summary" })
+  ).toBeVisible();
+  expect(screen.getByRole("button", { name: "Repair" })).toBeVisible();
+  expect(screen.getByRole("button", { name: "Deploy" })).toBeVisible();
+  expect(
+    screen.getByRole("generic", { name: "PaginationWidget" })
+  ).toBeVisible();
+
+  await apiHelper.resolve(
+    Either.right({
+      ...Resource.response,
+      metadata: {
+        ...Resource.response.metadata,
+        deploy_summary: {
+          ...Resource.response.metadata.deploy_summary,
+          by_state: {
+            ...Resource.response.metadata.deploy_summary.by_state,
+            available: 2,
+          },
+        },
+      },
+    })
+  );
+
+  expect(
+    await screen.findByRole("generic", {
+      name: "LegendItem-available",
+    })
+  ).toHaveAttribute("data-value", "2");
+});
+
 test("ResourcesView shows deploy state bar with available status without processing_events status", async () => {
   const { component, apiHelper } = setup();
   render(component);

--- a/src/Slices/Resource/UI/ResourcesPage/Page.tsx
+++ b/src/Slices/Resource/UI/ResourcesPage/Page.tsx
@@ -56,7 +56,7 @@ export const Page: React.FC = () => {
     if (RemoteData.isLoading(data)) return;
     setStaleData(data);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [data.kind, JSON.stringify(data)]);
+  }, [JSON.stringify(data)]);
 
   const updateFilter = (
     updater: (filter: Resource.Filter) => Resource.Filter

--- a/src/Slices/Resource/UI/ResourcesPage/Page.tsx
+++ b/src/Slices/Resource/UI/ResourcesPage/Page.tsx
@@ -56,7 +56,7 @@ export const Page: React.FC = () => {
     if (RemoteData.isLoading(data)) return;
     setStaleData(data);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [data.kind]);
+  }, [data.kind, JSON.stringify(data)]);
 
   const updateFilter = (
     updater: (filter: Resource.Filter) => Resource.Filter


### PR DESCRIPTION
# Description

The data for the progress bar is cached so it provides a more consistent look when paging. 
In this case the table shows the loading view (as the state of the data is set to loading), but when the regular updates happen after 5 seconds, we don't show a loading view, only update the table with the new results. 
The `kind` of the data is not updated in this case, so the whole update of the progress bar was skipped. With this PR, the contents of the response are taken into account as well for the update.

closes #3242 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Code is clear and sufficiently documented
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
