### PR TITLE
Ignore dependabot upgrades for react 18 types

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,6 @@ updates:
     # Serialize all Dependabot PRs to prevent merge conflicts
     # on the package.json and yarn.lock files
     open-pull-requests-limit: 1
+    ignore:
+      - dependency-name: "@types/react"
+        versions: [">=18.0"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,4 +11,4 @@ updates:
     open-pull-requests-limit: 1
     ignore:
       - dependency-name: "@types/react"
-        versions: [">=18.0"]
+        update-types: ["version-update:semver-major"]

--- a/changelogs/unreleased/ignore-react-18-types.yml
+++ b/changelogs/unreleased/ignore-react-18-types.yml
@@ -1,0 +1,3 @@
+description: Ignore dependabot upgrades for react 18 types
+change-type: patch
+destination-branches: [master, iso5]


### PR DESCRIPTION
# Description

The types for react 18 contain some breaking changes. While updating our code is possible, the libraries we depend on haven't been upgraded yet either, so the type checking still fails. I think it's best if we wait until the major libraries we depend on (e.g. patternfly, easy-peasy) are upgraded to handle this correctly

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Code is clear and sufficiently documented
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [x] ~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
