### PR TITLE
Build(deps): Bump @patternfly/react-tokens from 4.91.0 to 4.93.6 (#4199)

### DIFF
--- a/changelogs/unreleased/4199-dependabot.yml
+++ b/changelogs/unreleased/4199-dependabot.yml
@@ -1,0 +1,6 @@
+change-type: patch
+description: 'Build(deps): Bump @patternfly/react-tokens from 4.91.0 to 4.93.6'
+destination-branches:
+- master
+- iso5
+sections: {}

--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "@patternfly/react-icons": "^4.82.8",
     "@patternfly/react-styles": "^4.81.8",
     "@patternfly/react-table": "^4.108.0",
-    "@patternfly/react-tokens": "^4.91.0",
+    "@patternfly/react-tokens": "^4.93.6",
     "copy-to-clipboard": "^3.3.2",
     "easy-peasy": "^5.1.0",
     "file-saver": "^2.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2069,10 +2069,10 @@
     lodash "^4.17.19"
     tslib "^2.0.0"
 
-"@patternfly/react-tokens@^4.91.0":
-  version "4.91.0"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-4.91.0.tgz#f173a5a36911a789ea966a7e5955de92aeccf8fc"
-  integrity sha512-QeQCy8o8E/16fAr8mxqXIYRmpTsjCHJXi5p5jmgEDFmYMesN6Pqfv6N5D0FHb+CIaNOZWRps7GkWvlIMIE81sw==
+"@patternfly/react-tokens@^4.91.0", "@patternfly/react-tokens@^4.93.6":
+  version "4.93.6"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-4.93.6.tgz#b09e8935783dab86f10decd05e357570b2a70aec"
+  integrity sha512-rf4q5NoJNX7oBpRvGrWSjfK6sLA4yHSBgm6Rh5/2Uw1cgp47VaBY3XrErjT5YTu9uZCcvThGqBk8jiXI7tIRxw==
 
 "@pkgr/utils@^2.3.0":
   version "2.3.0"


### PR DESCRIPTION
Pull request opened by the merge tool on behalf of #4199