### PR TITLE
Build(deps): Bump @patternfly/react-tokens from 4.58.2 to 4.66.1 (#3477)

### DIFF
--- a/changelogs/unreleased/3477-dependabot.yml
+++ b/changelogs/unreleased/3477-dependabot.yml
@@ -1,0 +1,6 @@
+change-type: patch
+description: 'Build(deps): Bump @patternfly/react-tokens from 4.58.2 to 4.66.1'
+destination-branches:
+- master
+- iso5
+sections: {}

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "@patternfly/react-icons": "^4.53.16",
     "@patternfly/react-styles": "^4.56.2",
     "@patternfly/react-table": "^4.75.2",
-    "@patternfly/react-tokens": "^4.54.16",
+    "@patternfly/react-tokens": "^4.66.1",
     "copy-to-clipboard": "^3.3.1",
     "easy-peasy": "^5.0.4",
     "file-saver": "^2.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2007,10 +2007,10 @@
     lodash "^4.17.19"
     tslib "^2.0.0"
 
-"@patternfly/react-tokens@^4.54.16", "@patternfly/react-tokens@^4.58.2":
-  version "4.58.2"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-4.58.2.tgz#9d6d183af2046dbe62662eeb4fa69a1605098d40"
-  integrity sha512-gsEz5z3+6pOHTy/fChZJHR8qUBPO87gRIUrQZlN5+gkrY6y0pT2UIs/WbRdsgV8xJDMev1iZaC9RMGwfR9mtfQ==
+"@patternfly/react-tokens@^4.58.2", "@patternfly/react-tokens@^4.66.1":
+  version "4.66.1"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-4.66.1.tgz#524f7cc806e95622ec7b752ccf0db621383d20c6"
+  integrity sha512-k0IWqpufM6ezT+3gWlEamqQ7LW9yi8e8cBBlude5IU8eIEqIG6AccwR1WNBEK1wCVWGwVxakLMdf0XBLl4k52Q==
 
 "@pmmmwh/react-refresh-webpack-plugin@^0.5.1":
   version "0.5.3"


### PR DESCRIPTION
Pull request opened by the merge tool on behalf of #3477