### PR TITLE
Build(deps-dev): Bump @types/react-syntax-highlighter from 13.5.2 to 15.5.1 (#3420)

### DIFF
--- a/changelogs/unreleased/3420-dependabot.yml
+++ b/changelogs/unreleased/3420-dependabot.yml
@@ -1,0 +1,7 @@
+change-type: patch
+description: 'Build(deps-dev): Bump @types/react-syntax-highlighter from 13.5.2 to
+    15.5.1'
+destination-branches:
+- master
+- iso5
+sections: {}

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@types/react": "^17.0.44",
     "@types/react-dom": "^18.0.2",
     "@types/react-router-dom": "^5.3.3",
-    "@types/react-syntax-highlighter": "^13.5.2",
+    "@types/react-syntax-highlighter": "^15.5.1",
     "@types/styled-components": "^5.1.25",
     "@types/webpack": "^5.28.0",
     "@types/xml-formatter": "^2.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3375,10 +3375,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-syntax-highlighter@^13.5.2":
-  version "13.5.2"
-  resolved "https://registry.yarnpkg.com/@types/react-syntax-highlighter/-/react-syntax-highlighter-13.5.2.tgz#357cc03581dc434c57c3b31f70e0eecdbf7b3ab0"
-  integrity sha512-sRZoKZBGKaE7CzMvTTgz+0x/aVR58ZYUTfB7HN76vC+yQnvo1FWtzNARBt0fGqcLGEVakEzMu/CtPzssmanu8Q==
+"@types/react-syntax-highlighter@^15.5.1":
+  version "15.5.1"
+  resolved "https://registry.yarnpkg.com/@types/react-syntax-highlighter/-/react-syntax-highlighter-15.5.1.tgz#0c459cdd94a882df05778e93a1514430cc641043"
+  integrity sha512-+yD6D8y21JqLf89cRFEyRfptVMqo2ROHyAlysRvFwT28gT5gDo3KOiXHwGilHcq9y/OKTjlWK0f/hZUicrBFPQ==
   dependencies:
     "@types/react" "*"
 


### PR DESCRIPTION
Pull request opened by the merge tool on behalf of #3420