### PR TITLE
Build(deps-dev): Bump mini-css-extract-plugin from 2.6.1 to 2.7.0 (#4356)

### DIFF
--- a/changelogs/unreleased/4356-dependabot.yml
+++ b/changelogs/unreleased/4356-dependabot.yml
@@ -1,0 +1,6 @@
+change-type: patch
+description: 'Build(deps-dev): Bump mini-css-extract-plugin from 2.6.1 to 2.7.0'
+destination-branches:
+- master
+- iso5
+sections: {}

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "jest-junit": "^14.0.1",
     "lint-staged": "^13.0.3",
     "madge": "^5.0.1",
-    "mini-css-extract-plugin": "^2.6.1",
+    "mini-css-extract-plugin": "^2.7.0",
     "mocha": "^10.1.0",
     "mocha-junit-reporter": "^2.1.1",
     "mochawesome": "^7.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7232,10 +7232,10 @@ min-indent@^1.0.0:
   resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
   integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
 
-mini-css-extract-plugin@^2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/mini-css-extract-plugin/-/mini-css-extract-plugin-2.6.1.tgz#9a1251d15f2035c342d99a468ab9da7a0451b71e"
-  integrity sha512-wd+SD57/K6DiV7jIR34P+s3uckTRuQvx0tKPcvjFlrEylk6P4mQ2KSWk1hblj1Kxaqok7LogKOieygXqBczNlg==
+mini-css-extract-plugin@^2.7.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/mini-css-extract-plugin/-/mini-css-extract-plugin-2.7.0.tgz#d7d9ba0c5b596d155e36e2b174082fc7f010dd64"
+  integrity sha512-auqtVo8KhTScMsba7MbijqZTfibbXiBNlPAQbsVt7enQfcDYLdgG57eGxMqwVU3mfeWANY4F1wUg+rMF+ycZgw==
   dependencies:
     schema-utils "^4.0.0"
 


### PR DESCRIPTION
Pull request opened by the merge tool on behalf of #4356