### PR TITLE
Fix issue xml formatter

### DIFF
--- a/changelogs/unreleased/fix-issue-xml-formatter.yml
+++ b/changelogs/unreleased/fix-issue-xml-formatter.yml
@@ -1,0 +1,7 @@
+description: Fixed issue where web-console would crash when failing to format xml
+change-type: patch
+sections:
+  bugfix: "{{description}}"
+destination-branches:
+  - master
+  - iso5

--- a/src/Data/Common/XmlFormatter.ts
+++ b/src/Data/Common/XmlFormatter.ts
@@ -3,9 +3,13 @@ import { Formatter } from "@/Core";
 
 export class XmlFormatter implements Formatter {
   format(source: string): string {
-    return formatXml(source, {
-      collapseContent: true,
-      lineSeparator: "\n",
-    });
+    try {
+      return formatXml(source, {
+        collapseContent: true,
+        lineSeparator: "\n",
+      });
+    } catch {
+      return source;
+    }
   }
 }

--- a/src/UI/Components/DesiredStateAttributes/AttributeClassifier.spec.ts
+++ b/src/UI/Components/DesiredStateAttributes/AttributeClassifier.spec.ts
@@ -35,35 +35,3 @@ test("GIVEN AttributeClassifier WHEN provided with a custom multiline classifier
     },
   ]);
 });
-
-test("GIVEN AttributeClassifier WHEN provided with a wrong xml THEN return the string without formating to prevent crash", () => {
-  const classifier = new AttributeClassifier(
-    new JsonFormatter(),
-    new XmlFormatter()
-  );
-
-  expect(
-    classifier.classify({
-      goodXml: attributes["c"],
-      wrongXml1: attributes["wrongXml1"],
-      wrongXml2: attributes["wrongXml2"],
-    })
-  ).toEqual([
-    {
-      kind: "Xml",
-      key: "goodXml",
-      value: "<note>\n    <to>Tove</to>\n    <from>Jani</from>\n</note>",
-    },
-    {
-      kind: "Xml",
-      key: "wrongXml1",
-      value:
-        "<class 'AttributeError'>: 'RPCError' object has no attribute '_tag'",
-    },
-    {
-      kind: "Xml",
-      key: "wrongXml2",
-      value: "<class 'AttributeError'>",
-    },
-  ]);
-});

--- a/src/UI/Components/DesiredStateAttributes/AttributeClassifier.spec.ts
+++ b/src/UI/Components/DesiredStateAttributes/AttributeClassifier.spec.ts
@@ -35,3 +35,35 @@ test("GIVEN AttributeClassifier WHEN provided with a custom multiline classifier
     },
   ]);
 });
+
+test("GIVEN AttributeClassifier WHEN provided with a wrong xml THEN return the string without formating to prevent crash", () => {
+  const classifier = new AttributeClassifier(
+    new JsonFormatter(),
+    new XmlFormatter()
+  );
+
+  expect(
+    classifier.classify({
+      goodXml: attributes["c"],
+      wrongXml1: attributes["wrongXml1"],
+      wrongXml2: attributes["wrongXml2"],
+    })
+  ).toEqual([
+    {
+      kind: "Xml",
+      key: "goodXml",
+      value: "<note>\n    <to>Tove</to>\n    <from>Jani</from>\n</note>",
+    },
+    {
+      kind: "Xml",
+      key: "wrongXml1",
+      value:
+        "<class 'AttributeError'>: 'RPCError' object has no attribute '_tag'",
+    },
+    {
+      kind: "Xml",
+      key: "wrongXml2",
+      value: "<class 'AttributeError'>",
+    },
+  ]);
+});

--- a/src/UI/Components/DesiredStateAttributes/AttributeClassifier.ts
+++ b/src/UI/Components/DesiredStateAttributes/AttributeClassifier.ts
@@ -89,6 +89,6 @@ export class AttributeClassifier {
   }
 
   private isXml(value: string): boolean {
-    return value.startsWith("<");
+    return value.startsWith("<") && value.endsWith(">");
   }
 }

--- a/src/UI/Components/DesiredStateAttributes/Data.ts
+++ b/src/UI/Components/DesiredStateAttributes/Data.ts
@@ -57,6 +57,17 @@ export const classified: ClassifiedAttribute[] = [
     key: "some_password",
     value: "****",
   },
+  {
+    kind: "Xml",
+    key: "wrongXml1",
+    value:
+      "<class 'AttributeError'>: 'RPCError' object has no attribute '_tag'",
+  },
+  {
+    kind: "Xml",
+    key: "wrongXml2",
+    value: "<class 'AttributeError'>",
+  },
 ];
 
 export const longNames: ClassifiedAttribute[] = [

--- a/src/UI/Components/DesiredStateAttributes/Data.ts
+++ b/src/UI/Components/DesiredStateAttributes/Data.ts
@@ -58,7 +58,7 @@ export const classified: ClassifiedAttribute[] = [
     value: "****",
   },
   {
-    kind: "Xml",
+    kind: "SingleLine",
     key: "wrongXml1",
     value:
       "<class 'AttributeError'>: 'RPCError' object has no attribute '_tag'",

--- a/src/UI/Components/DesiredStateAttributes/Data.ts
+++ b/src/UI/Components/DesiredStateAttributes/Data.ts
@@ -15,6 +15,8 @@ export const attributes = {
   g: {},
   hash: "filehash",
   some_password: "abcde",
+  wrongXml1: `<class 'AttributeError'>: 'RPCError' object has no attribute '_tag'`,
+  wrongXml2: `<class 'AttributeError'>`,
 };
 
 export const classified: ClassifiedAttribute[] = [


### PR DESCRIPTION
# Description

currently the web-console will crash when failing to format an Xml string. This commit makes sure it wont crash and the a non formatted string will be returned. 


# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [x] Code is clear and sufficiently documented
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
