### PR TITLE
fix z-index issue on compliance page and compare page

### DIFF
--- a/changelogs/unreleased/4338-dropdown-z-index-issue.yml
+++ b/changelogs/unreleased/4338-dropdown-z-index-issue.yml
@@ -1,0 +1,8 @@
+change-type: patch
+description: 'Fix filter options being displayed under the DIFF comparator on some pages.'
+issue-nr: 4338
+destination-branches:
+- master
+- iso5
+sections: 
+  minor-improvement: "{{description}}"

--- a/src/Slices/ComplianceCheck/UI/Page.tsx
+++ b/src/Slices/ComplianceCheck/UI/Page.tsx
@@ -86,7 +86,7 @@ export const View: React.FC<Props> = ({ version }) => {
         <PageTitle>{words("desiredState.complianceCheck.title")}</PageTitle>
       </StyledPageSection>
       <PageSection variant="light">
-        <Toolbar>
+        <ToolBarContainer>
           <ToolbarContent style={{ padding: 0 }}>
             <SelectReportAction
               setSelectedReport={setSelectedReport}
@@ -99,7 +99,7 @@ export const View: React.FC<Props> = ({ version }) => {
             />
             <TriggerDryRunAction version={version} updateList={updateList} />
           </ToolbarContent>
-        </Toolbar>
+        </ToolBarContainer>
       </PageSection>
       <DiffPageSection
         report={selectedReport}
@@ -112,4 +112,8 @@ export const View: React.FC<Props> = ({ version }) => {
 
 const StyledPageSection = styled(PageSection)`
   padding-bottom: 0;
+`;
+
+const ToolBarContainer = styled(Toolbar)`
+  z-index: var(--pf-global--ZIndex--xl);
 `;

--- a/src/Slices/DesiredStateCompare/UI/Page.tsx
+++ b/src/Slices/DesiredStateCompare/UI/Page.tsx
@@ -41,14 +41,14 @@ export const View: React.FC<Diff.Identifiers> = ({ from, to }) => {
         <PageTitle>{words("desiredState.compare.title")}</PageTitle>
       </StyledPageSection>
       <PageSection variant="light">
-        <Toolbar>
+        <ToolBarContainer>
           <ToolbarContent style={{ padding: 0 }}>
             <DiffWizard.StatusFilter
               statuses={statuses}
               setStatuses={setStatuses}
             />
           </ToolbarContent>
-        </Toolbar>
+        </ToolBarContainer>
       </PageSection>
       <PageSection variant="light" hasShadowBottom sticky="top">
         <DiffWizard.Controls
@@ -82,4 +82,8 @@ export const View: React.FC<Diff.Identifiers> = ({ from, to }) => {
 
 const StyledPageSection = styled(PageSection)`
   padding-bottom: 0;
+`;
+
+const ToolBarContainer = styled(Toolbar)`
+  z-index: var(--pf-global--ZIndex--xl);
 `;


### PR DESCRIPTION
# Description

The filtering dropdown used to slip under the DIFF widget. Used the patternfly variables to resolve the issue

closes *#4338*

<img width="730" alt="image" src="https://user-images.githubusercontent.com/44098050/204216276-1bf34b82-515d-455b-8802-0a6a089aade0.png">
<img width="641" alt="image" src="https://user-images.githubusercontent.com/44098050/204216293-2455d721-3190-4a2a-a807-472bc5bdf4dd.png">


# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Code is clear and sufficiently documented
- [x] Correct, in line with design

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
