### PR TITLE
fix odd alignment for filters in general

### DIFF
--- a/changelogs/unreleased/4339-odd-alignment-filter.yml
+++ b/changelogs/unreleased/4339-odd-alignment-filter.yml
@@ -1,0 +1,8 @@
+description: Improve alignment of filter options on smaller screens.
+change-type: patch
+issue-nr: 4339
+destination-branches: 
+ - master
+ - iso5
+sections: 
+  minor-improvement: "{{description}}"

--- a/src/UI/Components/Filters/TimestampFilter.tsx
+++ b/src/UI/Components/Filters/TimestampFilter.tsx
@@ -80,7 +80,10 @@ export const TimestampFilter: React.FC<Props> = ({
   };
 
   return (
-    <Flex>
+    <Flex
+      style={{ gap: "var(--pf-global--spacer--md)" }}
+      flexWrap={{ lg: "nowrap" }}
+    >
       {isVisible && (
         <>
           <FlexItem>

--- a/src/UI/Styles/Global.ts
+++ b/src/UI/Styles/Global.ts
@@ -38,4 +38,21 @@ export const GlobalStyles = createGlobalStyle`
   .pf-c-calendar-month__header-year {
     width: 9ch;
   }
+  .pf-c-toolbar__content-section {
+    gap: var(--pf-global--spacer--sm);
+    align-items: flex-start;
+  }
+  .pf-c-select {
+    min-width: 180px;
+  }
+  .pf-c-toolbar__item .pf-c-input-group {
+    height: auto !important;
+  }
+  @media (max-width: 1000px) {
+    *[aria-label="FilterBar"] {
+      gap: var(--pf-global--spacer--md);
+      flex-wrap: wrap;
+    }
+  }
+
 `;


### PR DESCRIPTION
# Description

Tried to find an approach to resolve the issue for all the filters, not only the ones on the Desired state page.  I would have personally removed the vertical spacers, but this is advised by the Patternfly guidelines when having multiple types of actions in your toolbar. This means that when the Compile button jumps on the second line, it won't be nicely aligned with the content above in some cases. 

![filter-alignment-improvement](https://user-images.githubusercontent.com/44098050/204239063-c106fb73-f769-4997-8f44-a315c521f9a2.gif)

closes *#4339*

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Code is clear and sufficiently documented
- [x] Correct, in line with design

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
