### PR TITLE
Add Banner that shows user that changed were saved successfully

### DIFF
--- a/changelogs/unreleased/4117-config-feedback.yml
+++ b/changelogs/unreleased/4117-config-feedback.yml
@@ -1,0 +1,6 @@
+description: Add feedback for config editor
+issue-nr: 4117
+change-type: patch
+destination-branches:
+  - master
+  - iso5

--- a/src/Data/Managers/EnvironmentSettings/UpdateEnvironmentSetting/CommandManager.ts
+++ b/src/Data/Managers/EnvironmentSettings/UpdateEnvironmentSetting/CommandManager.ts
@@ -26,6 +26,7 @@ export function UpdateEnvironmentSettingCommandManager(
             details: false,
             id: environment,
           });
+          document.dispatchEvent(new Event("Settings update"));
         }
 
         return error;

--- a/src/Slices/Settings/UI/Tabs/Configuration/Container.tsx
+++ b/src/Slices/Settings/UI/Tabs/Configuration/Container.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { Alert, AlertActionCloseButton } from "@patternfly/react-core";
 import { TableComposable, Tbody } from "@patternfly/react-table";
 import styled from "styled-components";
@@ -18,6 +18,20 @@ export const Container: React.FC<Props> = ({
   onErrorClose,
   className,
 }) => {
+  const [showUpdateBanner, setShowUpdateBanner] = useState(false);
+
+  useEffect(() => {
+    const updateSuccessBanner = () => {
+      setShowUpdateBanner(true);
+      setTimeout(() => {
+        setShowUpdateBanner(false);
+      }, 2000);
+    };
+    document.addEventListener("Settings update", updateSuccessBanner);
+    return () => {
+      document.removeEventListener("Settings update", updateSuccessBanner);
+    };
+  }, [setShowUpdateBanner]);
   return (
     <Wrapper className={className}>
       {errorMessage && (
@@ -26,6 +40,19 @@ export const Container: React.FC<Props> = ({
           title={errorMessage}
           aria-live="polite"
           actionClose={<AlertActionCloseButton onClose={onErrorClose} />}
+          isInline
+        />
+      )}
+      {showUpdateBanner && (
+        <StyledAlert
+          variant="success"
+          title={"Setting Changed"}
+          aria-live="polite"
+          actionClose={
+            <AlertActionCloseButton
+              onClose={() => setShowUpdateBanner(false)}
+            />
+          }
           isInline
         />
       )}

--- a/src/Slices/Settings/UI/Tabs/Configuration/Tab.test.tsx
+++ b/src/Slices/Settings/UI/Tabs/Configuration/Tab.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { MemoryRouter } from "react-router-dom";
-import { act, render, screen, within } from "@testing-library/react";
+import { act, fireEvent, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { StoreProvider } from "easy-peasy";
 import { Either, Maybe } from "@/Core";
@@ -303,6 +303,9 @@ test("GIVEN ConfigurationTab and boolean input WHEN changing boolean value and s
       Either.right({ data: EnvironmentSettings.auto_deploy })
     );
   });
+
+  fireEvent(document, new Event("Settings update"));
+  expect(await screen.findByText("Setting Changed")).toBeVisible();
 
   expect(apiHelper.resolvedRequests).toHaveLength(3);
   expect(toggle.checked).toBeTruthy();


### PR DESCRIPTION
# Description

* Short description here *

closes #4117 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Code is clear and sufficiently documented
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
~~- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design

https://user-images.githubusercontent.com/113331659/200302485-356acee3-9237-4310-a727-c011e2b9ea43.mov

