### PR TITLE
issue/3519: Creating an environment fails when repository field is filled and cleared again

### DIFF
--- a/changelogs/unreleased/3519-fix-clear-field-env-creation.yml
+++ b/changelogs/unreleased/3519-fix-clear-field-env-creation.yml
@@ -1,0 +1,3 @@
+description: Fix env creation by allowing to clear optional fields
+change-type: patch
+destination-branches: [master, iso5]

--- a/changelogs/unreleased/3519-fix-clear-field-env-creation.yml
+++ b/changelogs/unreleased/3519-fix-clear-field-env-creation.yml
@@ -1,3 +1,3 @@
 description: Fix env creation by allowing to clear optional fields
 change-type: patch
-destination-branches: [master, iso5]
+destination-branches: [master, iso5, iso4]

--- a/src/Slices/CreateEnvironment/UI/CreateEnvironmentForm.test.tsx
+++ b/src/Slices/CreateEnvironment/UI/CreateEnvironmentForm.test.tsx
@@ -382,7 +382,7 @@ test(`Given CreateEnvironmentForm When an existing project, a valid environment 
   expect(apiHelper.pendingRequests).toHaveLength(1);
   const request = apiHelper.pendingRequests[0];
   expect(request).toEqual({
-    //branch and repository should not be present in th body
+    //branch and repository should not be present in the body
     method: "PUT",
     body: {
       name: "dev",

--- a/src/Slices/CreateEnvironment/UI/CreateEnvironmentForm.tsx
+++ b/src/Slices/CreateEnvironment/UI/CreateEnvironmentForm.tsx
@@ -37,18 +37,27 @@ export const CreateEnvironmentForm: React.FC<Props> = ({
     setCreateEnvironmentBody({ ...createEnvironmentBody, name });
   };
   const setDescription = (description: string) => {
-    setCreateEnvironmentBody({ ...createEnvironmentBody, description });
+    setCreateEnvironmentBody({
+      ...createEnvironmentBody,
+      description: description ? description : undefined,
+    });
   };
   const setRepository = (repository: string) => {
-    setCreateEnvironmentBody({ ...createEnvironmentBody, repository });
+    setCreateEnvironmentBody({
+      ...createEnvironmentBody,
+      repository: repository ? repository : undefined,
+    });
   };
   const setBranch = (branch: string) => {
-    setCreateEnvironmentBody({ ...createEnvironmentBody, branch });
+    setCreateEnvironmentBody({
+      ...createEnvironmentBody,
+      branch: branch ? branch : undefined,
+    });
   };
   const setIcon = (icon: string) => {
     setCreateEnvironmentBody({
       ...createEnvironmentBody,
-      icon,
+      icon: icon ? icon : undefined,
     });
   };
 


### PR DESCRIPTION
# Description

When creating an environment, if a user writes something in the repository field, and then deletes it, the request fails. This commit fixes this and allow to set fields back to empty.

closes #3519 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Code is clear and sufficiently documented
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
