### PR TITLE
[DEPENDABOT] pin @testing-library/react to major version 12

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,5 @@ updates:
     ignore:
       - dependency-name: "@types/react"
         update-types: ["version-update:semver-major"]
+      - dependency-name: "@testing-library/react"
+        update-types: ["version-update:semver-major"]

--- a/changelogs/unreleased/pin-testing-library-react-to-major-version-12.yml
+++ b/changelogs/unreleased/pin-testing-library-react-to-major-version-12.yml
@@ -1,0 +1,6 @@
+change-type: patch
+description: 'Pin testing library react to major version 12'
+destination-branches:
+- master
+- iso5
+sections: {}


### PR DESCRIPTION
# Description

Major version 13 of @testing-library/react requires react version 18 and at the time of writing the ticket we are using version 17.

This ticket can be reverted when react version is bumped to v18.

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Code is clear and sufficiently documented
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
