### PR TITLE
4114 display value conversion

### DIFF
--- a/changelogs/unreleased/4114-title-case-converter.yml
+++ b/changelogs/unreleased/4114-title-case-converter.yml
@@ -1,0 +1,6 @@
+description: Where possible, make the labels title cased.
+issue-nr: 4114
+change-type: patch
+destination-branches:
+  - master
+  - iso5

--- a/src/UI/Components/InlineEditable/EditableField.tsx
+++ b/src/UI/Components/InlineEditable/EditableField.tsx
@@ -7,6 +7,7 @@ import {
   FlexItem,
 } from "@patternfly/react-core";
 import { Maybe } from "@/Core";
+import { convertToTitleCase } from "@/UI/Utils";
 import {
   CancelEditButton,
   EnableEditButton,
@@ -84,7 +85,7 @@ export const EditableField: React.FC<Props> = ({
           spaceItems={{ default: "spaceItemsNone" }}
         >
           <InlineLabelItem aria-label={`${label}-label`}>
-            {label}
+            {convertToTitleCase(label)}
             {isRequired && (
               <span aria-hidden="true" style={{ color: "red" }}>
                 {" "}
@@ -121,7 +122,7 @@ export const EditableField: React.FC<Props> = ({
             <FlexItem grow={{ default: "grow" }}>
               <EditView
                 aria-label={`${label}-input`}
-                label={label}
+                label={convertToTitleCase(label)}
                 value={value}
                 onChange={setValue}
                 onSubmit={() => onSubmitRequest(value)}

--- a/src/UI/Components/InlineEditable/EditableMultiTextField.tsx
+++ b/src/UI/Components/InlineEditable/EditableMultiTextField.tsx
@@ -9,6 +9,7 @@ import {
   TextInput,
 } from "@patternfly/react-core";
 import { Maybe } from "@/Core";
+import { convertToTitleCase } from "@/UI/Utils";
 import {
   CancelEditButton,
   EnableEditButton,
@@ -100,7 +101,7 @@ export const EditableMultiTextField: React.FC<Props> = ({
           {Object.entries(fieldValues).map(([label, value]) => (
             <DescriptionListGroup key={label}>
               <DescriptionListTerm aria-label={`${label}-label`}>
-                {label}
+                {convertToTitleCase(label)}
               </DescriptionListTerm>
               <DescriptionListDescription>
                 {!editable && (

--- a/src/UI/Utils/displayValueConverter.test.tsx
+++ b/src/UI/Utils/displayValueConverter.test.tsx
@@ -1,0 +1,67 @@
+import { convertToTitleCase } from "./displayValueConverter";
+
+const testValues = {
+  snake_case: "some_case_text",
+  hyphen_case: "some-case-text",
+  mixed_case: "some_case-text",
+  mixed_upper_case: "SOME-CASE_TEXT",
+  start_with_underscore: "_some_case_text",
+  end_with_underscore: "some_case_text_",
+  start_with_hyphen: "-some-case-text",
+  end_with_hyphen: "some-case-text-",
+  double_hyphen: "some--case-text",
+  double_underscore: "some__case_text",
+  normal_string: "some case text",
+};
+
+const titleCasedResult = "Some Case Text";
+
+test("Should convert snake case to Title Cased text", () => {
+  expect(convertToTitleCase(testValues.snake_case)).toBe(titleCasedResult);
+});
+test("Should convert hyphen-case to title cased text", () => {
+  expect(convertToTitleCase(testValues.hyphen_case)).toBe(titleCasedResult);
+});
+test("Should convert mixed-cased to title cased text", () => {
+  expect(convertToTitleCase(testValues.mixed_case)).toBe(titleCasedResult);
+});
+test("Should convert mixed upper-cased to title cased text", () => {
+  expect(convertToTitleCase(testValues.mixed_upper_case)).toBe(
+    titleCasedResult
+  );
+});
+test("Should convert a snake cased string starting with an underscore to title cased text", () => {
+  expect(convertToTitleCase(testValues.start_with_underscore)).toBe(
+    titleCasedResult
+  );
+});
+test("Should convert a snake cased string ending with an underscore to title cased text", () => {
+  expect(convertToTitleCase(testValues.end_with_underscore)).toBe(
+    titleCasedResult
+  );
+});
+test("Should convert a hyphen cased string starting with a hyphen to title cased text", () => {
+  expect(convertToTitleCase(testValues.start_with_hyphen)).toBe(
+    titleCasedResult
+  );
+});
+test("Should convert a hyphen cased string ending with a hyphen to title cased text", () => {
+  expect(convertToTitleCase(testValues.end_with_hyphen)).toBe(titleCasedResult);
+});
+test("Should convert a snake cased string with double underscore to title cased text", () => {
+  expect(convertToTitleCase(testValues.double_underscore)).toBe(
+    titleCasedResult
+  );
+});
+test("Should convert a hyphen cased string with double hyphen to title cased text", () => {
+  expect(convertToTitleCase(testValues.double_hyphen)).toBe(titleCasedResult);
+});
+test("Should title case a string that already has white spaces", () => {
+  expect(convertToTitleCase(testValues.normal_string)).toBe(titleCasedResult);
+});
+test("It should not break when being passed numerical characters", () => {
+  expect(convertToTitleCase("300")).toBe("300");
+});
+test("It should not break when being passed other characters", () => {
+  expect(convertToTitleCase("@work!")).toBe("@work!");
+});

--- a/src/UI/Utils/displayValueConverter.tsx
+++ b/src/UI/Utils/displayValueConverter.tsx
@@ -1,0 +1,21 @@
+/**
+ * Transforms any given string that is separated by hyphens and or underscore and or white spaces to title cased text with white spaces.
+ *
+ * @param rawString
+ * @returns String
+ */
+export const convertToTitleCase = (rawString: string) => {
+  const transformedString = rawString
+    .toLowerCase()
+    .replace(/[-_]+(.)/g, (_, char) => {
+      return " " + char;
+    }) // replace underscore or hyphens into white space and avoid multiple white spaces
+    .replace(/[-_]/g, "") // remove any trailing underscores and hyphens
+    .split(" ")
+    .map((word) => {
+      return word.length ? word.replace(word[0], word[0].toUpperCase()) : word;
+    })
+    .join(" ");
+
+  return transformedString.trimStart().trimEnd(); // trim start and end of string from trailing white spaces
+};

--- a/src/UI/Utils/index.ts
+++ b/src/UI/Utils/index.ts
@@ -4,3 +4,4 @@ export * from "./UrlManager";
 export * from "./ScrollRowIntoView";
 export * from "./ResourceId";
 export * from "./useTicker";
+export * from "./displayValueConverter";


### PR DESCRIPTION
# Description

I created a function that is capable to transform any given string into title cased text. I applied the casing to the settings page on the Environment tab. 

<img width="362" alt="image" src="https://user-images.githubusercontent.com/44098050/200802849-b2bdfdf0-45f3-4f72-a1da-e205e03da49f.png">

closes *#4114*

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Code is clear and sufficiently documented
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
