### PR TITLE
Build(deps-dev): Bump eslint-plugin-testing-library from 5.2.0 to 5.2.1 (#3261)

### DIFF
--- a/changelogs/unreleased/3261-dependabot.yml
+++ b/changelogs/unreleased/3261-dependabot.yml
@@ -1,0 +1,6 @@
+change-type: patch
+description: 'Build(deps-dev): Bump eslint-plugin-testing-library from 5.2.0 to 5.2.1'
+destination-branches:
+- master
+- iso5
+sections: {}

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-react": "^7.29.4",
     "eslint-plugin-react-hooks": "^4.4.0",
-    "eslint-plugin-testing-library": "^5.2.0",
+    "eslint-plugin-testing-library": "^5.2.1",
     "fetch-mock": "^9.11.0",
     "file-loader": "^6.2.0",
     "git-revision-webpack-plugin": "^5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7243,10 +7243,10 @@ eslint-plugin-react@^7.29.4:
     semver "^6.3.0"
     string.prototype.matchall "^4.0.6"
 
-eslint-plugin-testing-library@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-testing-library/-/eslint-plugin-testing-library-5.2.0.tgz#4e097027345ecc4a2479be12b5a5b9098e7c9c7a"
-  integrity sha512-fYFH8lA1hbc1Epr9laNm/+YIR2d+R7WI8sFz9jIRAUfqCf21Nb5BzZwhNeZlu9wKXwDtuf+hUM5QJxG1PuDsTQ==
+eslint-plugin-testing-library@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-testing-library/-/eslint-plugin-testing-library-5.2.1.tgz#3f89cd28ade81329a11584e0bbea129bede01619"
+  integrity sha512-88qJv6uzYALtiYJDzhelP3ov0Px/GLgnu+UekjjDxL2nMyvgdTyboKqcDBsvFPmAeizlCoSWOjeBN4DxO0BxaA==
   dependencies:
     "@typescript-eslint/utils" "^5.13.0"
 


### PR DESCRIPTION
Pull request opened by the merge tool on behalf of #3261