### PR TITLE
Build(deps): Bump @patternfly/react-icons from 4.49.19 to 4.53.16 (#3312)

### DIFF
--- a/changelogs/unreleased/3312-dependabot.yml
+++ b/changelogs/unreleased/3312-dependabot.yml
@@ -1,0 +1,6 @@
+change-type: patch
+description: 'Build(deps): Bump @patternfly/react-icons from 4.49.19 to 4.53.16'
+destination-branches:
+- master
+- iso5
+sections: {}

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
   "dependencies": {
     "@patternfly/react-charts": "^6.51.19",
     "@patternfly/react-core": "^4.198.19",
-    "@patternfly/react-icons": "^4.26.4",
+    "@patternfly/react-icons": "^4.53.16",
     "@patternfly/react-styles": "^4.48.19",
     "@patternfly/react-table": "^4.67.19",
     "@patternfly/react-tokens": "^4.27.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1972,10 +1972,10 @@
     tippy.js "5.1.2"
     tslib "^2.0.0"
 
-"@patternfly/react-icons@^4.26.4", "@patternfly/react-icons@^4.49.19":
-  version "4.49.19"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-4.49.19.tgz#66f426570378213f6f717d4a39fadcbf57635d1e"
-  integrity sha512-Pr6JDDKWOnWChkifXKWglKEPo3Q+1CgiUTUrvk4ZbnD7mhq5e/TFxxInB9CPzi278bvnc2YlPyTjpaAcCN0yGw==
+"@patternfly/react-icons@^4.49.19", "@patternfly/react-icons@^4.53.16":
+  version "4.53.16"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-4.53.16.tgz#2ffb273d623d47952efefbf052fcb0e347a5bcb1"
+  integrity sha512-QQOZwl9MR71uNaKUPKJUm2qjvol28evN7GgyiqGn7fr0p4FnPopm9F5GsnKMsE/764/HGwGLjYHulUo3Eb06dQ==
 
 "@patternfly/react-styles@^4.48.19":
   version "4.48.19"


### PR DESCRIPTION
Pull request opened by the merge tool on behalf of #3312