### PR TITLE
Build(deps-dev): Bump regenerator-runtime from 0.13.10 to 0.13.11 (#4396)

### DIFF
--- a/changelogs/unreleased/4396-dependabot.yml
+++ b/changelogs/unreleased/4396-dependabot.yml
@@ -1,0 +1,7 @@
+change-type: patch
+description: 'Build(deps-dev): Bump regenerator-runtime from 0.13.10 to 0.13.11'
+destination-branches:
+- master
+- iso6
+- iso5
+sections: {}

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "prettier": "^2.7.1",
     "raw-loader": "^4.0.2",
     "react-svg-loader": "^3.0.3",
-    "regenerator-runtime": "^0.13.10",
+    "regenerator-runtime": "^0.13.11",
     "rimraf": "^3.0.0",
     "start-server-and-test": "^1.14.0",
     "style-loader": "^3.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8873,10 +8873,10 @@ refractor@^3.6.0:
     parse-entities "^2.0.0"
     prismjs "~1.27.0"
 
-regenerator-runtime@^0.13.10, regenerator-runtime@^0.13.4:
-  version "0.13.10"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.10.tgz#ed07b19616bcbec5da6274ebc75ae95634bfc2ee"
-  integrity sha512-KepLsg4dU12hryUO7bp/axHAKvwGOCV0sGloQtpagJ12ai+ojVDqkeGSiRX1zlq+kjIMZ1t7gpze+26QqtdGqw==
+regenerator-runtime@^0.13.10, regenerator-runtime@^0.13.11, regenerator-runtime@^0.13.4:
+  version "0.13.11"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
+  integrity sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==
 
 regexp.prototype.flags@^1.4.1, regexp.prototype.flags@^1.4.3:
   version "1.4.3"


### PR DESCRIPTION
Pull request opened by the merge tool on behalf of #4396