### PR TITLE
remove link to dashboard

### DIFF
--- a/changelogs/unreleased/4108-remove-dashboard-link.yml
+++ b/changelogs/unreleased/4108-remove-dashboard-link.yml
@@ -1,0 +1,8 @@
+description: The link to the old dashboard has been removed from the sidebar.
+sections: 
+  minor-improvement: "{{description}}"
+issue-nr: 4108
+change-type: patch
+destination-branches:
+  - master
+  - iso5

--- a/src/UI/Root/Components/Sidebar/Navigation/Group.ts
+++ b/src/UI/Root/Components/Sidebar/Navigation/Group.ts
@@ -101,21 +101,3 @@ export const resourceManager = (
     },
   ],
 });
-
-export const otherSites = (
-  dashboardUrl: string,
-  isEnvPresent: boolean
-): Group => ({
-  id: "OtherSites",
-  title: "Other Sites",
-  links: [
-    {
-      id: "Dashboard",
-      label: "Dashboard",
-      url: dashboardUrl,
-      external: true,
-      locked: !isEnvPresent,
-      statusIndication: false,
-    },
-  ],
-});

--- a/src/UI/Root/Components/Sidebar/Navigation/Navigation.test.tsx
+++ b/src/UI/Root/Components/Sidebar/Navigation/Navigation.test.tsx
@@ -54,7 +54,7 @@ test("GIVEN Navigation WHEN lsm enabled THEN shows all navigation items", () => 
 
   const navigation = screen.getByRole("navigation", { name: "Global" });
   expect(navigation).toBeVisible();
-  expect(within(navigation).getAllByRole("region").length).toEqual(4);
+  expect(within(navigation).getAllByRole("region").length).toEqual(3);
 
   expect(
     within(navigation).getByRole("region", {
@@ -81,7 +81,7 @@ test("GIVEN Navigation WHEN no lsm THEN lsm is not shown", () => {
 
   const navigation = screen.getByRole("navigation", { name: "Global" });
   expect(navigation).toBeVisible();
-  expect(within(navigation).getAllByRole("region").length).toEqual(3);
+  expect(within(navigation).getAllByRole("region").length).toEqual(2);
 
   expect(
     within(navigation).queryByRole("region", {

--- a/src/UI/Root/Components/Sidebar/Navigation/Navigation.test.tsx
+++ b/src/UI/Root/Components/Sidebar/Navigation/Navigation.test.tsx
@@ -73,12 +73,6 @@ test("GIVEN Navigation WHEN lsm enabled THEN shows all navigation items", () => 
       name: "Resource Manager",
     })
   ).toBeVisible();
-
-  expect(
-    within(navigation).getByRole("region", {
-      name: "Other Sites",
-    })
-  ).toBeVisible();
 });
 
 test("GIVEN Navigation WHEN no lsm THEN lsm is not shown", () => {

--- a/src/UI/Root/Components/Sidebar/Navigation/Navigation.tsx
+++ b/src/UI/Root/Components/Sidebar/Navigation/Navigation.tsx
@@ -4,7 +4,6 @@ import { DependencyContext } from "@/UI/Dependency";
 import {
   lifecycleServiceManager,
   orchestrationEngine,
-  otherSites,
   resourceManager,
 } from "./Group";
 import { NavigationItem } from "./NavigationItem";
@@ -12,8 +11,7 @@ import { NavigationItem } from "./NavigationItem";
 export const Navigation: React.FC<{ environment: string | undefined }> = ({
   environment,
 }) => {
-  const { featureManager, routeManager, urlManager } =
-    useContext(DependencyContext);
+  const { featureManager, routeManager } = useContext(DependencyContext);
   const isEnvPresent = typeof environment !== "undefined";
   const groups = [
     ...(featureManager.isLsmEnabled()
@@ -21,10 +19,6 @@ export const Navigation: React.FC<{ environment: string | undefined }> = ({
       : []),
     orchestrationEngine(routeManager, isEnvPresent),
     resourceManager(routeManager, isEnvPresent),
-    otherSites(
-      environment ? urlManager.getDashboardUrl(environment) : "",
-      isEnvPresent
-    ),
   ];
 
   return (


### PR DESCRIPTION
# Description

The link to the dashboard has been removed from the sidebar.

closes *#4108*

<img width="221" alt="image" src="https://user-images.githubusercontent.com/44098050/200819942-d3da22b4-084e-4c8f-a98f-e7d6adac70c6.png">

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Code is clear and sufficiently documented
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
