### PR TITLE
Use syntax highlighter for traceback on resource log view

### DIFF
--- a/changelogs/unreleased/3241-traceback-syntax-highlight.yml
+++ b/changelogs/unreleased/3241-traceback-syntax-highlight.yml
@@ -1,0 +1,4 @@
+description: Use syntax highlighter for traceback on resource log view
+issue-nr: 3241
+change-type: patch
+destination-branches: [master, iso5]

--- a/src/Slices/DesiredStateResourceDetails/UI/Details.tsx
+++ b/src/Slices/DesiredStateResourceDetails/UI/Details.tsx
@@ -21,5 +21,6 @@ export const Details: React.FC<Props> = ({ details, ...props }) => (
 const classifier = new AttributeClassifier(
   new JsonFormatter(),
   new XmlFormatter(),
+  undefined,
   () => false
 );

--- a/src/Slices/ResourceDetails/UI/Tabs/LogTab/Details.tsx
+++ b/src/Slices/ResourceDetails/UI/Tabs/LogTab/Details.tsx
@@ -6,7 +6,7 @@ import {
   DescriptionListTerm,
 } from "@patternfly/react-core";
 import styled from "styled-components";
-import { isObjectEmpty } from "@/Core";
+import { isObjectEmpty, Maybe } from "@/Core";
 import { JsonFormatter, XmlFormatter } from "@/Data";
 import { AttributeClassifier, AttributeList, CodeText } from "@/UI/Components";
 import { ResourceLog } from "@S/ResourceDetails/Core/ResourceLog";
@@ -28,7 +28,10 @@ export const Details: React.FC<Props> = ({ log }) => {
         <DescriptionListGroup>
           <StyledTerm>Kwargs</StyledTerm>
           <DescriptionListDescription>
-            <AttributeList attributes={classifier.classify(log.kwargs)} />
+            <AttributeList
+              attributes={classifier.classify(log.kwargs)}
+              variant="monospace"
+            />
           </DescriptionListDescription>
         </DescriptionListGroup>
       )}
@@ -42,5 +45,6 @@ const StyledTerm = styled(DescriptionListTerm)`
 
 const classifier = new AttributeClassifier(
   new JsonFormatter(),
-  new XmlFormatter()
+  new XmlFormatter(),
+  (key: string, value: string) => Maybe.some({ kind: "Python", key, value })
 );

--- a/src/UI/Components/DesiredStateAttributes/AttributeClassifier.spec.ts
+++ b/src/UI/Components/DesiredStateAttributes/AttributeClassifier.spec.ts
@@ -1,3 +1,4 @@
+import { Maybe } from "@/Core";
 import { JsonFormatter, XmlFormatter } from "@/Data";
 import { AttributeClassifier } from "./AttributeClassifier";
 import { attributes, classified } from "./Data";
@@ -9,4 +10,28 @@ test("GIVEN AttributeClassifier WHEN provided with a mixed attributes object THE
   );
 
   expect(classifier.classify(attributes)).toEqual(classified);
+});
+
+test("GIVEN AttributeClassifier WHEN provided with a custom multiline classifier THEN returns the correct list of ClassifiedAttributes", () => {
+  const classifier = new AttributeClassifier(
+    new JsonFormatter(),
+    new XmlFormatter(),
+    (key: string, value: string) => Maybe.some({ kind: "Python", key, value })
+  );
+
+  expect(
+    classifier.classify({ f: attributes["f"], ff: attributes["ff"] })
+  ).toEqual([
+    {
+      kind: "Python",
+      key: "f",
+      value:
+        "This text has a length longer than 80. abcdefghijklmnopqrstvuwxyz abcdefghijklmnopqrstvuwxyz",
+    },
+    {
+      kind: "Python",
+      key: "ff",
+      value: "This text contains a newline.\nblablabla...",
+    },
+  ]);
 });

--- a/src/UI/Components/DesiredStateAttributes/AttributeClassifier.ts
+++ b/src/UI/Components/DesiredStateAttributes/AttributeClassifier.ts
@@ -5,6 +5,11 @@ export class AttributeClassifier {
   constructor(
     private readonly jsonFormatter: Formatter<unknown>,
     private readonly xmlFormatter: Formatter,
+    private readonly multilineClassifier: (
+      key: string,
+      value: string
+    ) => Maybe.Type<ClassifiedAttribute> = (key, value) =>
+      Maybe.some({ kind: "MultiLine", key, value }),
     private readonly isKeyIgnored: (key: string) => boolean = (key: string) =>
       key === "version" || key === "requires"
   ) {}
@@ -41,7 +46,7 @@ export class AttributeClassifier {
           value: this.xmlFormatter.format(value),
         });
       } else if (this.isMultiLine(value)) {
-        return Maybe.some({ kind: "MultiLine", key, value });
+        return this.multilineClassifier(key, value);
       }
       return Maybe.some({ kind: "SingleLine", key, value });
     } else if (this.isObject(value)) {

--- a/src/UI/Components/DesiredStateAttributes/AttributeList.test.tsx
+++ b/src/UI/Components/DesiredStateAttributes/AttributeList.test.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { AttributeList } from "./AttributeList";
+import { attributes, classified } from "./Data";
+
+test("Given the AttributeList component When rendered with the monospace variant Then the font-family is correct", async () => {
+  render(<AttributeList attributes={classified} variant="monospace" />);
+  const singleLineValue = await screen.findByText(attributes["b"]);
+  expect(singleLineValue).toHaveStyle("font-family: monospace");
+  const multiLineValue = await screen.findByText(attributes["f"]);
+  expect(multiLineValue).toHaveStyle("font-family: monospace");
+});

--- a/src/UI/Components/DesiredStateAttributes/AttributeList.tsx
+++ b/src/UI/Components/DesiredStateAttributes/AttributeList.tsx
@@ -14,41 +14,52 @@ import { FileBlock } from "./FileBlock";
 
 interface Props {
   attributes: ClassifiedAttribute[];
+  variant?: AttributeTextVariant;
 }
 
-export const AttributeList: React.FC<Props> = ({ attributes }) => (
+type AttributeTextVariant = "default" | "monospace";
+
+export const AttributeList: React.FC<Props> = ({
+  attributes,
+  variant = "default",
+}) => (
   <StyledDescriptionList isHorizontal isAutoColumnWidths>
     {attributes.map((attribute) => (
       <DescriptionListGroup key={attribute.key}>
         <StyledDescriptionListTerm>{attribute.key}</StyledDescriptionListTerm>
         <DescriptionListDescription>
-          <AttributeValue attribute={attribute} />
+          <AttributeValue attribute={attribute} variant={variant} />
         </DescriptionListDescription>
       </DescriptionListGroup>
     ))}
   </StyledDescriptionList>
 );
 
-const AttributeValue: React.FC<{ attribute: ClassifiedAttribute }> = ({
-  attribute,
-}) => {
+const AttributeValue: React.FC<{
+  attribute: ClassifiedAttribute;
+  variant?: AttributeTextVariant;
+}> = ({ attribute, variant }) => {
   switch (attribute.kind) {
     case "Undefined":
       return (
-        <>
+        <TextContainer $variant={variant}>
           <OutlinedQuestionCircleIcon /> undefined
-        </>
+        </TextContainer>
       );
 
     case "Password":
-      return <span>{attribute.value}</span>;
+      return (
+        <TextContainer $variant={variant}>{attribute.value}</TextContainer>
+      );
 
     case "SingleLine":
       return (
         <TextWithCopy
           value={attribute.value}
           tooltipContent="Copy to clipboard"
-        />
+        >
+          <TextContainer $variant={variant}>{attribute.value}</TextContainer>
+        </TextWithCopy>
       );
 
     case "MultiLine":
@@ -56,7 +67,9 @@ const AttributeValue: React.FC<{ attribute: ClassifiedAttribute }> = ({
         <MultiTextWithCopy
           value={attribute.value}
           tooltipContent="Copy to clipboard"
-        />
+        >
+          <TextContainer $variant={variant}>{attribute.value}</TextContainer>
+        </MultiTextWithCopy>
       );
 
     case "File":
@@ -67,6 +80,8 @@ const AttributeValue: React.FC<{ attribute: ClassifiedAttribute }> = ({
 
     case "Xml":
       return <CodeHighlighter code={attribute.value} language="xml" />;
+    case "Python":
+      return <CodeHighlighter code={attribute.value} language="python" />;
   }
 };
 
@@ -83,4 +98,8 @@ const MultiTextWithCopy = styled(TextWithCopy)`
   display: block;
   max-width: 80ch;
   white-space: pre-wrap;
+`;
+
+const TextContainer = styled.span<{ $variant?: AttributeTextVariant }>`
+  ${(p) => (p.$variant === "monospace" ? "font-family: monospace;" : "")};
 `;

--- a/src/UI/Components/DesiredStateAttributes/ClassifiedAttribute.ts
+++ b/src/UI/Components/DesiredStateAttributes/ClassifiedAttribute.ts
@@ -5,7 +5,8 @@ export type ClassifiedAttribute =
   | Password
   | File
   | Json
-  | Xml;
+  | Xml
+  | Python;
 
 interface Base<Kind> {
   kind: Kind;
@@ -19,6 +20,7 @@ type Json = Base<"Json">;
 type Xml = Base<"Xml">;
 type Password = Base<"Password">;
 type File = Base<"File">;
+type Python = Base<"Python">;
 
 interface Undefined {
   kind: "Undefined";


### PR DESCRIPTION
# Description

closes #3241 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Code is clear and sufficiently documented
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
