### PR TITLE
Issue/3470: Go to notification details on click

### DIFF
--- a/changelogs/unreleased/3470-notification-go-to-details-on-click.yml
+++ b/changelogs/unreleased/3470-notification-go-to-details-on-click.yml
@@ -1,0 +1,3 @@
+description: Go to notification details on click
+change-type: patch
+destination-branches: [master, iso5]

--- a/src/Core/Contracts/RouteManager.ts
+++ b/src/Core/Contracts/RouteManager.ts
@@ -45,7 +45,5 @@ export interface RouteManager {
   useUrl(kind: RouteKind, params: RouteParams<RouteKind>): string;
   getCrumbs(url: string): Crumb[];
 
-  getUrlCompileDetailsId(
-    uri: string
-  ): RouteKindWithId<"CompileDetails"> | undefined;
+  getParamsFromUrl(uri: string): RouteKindWithId<"CompileDetails"> | undefined;
 }

--- a/src/Core/Contracts/RouteManager.ts
+++ b/src/Core/Contracts/RouteManager.ts
@@ -45,5 +45,5 @@ export interface RouteManager {
   useUrl(kind: RouteKind, params: RouteParams<RouteKind>): string;
   getCrumbs(url: string): Crumb[];
 
-  getUrlFromKindWithId(uri: string): RouteKindWithId | undefined;
+  getUrlCompileDetailsId(uri: string): RouteKindWithId | undefined;
 }

--- a/src/Core/Contracts/RouteManager.ts
+++ b/src/Core/Contracts/RouteManager.ts
@@ -4,6 +4,7 @@ import {
   RouteParams,
   RouteMatch,
   Crumb,
+  RouteKindWithId,
 } from "@/Core/Domain";
 
 export type RouteDictionary = Record<RouteKind, Route>;
@@ -43,4 +44,9 @@ export interface RouteManager {
    */
   useUrl(kind: RouteKind, params: RouteParams<RouteKind>): string;
   getCrumbs(url: string): Crumb[];
+
+  getUrlFromKindWithId(
+    kind: RouteKind,
+    uri: string
+  ): RouteKindWithId | undefined;
 }

--- a/src/Core/Contracts/RouteManager.ts
+++ b/src/Core/Contracts/RouteManager.ts
@@ -45,5 +45,7 @@ export interface RouteManager {
   useUrl(kind: RouteKind, params: RouteParams<RouteKind>): string;
   getCrumbs(url: string): Crumb[];
 
-  getUrlCompileDetailsId(uri: string): RouteKindWithId | undefined;
+  getUrlCompileDetailsId(
+    uri: string
+  ): RouteKindWithId<"CompileDetails"> | undefined;
 }

--- a/src/Core/Contracts/RouteManager.ts
+++ b/src/Core/Contracts/RouteManager.ts
@@ -45,8 +45,5 @@ export interface RouteManager {
   useUrl(kind: RouteKind, params: RouteParams<RouteKind>): string;
   getCrumbs(url: string): Crumb[];
 
-  getUrlFromKindWithId(
-    kind: RouteKind,
-    uri: string
-  ): RouteKindWithId | undefined;
+  getUrlFromKindWithId(uri: string): RouteKindWithId | undefined;
 }

--- a/src/Core/Domain/Route.ts
+++ b/src/Core/Domain/Route.ts
@@ -56,6 +56,11 @@ export interface Route<K extends RouteKind = RouteKind> {
   environmentRole: EnvironmentRole;
 }
 
+export interface RouteKindWithId<K extends RouteKind = RouteKind> {
+  kind: K;
+  params: RouteParams<K>;
+}
+
 /**
  * Only contains routes that have parameters (environment not included)
  */

--- a/src/Slices/Notification/UI/Drawer/Drawer.test.tsx
+++ b/src/Slices/Notification/UI/Drawer/Drawer.test.tsx
@@ -197,6 +197,19 @@ test("Given Drawer When user clicks a notification Then it becomes read", async 
   ).toHaveLength(3);
 });
 
+test("Given Drawer When user clicks a notification with an uri then go to the uri", async () => {
+  const { component, apiHelper } = setup();
+  render(component);
+  await act(async () => {
+    await apiHelper.resolve(Either.right(Mock.response));
+  });
+
+  const items = screen.getAllByRole("listitem", { name: "NotificationItem" });
+  await userEvent.click(items[0]);
+
+  //verify call to
+});
+
 test("Given Drawer When user clicks on 'unread' for 1 notification Then it becomes unread", async () => {
   const { component, apiHelper, getAllRequest, updateRequest } = setup();
   render(component);

--- a/src/Slices/Notification/UI/Drawer/Drawer.test.tsx
+++ b/src/Slices/Notification/UI/Drawer/Drawer.test.tsx
@@ -1,9 +1,10 @@
 import React from "react";
-import { MemoryRouter } from "react-router-dom";
+import { Router } from "react-router-dom";
 import { Page, PageHeader } from "@patternfly/react-core";
 import { act, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { StoreProvider } from "easy-peasy";
+import { createMemoryHistory } from "history";
 import { Either, Maybe } from "@/Core";
 import {
   CommandManagerResolver,
@@ -19,10 +20,9 @@ import { DependencyProvider } from "@/UI/Dependency";
 import * as Mock from "@S/Notification/Core/Mock";
 import { Badge } from "@S/Notification/UI/Badge";
 import { Drawer } from "./Drawer";
-
 function setup() {
   const apiHelper = new DeferredApiHelper();
-
+  const history = createMemoryHistory();
   const scheduler = new StaticScheduler();
   const store = getStoreInstance();
 
@@ -52,7 +52,7 @@ function setup() {
 
   const component = (
     <StoreProvider store={store}>
-      <MemoryRouter>
+      <Router location={history.location} navigator={history}>
         <DependencyProvider
           dependencies={{ ...dependencies, queryResolver, commandResolver }}
         >
@@ -69,11 +69,18 @@ function setup() {
             }
           />
         </DependencyProvider>
-      </MemoryRouter>
+      </Router>
     </StoreProvider>
   );
 
-  return { component, apiHelper, closeCallback, updateRequest, getAllRequest };
+  return {
+    component,
+    apiHelper,
+    closeCallback,
+    updateRequest,
+    getAllRequest,
+    history,
+  };
 }
 
 test("Given Drawer Then a list of notifications are shown", async () => {
@@ -198,7 +205,7 @@ test("Given Drawer When user clicks a notification Then it becomes read", async 
 });
 
 test("Given Drawer When user clicks a notification with an uri then go to the uri", async () => {
-  const { component, apiHelper } = setup();
+  const { component, apiHelper, history } = setup();
   render(component);
   await act(async () => {
     await apiHelper.resolve(Either.right(Mock.response));
@@ -206,8 +213,23 @@ test("Given Drawer When user clicks a notification with an uri then go to the ur
 
   const items = screen.getAllByRole("listitem", { name: "NotificationItem" });
   await userEvent.click(items[0]);
+  expect(history.location.pathname).toBe(
+    "/compilereports/f2c68117-24bd-43cf-a9dc-ce42b934a614"
+  );
+});
 
-  //verify call to
+test("Given Drawer When user clicks a notification toggle with an uri then do not go to uri", async () => {
+  const { component, apiHelper, history } = setup();
+  render(component);
+  await act(async () => {
+    await apiHelper.resolve(Either.right(Mock.response));
+  });
+
+  const items = screen.getAllByRole("button", {
+    name: "NotificationItemActions",
+  });
+  await userEvent.click(items[0]);
+  expect(history.location.pathname).toBe("/");
 });
 
 test("Given Drawer When user clicks on 'unread' for 1 notification Then it becomes unread", async () => {

--- a/src/Slices/Notification/UI/Drawer/Item.tsx
+++ b/src/Slices/Notification/UI/Drawer/Item.tsx
@@ -8,7 +8,7 @@ import {
   NotificationDrawerListItemBody,
   NotificationDrawerListItemHeader,
 } from "@patternfly/react-core";
-import { RouteKind } from "@/Core";
+import { RouteKindWithId } from "@/Core";
 import { useNavigateTo, words } from "@/UI";
 import { DependencyContext } from "@/UI/Dependency";
 import { MomentDatePresenter } from "@/UI/Utils";
@@ -24,17 +24,16 @@ interface Props {
 
 export const Item: React.FC<Props> = ({ notification, onUpdate }) => {
   const { routeManager } = useContext(DependencyContext);
-  const detailsLink = routeManager.getUrlFromKindWithId(
-    "CompileDetails",
-    notification.uri
-  );
+  const detailsLink: RouteKindWithId<"CompileDetails"> | undefined =
+    routeManager.getUrlFromKindWithId(
+      notification.uri
+    ) as RouteKindWithId<"CompileDetails">;
   const navigate = useNavigateTo();
 
   const onClick = (notification: Notification): void => {
     if (!notification.read) onUpdate({ read: true });
     if (detailsLink) {
-      // navigate(detailsLink.kind as RouteKind, { id: detailsLink.id });
-      navigate(detailsLink.kind as RouteKind, { id: "aaaaaaa" });
+      navigate(detailsLink.kind, { id: detailsLink.params.id });
     }
   };
   return (

--- a/src/Slices/Notification/UI/Drawer/Item.tsx
+++ b/src/Slices/Notification/UI/Drawer/Item.tsx
@@ -25,7 +25,7 @@ interface Props {
 export const Item: React.FC<Props> = ({ notification, onUpdate }) => {
   const { routeManager } = useContext(DependencyContext);
   const detailsLink: RouteKindWithId<"CompileDetails"> | undefined =
-    routeManager.getUrlFromKindWithId(
+    routeManager.getUrlCompileDetailsId(
       notification.uri
     ) as RouteKindWithId<"CompileDetails">;
   const navigate = useNavigateTo();

--- a/src/Slices/Notification/UI/Drawer/Item.tsx
+++ b/src/Slices/Notification/UI/Drawer/Item.tsx
@@ -1,5 +1,4 @@
 import React, { useContext, useState } from "react";
-// import { Navigate } from "react-router-dom";
 import {
   Dropdown,
   DropdownItem,
@@ -91,18 +90,6 @@ const ActionList: React.FC<Props> = ({ notification, onUpdate }) => {
         >
           {words("notification.drawer.clear")}
         </DropdownItem>,
-        // <DropdownSeparator key="separator" />,
-        // <DropdownItem
-        //   key="details"
-        //   isDisabled={detailsLink === undefined}
-        //   component={
-        //     detailsLink ? (
-        //       <Link pathname={detailsLink}>
-        //         {words("notification.drawer.details")}
-        //       </Link>
-        //     ) : undefined
-        //   }
-        // />,
       ]}
     />
   );

--- a/src/Slices/Notification/UI/Drawer/Item.tsx
+++ b/src/Slices/Notification/UI/Drawer/Item.tsx
@@ -24,12 +24,10 @@ interface Props {
 export const Item: React.FC<Props> = ({ notification, onUpdate }) => {
   const { routeManager } = useContext(DependencyContext);
   const detailsLink: RouteKindWithId<"CompileDetails"> | undefined =
-    routeManager.getUrlCompileDetailsId(
-      notification.uri
-    ) as RouteKindWithId<"CompileDetails">;
+    routeManager.getUrlCompileDetailsId(notification.uri);
   const navigate = useNavigateTo();
 
-  const onClick = (notification: Notification): void => {
+  const onClick = (): void => {
     if (!notification.read) onUpdate({ read: true });
     if (detailsLink) {
       navigate(detailsLink.kind, { id: detailsLink.params.id });
@@ -38,7 +36,7 @@ export const Item: React.FC<Props> = ({ notification, onUpdate }) => {
   return (
     <NotificationDrawerListItem
       variant={getSeverityForNotification(notification.severity)}
-      onClick={() => onClick(notification)}
+      onClick={onClick}
       isRead={notification.read}
       aria-label="NotificationItem"
     >
@@ -46,7 +44,7 @@ export const Item: React.FC<Props> = ({ notification, onUpdate }) => {
         variant={getSeverityForNotification(notification.severity)}
         title={notification.title}
       >
-        <ActionList {...{ notification, onUpdate, detailsLink }} />
+        <ActionList {...{ notification, onUpdate }} />
       </NotificationDrawerListItemHeader>
       <NotificationDrawerListItemBody
         timestamp={new MomentDatePresenter().get(notification.created).relative}

--- a/src/Slices/Notification/UI/Drawer/Item.tsx
+++ b/src/Slices/Notification/UI/Drawer/Item.tsx
@@ -24,7 +24,7 @@ interface Props {
 export const Item: React.FC<Props> = ({ notification, onUpdate }) => {
   const { routeManager } = useContext(DependencyContext);
   const detailsLink: RouteKindWithId<"CompileDetails"> | undefined =
-    routeManager.getUrlCompileDetailsId(notification.uri);
+    routeManager.getParamsFromUrl(notification.uri);
   const navigate = useNavigateTo();
 
   const onClick = (): void => {

--- a/src/Slices/Notification/UI/Drawer/Item.tsx
+++ b/src/Slices/Notification/UI/Drawer/Item.tsx
@@ -1,15 +1,15 @@
 import React, { useContext, useState } from "react";
+// import { Navigate } from "react-router-dom";
 import {
   Dropdown,
   DropdownItem,
-  DropdownSeparator,
   KebabToggle,
   NotificationDrawerListItem,
   NotificationDrawerListItemBody,
   NotificationDrawerListItemHeader,
 } from "@patternfly/react-core";
-import { words } from "@/UI";
-import { Link } from "@/UI/Components";
+import { RouteKind } from "@/Core";
+import { useNavigateTo, words } from "@/UI";
 import { DependencyContext } from "@/UI/Dependency";
 import { MomentDatePresenter } from "@/UI/Utils";
 import { Notification, Body } from "@S/Notification/Core/Domain";
@@ -23,10 +23,24 @@ interface Props {
 }
 
 export const Item: React.FC<Props> = ({ notification, onUpdate }) => {
+  const { routeManager } = useContext(DependencyContext);
+  const detailsLink = routeManager.getUrlFromKindWithId(
+    "CompileDetails",
+    notification.uri
+  );
+  const navigate = useNavigateTo();
+
+  const onClick = (notification: Notification): void => {
+    if (!notification.read) onUpdate({ read: true });
+    if (detailsLink) {
+      // navigate(detailsLink.kind as RouteKind, { id: detailsLink.id });
+      navigate(detailsLink.kind as RouteKind, { id: "aaaaaaa" });
+    }
+  };
   return (
     <NotificationDrawerListItem
       variant={getSeverityForNotification(notification.severity)}
-      onClick={notification.read ? undefined : () => onUpdate({ read: true })}
+      onClick={() => onClick(notification)}
       isRead={notification.read}
       aria-label="NotificationItem"
     >
@@ -34,7 +48,7 @@ export const Item: React.FC<Props> = ({ notification, onUpdate }) => {
         variant={getSeverityForNotification(notification.severity)}
         title={notification.title}
       >
-        <ActionList {...{ notification, onUpdate }} />
+        <ActionList {...{ notification, onUpdate, detailsLink }} />
       </NotificationDrawerListItemHeader>
       <NotificationDrawerListItemBody
         timestamp={new MomentDatePresenter().get(notification.created).relative}
@@ -46,20 +60,19 @@ export const Item: React.FC<Props> = ({ notification, onUpdate }) => {
 };
 
 const ActionList: React.FC<Props> = ({ notification, onUpdate }) => {
-  const { routeManager } = useContext(DependencyContext);
   const [isOpen, setIsOpen] = useState(false);
 
-  const detailsLink = routeManager.getUrlForApiUri(notification.uri);
+  const onToggle = (value: boolean, e: React.ChangeEvent): void => {
+    e.stopPropagation();
+    setIsOpen(value);
+  };
 
   return (
     <Dropdown
       position="right"
       onSelect={() => setIsOpen(false)}
       toggle={
-        <KebabToggle
-          onToggle={setIsOpen}
-          aria-label="NotificationItemActions"
-        />
+        <KebabToggle onToggle={onToggle} aria-label="NotificationItemActions" />
       }
       isOpen={isOpen}
       isPlain
@@ -79,18 +92,18 @@ const ActionList: React.FC<Props> = ({ notification, onUpdate }) => {
         >
           {words("notification.drawer.clear")}
         </DropdownItem>,
-        <DropdownSeparator key="separator" />,
-        <DropdownItem
-          key="details"
-          isDisabled={detailsLink === undefined}
-          component={
-            detailsLink ? (
-              <Link pathname={detailsLink}>
-                {words("notification.drawer.details")}
-              </Link>
-            ) : undefined
-          }
-        />,
+        // <DropdownSeparator key="separator" />,
+        // <DropdownItem
+        //   key="details"
+        //   isDisabled={detailsLink === undefined}
+        //   component={
+        //     detailsLink ? (
+        //       <Link pathname={detailsLink}>
+        //         {words("notification.drawer.details")}
+        //       </Link>
+        //     ) : undefined
+        //   }
+        // />,
       ]}
     />
   );

--- a/src/UI/Dependency/Dummy/DummyRouteManager.ts
+++ b/src/UI/Dependency/Dummy/DummyRouteManager.ts
@@ -41,7 +41,7 @@ export class DummyRouteManager implements RouteManager {
   getRouteDictionary(): Record<RouteKind, Route> {
     throw new Error("Method not implemented.");
   }
-  getUrlCompileDetailsId(): RouteKindWithId<"CompileDetails"> | undefined {
+  getParamsFromUrl(): RouteKindWithId<"CompileDetails"> | undefined {
     throw new Error("Method not implemented.");
   }
 }

--- a/src/UI/Dependency/Dummy/DummyRouteManager.ts
+++ b/src/UI/Dependency/Dummy/DummyRouteManager.ts
@@ -41,7 +41,7 @@ export class DummyRouteManager implements RouteManager {
   getRouteDictionary(): Record<RouteKind, Route> {
     throw new Error("Method not implemented.");
   }
-  getUrlFromKindWithId(): RouteKindWithId | undefined {
+  getUrlCompileDetailsId(): RouteKindWithId | undefined {
     throw new Error("Method not implemented.");
   }
 }

--- a/src/UI/Dependency/Dummy/DummyRouteManager.ts
+++ b/src/UI/Dependency/Dummy/DummyRouteManager.ts
@@ -1,4 +1,11 @@
-import { RouteManager, Route, RouteKind, RouteMatch, Crumb } from "@/Core";
+import {
+  RouteManager,
+  Route,
+  RouteKind,
+  RouteMatch,
+  Crumb,
+  RouteKindWithId,
+} from "@/Core";
 
 export class DummyRouteManager implements RouteManager {
   getCrumbs(): Crumb[] {
@@ -32,6 +39,9 @@ export class DummyRouteManager implements RouteManager {
     throw new Error("Method not implemented.");
   }
   getRouteDictionary(): Record<RouteKind, Route> {
+    throw new Error("Method not implemented.");
+  }
+  getUrlFromKindWithId(): RouteKindWithId | undefined {
     throw new Error("Method not implemented.");
   }
 }

--- a/src/UI/Dependency/Dummy/DummyRouteManager.ts
+++ b/src/UI/Dependency/Dummy/DummyRouteManager.ts
@@ -41,7 +41,7 @@ export class DummyRouteManager implements RouteManager {
   getRouteDictionary(): Record<RouteKind, Route> {
     throw new Error("Method not implemented.");
   }
-  getUrlCompileDetailsId(): RouteKindWithId | undefined {
+  getUrlCompileDetailsId(): RouteKindWithId<"CompileDetails"> | undefined {
     throw new Error("Method not implemented.");
   }
 }

--- a/src/UI/Routing/PrimaryRouteManager.ts
+++ b/src/UI/Routing/PrimaryRouteManager.ts
@@ -12,7 +12,9 @@ import {
   RouteParams,
   RouteMatch,
   Crumb,
+  RouteKindWithId,
 } from "@/Core";
+
 import { AgentProcess } from "@S/AgentProcess";
 import { Agents } from "@S/Agents";
 import { CompileDetails } from "@S/CompileDetails";
@@ -152,6 +154,23 @@ export class PrimaryRouteManager implements RouteManager {
     if (match === null) return undefined;
     if (match.params.id === undefined) return undefined;
     return this.getUrl("CompileDetails", { id: match.params.id });
+  }
+
+  getUrlFromKindWithId<K extends RouteKind>(
+    kind: K,
+    uri: string
+  ): RouteKindWithId<K> | undefined {
+    if (uri.length <= 0) return undefined;
+    const pattern = "/api/v2/compilereport/:id";
+    const match = matchPath(pattern, uri);
+    if (match === null) return undefined;
+    if (match.params.id === undefined) return undefined;
+    if (kind == "CompileDetails") {
+      const params = { id: match.params.id };
+      console.log(params);
+      // return { kind, params: params as RouteParams<"CompileDetails"> };
+    }
+    return undefined;
   }
 
   getRouteMatchFromUrl(url: string): RouteMatch | undefined {

--- a/src/UI/Routing/PrimaryRouteManager.ts
+++ b/src/UI/Routing/PrimaryRouteManager.ts
@@ -14,7 +14,6 @@ import {
   Crumb,
   RouteKindWithId,
 } from "@/Core";
-
 import { AgentProcess } from "@S/AgentProcess";
 import { Agents } from "@S/Agents";
 import { CompileDetails } from "@S/CompileDetails";

--- a/src/UI/Routing/PrimaryRouteManager.ts
+++ b/src/UI/Routing/PrimaryRouteManager.ts
@@ -156,7 +156,7 @@ export class PrimaryRouteManager implements RouteManager {
     return this.getUrl("CompileDetails", { id: match.params.id });
   }
 
-  getUrlFromKindWithId(
+  getUrlCompileDetailsId(
     uri: string
   ): RouteKindWithId<"CompileDetails"> | undefined {
     if (uri.length <= 0) return undefined;

--- a/src/UI/Routing/PrimaryRouteManager.ts
+++ b/src/UI/Routing/PrimaryRouteManager.ts
@@ -156,21 +156,19 @@ export class PrimaryRouteManager implements RouteManager {
     return this.getUrl("CompileDetails", { id: match.params.id });
   }
 
-  getUrlFromKindWithId<K extends RouteKind>(
-    kind: K,
+  getUrlFromKindWithId(
     uri: string
-  ): RouteKindWithId<K> | undefined {
+  ): RouteKindWithId<"CompileDetails"> | undefined {
     if (uri.length <= 0) return undefined;
     const pattern = "/api/v2/compilereport/:id";
     const match = matchPath(pattern, uri);
     if (match === null) return undefined;
     if (match.params.id === undefined) return undefined;
-    if (kind == "CompileDetails") {
-      const params = { id: match.params.id };
-      console.log(params);
-      // return { kind, params: params as RouteParams<"CompileDetails"> };
-    }
-    return undefined;
+    const params = { id: match.params.id };
+    return {
+      kind: "CompileDetails",
+      params,
+    };
   }
 
   getRouteMatchFromUrl(url: string): RouteMatch | undefined {

--- a/src/UI/Routing/PrimaryRouteManager.ts
+++ b/src/UI/Routing/PrimaryRouteManager.ts
@@ -155,9 +155,7 @@ export class PrimaryRouteManager implements RouteManager {
     return this.getUrl("CompileDetails", { id: match.params.id });
   }
 
-  getUrlCompileDetailsId(
-    uri: string
-  ): RouteKindWithId<"CompileDetails"> | undefined {
+  getParamsFromUrl(uri: string): RouteKindWithId<"CompileDetails"> | undefined {
     if (uri.length <= 0) return undefined;
     const pattern = "/api/v2/compilereport/:id";
     const match = matchPath(pattern, uri);


### PR DESCRIPTION
# Description

When clicking on a notification, navigate to the details page. this should not happen when clicking on the toggle present on a notification.

closes https://github.com/inmanta/web-console/issues/3470

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Code is clear and sufficiently documented
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
