### PR TITLE
Build(deps-dev): Bump eslint-plugin-testing-library from 5.3.0 to 5.3.1 (#3345)

### DIFF
--- a/changelogs/unreleased/3345-dependabot.yml
+++ b/changelogs/unreleased/3345-dependabot.yml
@@ -1,0 +1,6 @@
+change-type: patch
+description: 'Build(deps-dev): Bump eslint-plugin-testing-library from 5.3.0 to 5.3.1'
+destination-branches:
+- master
+- iso5
+sections: {}

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-react": "^7.29.4",
     "eslint-plugin-react-hooks": "^4.4.0",
-    "eslint-plugin-testing-library": "^5.3.0",
+    "eslint-plugin-testing-library": "^5.3.1",
     "fetch-mock": "^9.11.0",
     "file-loader": "^6.2.0",
     "git-revision-webpack-plugin": "^5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7230,10 +7230,10 @@ eslint-plugin-react@^7.29.4:
     semver "^6.3.0"
     string.prototype.matchall "^4.0.6"
 
-eslint-plugin-testing-library@^5.3.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-testing-library/-/eslint-plugin-testing-library-5.3.0.tgz#1f5a58827fefc240e1ec1bac706de4c24f5de7be"
-  integrity sha512-DpQmduNYNQamIz/rz2haCOlJVIVi8gZ8mpDCCX7IMWMK436HMpepXafHhdUZxdRoaAkziLSJosRg6bqGAFqT3w==
+eslint-plugin-testing-library@^5.3.1:
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-testing-library/-/eslint-plugin-testing-library-5.3.1.tgz#7638ee79cc86fd8bb57d671af35a1cbaa77e9548"
+  integrity sha512-OfF4dlG/q6ck6DL3P8Z0FPdK0dU5K57gsBu7eUcaVbwYKaNzjgejnXiM9CCUevppORkvfek+9D3Uj/9ZZ8Vz8g==
   dependencies:
     "@typescript-eslint/utils" "^5.13.0"
 


### PR DESCRIPTION
Pull request opened by the merge tool on behalf of #3345