### PR TITLE
Build(deps): Bump keycloak-js from 19.0.2 to 19.0.3 (#4167)

### DIFF
--- a/changelogs/unreleased/4167-dependabot.yml
+++ b/changelogs/unreleased/4167-dependabot.yml
@@ -1,0 +1,6 @@
+change-type: patch
+description: 'Build(deps): Bump keycloak-js from 19.0.2 to 19.0.3'
+destination-branches:
+- master
+- iso5
+sections: {}

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "history": "5.3.0",
     "json-bigint": "^1.0.0",
     "jszip": "^3.10.1",
-    "keycloak-js": "19.0.2",
+    "keycloak-js": "19.0.3",
     "lint": "^0.7.0",
     "lodash": "^4.17.21",
     "lodash-es": "^4.17.21",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10902,10 +10902,10 @@ junk@^3.1.0:
   resolved "https://registry.yarnpkg.com/junk/-/junk-3.1.0.tgz#31499098d902b7e98c5d9b9c80f43457a88abfa1"
   integrity sha512-pBxcB3LFc8QVgdggvZWyeys+hnrNWg4OcZIU/1X59k5jQdLBlCsYGRQaz234SqoRLTCgMH00fY0xRJH+F9METQ==
 
-keycloak-js@19.0.2:
-  version "19.0.2"
-  resolved "https://registry.yarnpkg.com/keycloak-js/-/keycloak-js-19.0.2.tgz#df8d12138c3edf70d9880097204a943674c605ee"
-  integrity sha512-tQjkLVVIwaV1xf4Fri5u+d+Ttddrh0S5cv3ltG+uTUd7WNwt5LkOXsPnqWQjj9stpoBTFgTuzIqJ2C6vk0CcEQ==
+keycloak-js@19.0.3:
+  version "19.0.3"
+  resolved "https://registry.yarnpkg.com/keycloak-js/-/keycloak-js-19.0.3.tgz#f70e988b799054957e47c981b7e962c9874da00e"
+  integrity sha512-mzCBxrzfl+vB551Q7MB+T9+40IHU4i0a6g1eTatzeEGrQMis5m/BqvPC3kxTsI+/LxHbB9XYQE3u9SlWKDHQCw==
   dependencies:
     base64-js "^1.5.1"
     js-sha256 "^0.9.0"


### PR DESCRIPTION
Pull request opened by the merge tool on behalf of #4167