### PR TITLE
Build(deps): Bump keycloak-js from 20.0.0 to 20.0.1 (#4308)

### DIFF
--- a/changelogs/unreleased/4308-dependabot.yml
+++ b/changelogs/unreleased/4308-dependabot.yml
@@ -1,0 +1,6 @@
+change-type: patch
+description: 'Build(deps): Bump keycloak-js from 20.0.0 to 20.0.1'
+destination-branches:
+- master
+- iso5
+sections: {}

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "history": "5.3.0",
     "json-bigint": "^1.0.0",
     "jszip": "^3.10.1",
-    "keycloak-js": "^20.0.0",
+    "keycloak-js": "^20.0.1",
     "lint": "^0.7.0",
     "lodash": "^4.17.21",
     "lodash-es": "^4.17.21",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6768,10 +6768,10 @@ junk@^3.1.0:
   resolved "https://registry.yarnpkg.com/junk/-/junk-3.1.0.tgz#31499098d902b7e98c5d9b9c80f43457a88abfa1"
   integrity sha512-pBxcB3LFc8QVgdggvZWyeys+hnrNWg4OcZIU/1X59k5jQdLBlCsYGRQaz234SqoRLTCgMH00fY0xRJH+F9METQ==
 
-keycloak-js@^20.0.0:
-  version "20.0.0"
-  resolved "https://registry.yarnpkg.com/keycloak-js/-/keycloak-js-20.0.0.tgz#5026c0fdf4b01119e9259b70a289d0300d9615ec"
-  integrity sha512-nd84PGuZZaU32iTvNYkHyw8UvmO6b6k9hCu/7kftwSaYTmOytQG9eK3DyL6idHmZQFHwz8QhJnqzEJYUtgmDIQ==
+keycloak-js@^20.0.1:
+  version "20.0.1"
+  resolved "https://registry.yarnpkg.com/keycloak-js/-/keycloak-js-20.0.1.tgz#3f73499a6b071d096f82ab74257b1b7429f53c8c"
+  integrity sha512-YNj0X0mmdLpqjB9W5DTAVDI14CzZs7RFn9T/t/g8Uq80OjaW2zZUis/g73aWwz04S3B6U6Vrg8h1wAMGbx2NQQ==
   dependencies:
     base64-js "^1.5.1"
     js-sha256 "^0.9.0"


### PR DESCRIPTION
Pull request opened by the merge tool on behalf of #4308