### PR TITLE
Migrate cleanup script for old npm packages from graphql to rest

### DIFF
--- a/changelogs/unreleased/fix-npm-cleanup-script.yml
+++ b/changelogs/unreleased/fix-npm-cleanup-script.yml
@@ -1,0 +1,4 @@
+---
+description: Migrate the script that cleans up old npm packages from the graphql API to the rest API of Github. The graphql API is deprecated for packages (See: https://github.blog/changelog/2022-08-18-deprecation-notice-graphql-for-packages/).
+change-type: patch
+destination-branches: [master, iso6, iso5, iso4]

--- a/changelogs/unreleased/fix-npm-cleanup-script.yml
+++ b/changelogs/unreleased/fix-npm-cleanup-script.yml
@@ -1,4 +1,4 @@
 ---
-description: Migrate the script that cleans up old npm packages from the graphql API to the rest API of Github. The graphql API is deprecated for packages (See: https://github.blog/changelog/2022-08-18-deprecation-notice-graphql-for-packages/).
+description: "Migrate the script that cleans up old npm packages from the graphql API to the rest API of Github. The graphql API is deprecated for packages (See: https://github.blog/changelog/2022-08-18-deprecation-notice-graphql-for-packages/)."
 change-type: patch
 destination-branches: [master, iso6, iso5, iso4]

--- a/clean_up_packages.js
+++ b/clean_up_packages.js
@@ -1,75 +1,100 @@
-// Get a list of packageVersionIds
-async function getDevVersions() {
-  const getQueryString = (cursor) =>
-    `{repository(owner:"inmanta",name:"web-console"){packages(first:1, names:"web-console"){nodes{packageType,name,id,versions(last:50, ${cursor} orderBy:{field:CREATED_AT, direction:DESC}){nodes{id,version,preRelease,files(first:1){nodes{name, updatedAt}}}, pageInfo{hasNextPage, hasPreviousPage,startCursor}}}}}}`;
-  let queryString = getQueryString("");
-  let moreRows = true;
-  while (moreRows) {
+function getLinkToNextPage(headerObj) {
+  /**
+   *  Takes the Header object and returns the URL to the next page or null if no such page exists.
+   *
+   *  Format of link_header: '<URL>; rel="next", <URL>; rel="last"' where URL is a URL to a certain page.
+   */
+  if (!headerObj.has("link")) {
+    return null;
+  }
+  const linkHeader = headerObj.get("link");
+  const splittedLinkHeader = linkHeader.trim().split(",");
+  for (let i = 0; i < splittedLinkHeader.length; i++) {
+    const splittedHeaderParts = splittedLinkHeader[i].trim().split(";");
+    const refName = splittedHeaderParts[1].trim();
+    const refLink = splittedHeaderParts[0].trim();
+    if (refName === 'rel="next"') {
+      // The link is represented as '<url>'. This shops off the '<' and '>' characters.
+      return refLink.slice(1, refLink.length - 1);
+    }
+  }
+  return null;
+}
+
+async function getOldDevVersions() {
+  /**
+   *  Return a list of development packages that is older than 30 days.
+   *  The list of packages return by this method is not necessarily complete.
+   *  This is intentional, because we don't want to execute too many requests at once.
+   */
+  let queryUrl =
+    "https://api.github.com/orgs/inmanta/packages/npm/web-console/versions?per_page=100";
+  let result = [];
+  while (true) {
+    // This API endpoint sorts the packages from new to old.
     const queryResults = await fetch(
-      "https://api.github.com/graphql",
+      queryUrl,
       {
-        headers: { Authorization: `bearer ${process.env.GITHUB_TOKEN}` },
-        method: "POST",
-        body: JSON.stringify({
-          query: queryString,
-        }),
+        headers: {
+          Authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
+          Accept: "application/vnd.github+json",
+          "X-GitHub-Api-Version": "2022-11-28",
+        },
+        method: "GET",
       },
       (error) => console.log(error)
-    ).then((result) => {
-      return result.json();
-    });
-    // Make sure we're working with the web-console
-    const webConsole = queryResults.data.repository.packages.nodes.find(
-      (pkg) => pkg.name === "web-console"
     );
+    let packages = await queryResults.json();
+    let response_headers = queryResults.headers;
 
-    if (!webConsole) {
+    if (packages.length === 0) {
       throw Error("Unable to find web-console packages");
     }
 
     // Take the dev versions only
-    const devVersions = webConsole.versions.nodes.filter((packageVersion) =>
-      packageVersion.version.includes("dev")
+    let devVersions = packages.filter((pkg) => pkg.name.includes("dev"));
+    let devVersionsWithDate = devVersions.map((devPackageVersion) => {
+      return {
+        id: devPackageVersion.id,
+        version: devPackageVersion.name,
+        updatedAt: devPackageVersion.updated_at,
+      };
+    });
+    // Take the versions that are older than 30 days
+    let oldDevVersions = devVersionsWithDate.filter(
+      (devPackageVersion) =>
+        Math.floor(
+          (new Date() - new Date(devPackageVersion.updatedAt)) /
+            (1000 * 60 * 60 * 24)
+        ) > 30
     );
 
+    if (result.length > 0 && oldDevVersions.length === 0) {
+      // We probably cleaned up until here during the previous run of this script.
+      // Don't go further back in history to limit the amount of requests.
+      return result;
+    }
+    result = result.concat(oldDevVersions);
+    if (result.length > 5) {
+      // Return as soon as we have at least five packages to not execute too many requests at once.
+      return result;
+    }
+
     // Check to see if another page should be queried
-    if (
-      devVersions.length == 0 &&
-      webConsole.versions.pageInfo.hasPreviousPage &&
-      webConsole.versions.pageInfo.startCursor
-    ) {
-      queryString = getQueryString(
-        `before: "${webConsole.versions.pageInfo.startCursor}",`
-      );
-      console.log(
-        `No dev versions found on this page of the results, fetching the previous page from ${webConsole.versions.pageInfo.startCursor}`
-      );
+    let linkToNextPage = getLinkToNextPage(response_headers);
+    if (linkToNextPage != null) {
+      queryUrl = linkToNextPage;
+      console.log(`Fetching the next page from ${queryUrl}`);
     } else {
-      console.log("Dev versions found, no need to query more pages");
-      moreRows = false;
-      return devVersions;
+      if (result.length === 0) {
+        console.log("No dev version exist");
+      }
+      return result;
     }
   }
 }
 
-getDevVersions().then((devVersions) => {
-  const devVersionsWithDate = devVersions
-    .map((devPackageVersion) => {
-      return {
-        id: devPackageVersion.id,
-        version: devPackageVersion.version,
-        updatedAt: devPackageVersion.files.nodes[0].updatedAt,
-      };
-    })
-    .reverse();
-  // Take the versions that are older than 30 days
-  let oldDevVersions = devVersionsWithDate.filter(
-    (devPackageVersion) =>
-      Math.floor(
-        (new Date() - new Date(devPackageVersion.updatedAt)) /
-          (1000 * 60 * 60 * 24)
-      ) > 30
-  );
+getOldDevVersions().then((oldDevVersions) => {
   if (oldDevVersions.length == 0) {
     console.log("No old versions found matching the criteria");
     return;
@@ -83,27 +108,29 @@ getDevVersions().then((devVersions) => {
     console.log(
       `Attempting to delete version ${oldDevVersion.version} with id ${idToDelete} from ${oldDevVersion.updatedAt}`
     );
-    fetch("https://api.github.com/graphql", {
-      headers: {
-        Authorization: `bearer ${process.env.GITHUB_TOKEN}`,
-        Accept: "application/vnd.github.package-deletes-preview+json",
-      },
-      method: "POST",
-      body: JSON.stringify({
-        query: `mutation { deletePackageVersion(input:{packageVersionId:"${idToDelete}"}) { success }}`,
-      }),
-    })
-      .then((result) => result.json())
-      .then((result) => {
-        if (result.errors && result.errors.length > 0) {
-          console.log(`Deleting package ${idToDelete} failed:`, result.errors);
-          throw Error(
-            `Deleting version ${oldDevVersion.id} failed:`,
-            JSON.stringify(result.errors)
-          );
-        } else {
+    fetch(
+      `https://api.github.com/orgs/inmanta/packages/npm/web-console/versions/${idToDelete}`,
+      {
+        headers: {
+          Authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
+          Accept: "application/vnd.github+json",
+          "X-GitHub-Api-Version": "2022-11-28",
+        },
+        method: "DELETE",
+      }
+    ).then(
+      (response) => {
+        if (response.ok) {
           console.log(`Successfully deleted package ${idToDelete}`);
+        } else {
+          const error_message = `Deleting package ${idToDelete} failed: ${response.statusText}`;
+          console.log(error_message);
+          throw Error(error_message);
         }
-      });
+      },
+      (reason) => {
+        console.log(reason);
+      }
+    );
   });
 });

--- a/clean_up_packages.js
+++ b/clean_up_packages.js
@@ -14,7 +14,7 @@ function getLinkToNextPage(headerObj) {
     const refName = splittedHeaderParts[1].trim();
     const refLink = splittedHeaderParts[0].trim();
     if (refName === 'rel="next"') {
-      // The link is represented as '<url>'. This shops off the '<' and '>' characters.
+      // The link is represented as '<url>'. This chops off the '<' and '>' characters.
       return refLink.slice(1, refLink.length - 1);
     }
   }


### PR DESCRIPTION
# Description

Migrate the script that cleans up old npm packages from the graphql API to the rest API of Github. The graphql API is deprecated for packages (See: https://github.blog/changelog/2022-08-18-deprecation-notice-graphql-for-packages/).

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Code is clear and sufficiently documented
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~