### PR TITLE
Build(deps-dev): Bump @types/react-syntax-highlighter from 15.5.1 to 15.5.2 (#3620)

### DIFF
--- a/changelogs/unreleased/3620-dependabot.yml
+++ b/changelogs/unreleased/3620-dependabot.yml
@@ -1,0 +1,7 @@
+change-type: patch
+description: 'Build(deps-dev): Bump @types/react-syntax-highlighter from 15.5.1 to
+    15.5.2'
+destination-branches:
+- master
+- iso5
+sections: {}

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@types/react": "^17.0.45",
     "@types/react-dom": "^18.0.3",
     "@types/react-router-dom": "^5.3.3",
-    "@types/react-syntax-highlighter": "^15.5.1",
+    "@types/react-syntax-highlighter": "^15.5.2",
     "@types/styled-components": "^5.1.25",
     "@types/webpack": "^5.28.0",
     "@types/xml-formatter": "^2.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3643,10 +3643,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-syntax-highlighter@^15.5.1":
-  version "15.5.1"
-  resolved "https://registry.yarnpkg.com/@types/react-syntax-highlighter/-/react-syntax-highlighter-15.5.1.tgz#0c459cdd94a882df05778e93a1514430cc641043"
-  integrity sha512-+yD6D8y21JqLf89cRFEyRfptVMqo2ROHyAlysRvFwT28gT5gDo3KOiXHwGilHcq9y/OKTjlWK0f/hZUicrBFPQ==
+"@types/react-syntax-highlighter@^15.5.2":
+  version "15.5.2"
+  resolved "https://registry.yarnpkg.com/@types/react-syntax-highlighter/-/react-syntax-highlighter-15.5.2.tgz#b3450851c11b8526a27edf51d00769b69d8fbf20"
+  integrity sha512-cJJvwU8lQv/efGSo/LmPoaOqWi/B0AG4CNKKCn7HPUL25SqiPn1Vl+fV1JiUigJv97ruTZ8mo08+b8/0zoYufA==
   dependencies:
     "@types/react" "*"
 


### PR DESCRIPTION
Pull request opened by the merge tool on behalf of #3620