### PR TITLE
4259 upgrade scroll intoview

### DIFF
--- a/changelogs/unreleased/4259-bugfix-scrollinto-view.yml
+++ b/changelogs/unreleased/4259-bugfix-scrollinto-view.yml
@@ -1,0 +1,6 @@
+description: Bugfix for the scroll into view behaviour.
+issue-nr: 4259
+change-type: patch
+destination-branches:
+  - master
+  - iso5

--- a/src/UI/Components/CodeHighlighter/index.tsx
+++ b/src/UI/Components/CodeHighlighter/index.tsx
@@ -45,12 +45,12 @@ export const CodeHighlighter: React.FC<Props> = ({
   scrollBottom = false,
   close,
 }) => {
-  const [allowScrollState, setAllowScrollState] = useState(true);
   const [copied, setCopied] = useState(false);
   const [zoomed, setZoomed] = useState(false);
   const [showLineNumbers, setShowLineNumbers] = useState(false);
   const [wrapLongLines, setWraplongLines] = useState(true);
   const codeBlockRef = useRef<HTMLDivElement>(null);
+  const [allowScrollState, setAllowScrollState] = useState(true);
   const minHeight = "8em";
 
   const onCopy = () => {
@@ -144,11 +144,9 @@ export const CodeHighlighter: React.FC<Props> = ({
   );
 
   const setScrollPositionBottom = (element) => {
-    if (!scrollBottom || !allowScrollState || !element) {
-      return;
+    if (element && scrollBottom && allowScrollState) {
+      element.scrollTo(0, element.scrollHeight);
     }
-
-    element.scrollTo(0, element.scrollHeight);
   };
 
   const updateScrollPosition = ({ target }) => {
@@ -175,9 +173,8 @@ export const CodeHighlighter: React.FC<Props> = ({
 
     if (scrollBottom && preBlock?.firstChild?.nodeName === "CODE") {
       preBlock?.addEventListener("scroll", updateScrollPosition);
+      setScrollPositionBottom(preBlock);
     }
-
-    setScrollPositionBottom(preBlock);
 
     return () => {
       if (!allowScrollState) {


### PR DESCRIPTION
# Description

Adjust the previously implemented scroll into view for reports. Now, when the user does scroll upwards, the scroll to end of the container is being deactivated. I used the native dataset attribute to store the positioning (this doesn't cause re-renders as it isn't a state/prop change) and allows to track if the user scrolled upwards. 

closes *#4359*

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Code is clear and sufficiently documented
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Code is clear and sufficiently documented
- [x] Correct, in line with design
