### PR TITLE
hotfix xml formatter

### DIFF
--- a/changelogs/unreleased/hotfix-xml-formatter.yml
+++ b/changelogs/unreleased/hotfix-xml-formatter.yml
@@ -1,0 +1,8 @@
+description: Hotfix for the xml-formatter when the scenario occurs where the string to be formatted is preceded or ends with whitspaces.
+sections: 
+  bugfix: "{{description}}"
+issue-nr: 4144
+change-type: patch
+destination-branches:
+  - master
+  - iso5

--- a/src/UI/Components/DesiredStateAttributes/AttributeClassifier.spec.ts
+++ b/src/UI/Components/DesiredStateAttributes/AttributeClassifier.spec.ts
@@ -9,7 +9,7 @@ test("GIVEN AttributeClassifier WHEN provided with a mixed attributes object THE
     new XmlFormatter()
   );
 
-  expect(classifier.classify(attributes)).toEqual(classified.sort());
+  expect(classifier.classify(attributes)).toEqual(classified);
 });
 
 test("GIVEN AttributeClassifier WHEN provided with a custom multiline classifier THEN returns the correct list of ClassifiedAttributes", () => {
@@ -21,7 +21,7 @@ test("GIVEN AttributeClassifier WHEN provided with a custom multiline classifier
 
   expect(
     classifier.classify({ f: attributes["f"], ff: attributes["ff"] })
-  ).toStrictEqual([
+  ).toEqual([
     {
       kind: "Python",
       key: "f",

--- a/src/UI/Components/DesiredStateAttributes/AttributeClassifier.spec.ts
+++ b/src/UI/Components/DesiredStateAttributes/AttributeClassifier.spec.ts
@@ -9,7 +9,7 @@ test("GIVEN AttributeClassifier WHEN provided with a mixed attributes object THE
     new XmlFormatter()
   );
 
-  expect(classifier.classify(attributes)).toEqual(classified);
+  expect(classifier.classify(attributes)).toEqual(classified.sort());
 });
 
 test("GIVEN AttributeClassifier WHEN provided with a custom multiline classifier THEN returns the correct list of ClassifiedAttributes", () => {
@@ -21,7 +21,7 @@ test("GIVEN AttributeClassifier WHEN provided with a custom multiline classifier
 
   expect(
     classifier.classify({ f: attributes["f"], ff: attributes["ff"] })
-  ).toEqual([
+  ).toStrictEqual([
     {
       kind: "Python",
       key: "f",

--- a/src/UI/Components/DesiredStateAttributes/AttributeClassifier.ts
+++ b/src/UI/Components/DesiredStateAttributes/AttributeClassifier.ts
@@ -89,6 +89,7 @@ export class AttributeClassifier {
   }
 
   private isXml(value: string): boolean {
-    return value.startsWith("<") && value.endsWith(">");
+    const trimmedValue = value.trimStart().trimEnd();
+    return trimmedValue.startsWith("<") && trimmedValue.endsWith(">");
   }
 }

--- a/src/UI/Components/DesiredStateAttributes/Data.ts
+++ b/src/UI/Components/DesiredStateAttributes/Data.ts
@@ -17,6 +17,7 @@ export const attributes = {
   some_password: "abcde",
   wrongXml1: `<class 'AttributeError'>: 'RPCError' object has no attribute '_tag'`,
   wrongXml2: `<class 'AttributeError'>`,
+  whiteSpacedXML: `  <note><to>Tove</to><from>Jani</from></note> `,
 };
 
 export const classified: ClassifiedAttribute[] = [
@@ -56,6 +57,11 @@ export const classified: ClassifiedAttribute[] = [
     kind: "Password",
     key: "some_password",
     value: "****",
+  },
+  {
+    kind: "Xml",
+    key: "whiteSpacedXML",
+    value: `<note>\n    <to>Tove</to>\n    <from>Jani</from>\n</note>`,
   },
   {
     kind: "SingleLine",


### PR DESCRIPTION
# Description

* Short description here *

Fixed the scenario where the xml string is preceded or ends with white spaces. 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Code is clear and sufficiently documented
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Code is clear and sufficiently documented
- [x] Correct, in line with design
