### PR TITLE
Build(deps-dev): Bump @types/react-syntax-highlighter from 15.5.4 to 15.5.5 (#3938)

### DIFF
--- a/changelogs/unreleased/3938-dependabot.yml
+++ b/changelogs/unreleased/3938-dependabot.yml
@@ -1,0 +1,7 @@
+change-type: patch
+description: 'Build(deps-dev): Bump @types/react-syntax-highlighter from 15.5.4 to
+    15.5.5'
+destination-branches:
+- master
+- iso5
+sections: {}

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@types/react": "^17.0.45",
     "@types/react-dom": "^18.0.3",
     "@types/react-router-dom": "^5.3.3",
-    "@types/react-syntax-highlighter": "^15.5.4",
+    "@types/react-syntax-highlighter": "^15.5.5",
     "@types/styled-components": "^5.1.26",
     "@types/webpack": "^5.28.0",
     "@types/xml-formatter": "^2.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3673,10 +3673,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-syntax-highlighter@^15.5.4":
-  version "15.5.4"
-  resolved "https://registry.yarnpkg.com/@types/react-syntax-highlighter/-/react-syntax-highlighter-15.5.4.tgz#c76dd9cab769484bb7360849074eb340421183ca"
-  integrity sha512-GYXA4nRBG4jTGFfYMLO2/yuqyOyaQ415oeJWw6akE5gipOEsGhvXFvWhsctGVMHzAfRI7e/J0B9cpqrfMOwZhA==
+"@types/react-syntax-highlighter@^15.5.5":
+  version "15.5.5"
+  resolved "https://registry.yarnpkg.com/@types/react-syntax-highlighter/-/react-syntax-highlighter-15.5.5.tgz#4d3b51f8956195f1f63360ff03f8822c5d74c516"
+  integrity sha512-QH3JZQXa2usAvJvSsdSUJ4Yu4j8ReuZpgRrEW+XP+Rmosbn425YshW9iGEb/pAARm8496axHhHUPRH3UmTiB6A==
   dependencies:
     "@types/react" "*"
 


### PR DESCRIPTION
Pull request opened by the merge tool on behalf of #3938