### PR TITLE
Build(deps): Bump @patternfly/react-charts from 6.94.12 to 6.94.15 (#4488)

### DIFF
--- a/changelogs/unreleased/4488-dependabot.yml
+++ b/changelogs/unreleased/4488-dependabot.yml
@@ -1,0 +1,7 @@
+change-type: patch
+description: 'Build(deps): Bump @patternfly/react-charts from 6.94.12 to 6.94.15'
+destination-branches:
+- master
+- iso6
+- iso5
+sections: {}

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "webpack-version-file": "^0.1.7"
   },
   "dependencies": {
-    "@patternfly/react-charts": "^6.94.12",
+    "@patternfly/react-charts": "^6.94.15",
     "@patternfly/react-core": "^4.267.6",
     "@patternfly/react-icons": "^4.92.10",
     "@patternfly/react-styles": "^4.92.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -969,13 +969,13 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@patternfly/react-charts@^6.94.12":
-  version "6.94.12"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-charts/-/react-charts-6.94.12.tgz#c687a603ed73e4f27372a8cdc9bf4563ea3d1320"
-  integrity sha512-jVVDbdi6VADukS0XGGuvvH8CZzVp8E/8bA9RPFA3oqNrWR64hhXiQvnvlZ3t1D4BwKWwstC+a02qZzMVHhPY2w==
+"@patternfly/react-charts@^6.94.15":
+  version "6.94.15"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-charts/-/react-charts-6.94.15.tgz#23c32633612c72150d955c0874914e8d211554aa"
+  integrity sha512-wtuZQIR1b9eVPkho1uDrKxIAXOtMiW6XYweosaHyjzg0LQkSzd4vBisvn/QW8BSnyla0g/HztSFnxC5hckwNyQ==
   dependencies:
-    "@patternfly/react-styles" "^4.92.0"
-    "@patternfly/react-tokens" "^4.94.0"
+    "@patternfly/react-styles" "^4.92.3"
+    "@patternfly/react-tokens" "^4.94.3"
     hoist-non-react-statics "^3.3.0"
     lodash "^4.17.19"
     tslib "^2.0.0"
@@ -1019,7 +1019,7 @@
   resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-4.93.3.tgz#ba617b1daefce81ba903bc702ff66060413e2a9f"
   integrity sha512-OIEeTc4Noi9XOIRF3OB3sz9dRnxr1h4eNIzIeZwRd8xXWCQxYcrllxPV98F3+RpL4ZCH2QWb/2gG4mHrVyX+0A==
 
-"@patternfly/react-styles@^4.92.0", "@patternfly/react-styles@^4.92.3":
+"@patternfly/react-styles@^4.92.3":
   version "4.92.3"
   resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-4.92.3.tgz#046acee6e38c996cf41c288819eca17c3634a782"
   integrity sha512-jC8F71trFWVYM7YVTP/3MBLwLZDCY3tgHeAmSKdcw6R607LK4rtCzfw5lt2IHNmAjQ0ggqDlJGWsJAfGMe4iPA==
@@ -1036,12 +1036,7 @@
     lodash "^4.17.19"
     tslib "^2.0.0"
 
-"@patternfly/react-tokens@^4.93.10", "@patternfly/react-tokens@^4.94.0":
-  version "4.94.0"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-4.94.0.tgz#d605487667c544a71ab3495a19e3ad2777191943"
-  integrity sha512-fYXxUJZnzpn89K2zzHF0cSncZZVGKrohdb5f5T1wzxwU2NZPVGpvr88xhm+V2Y/fSrrTPwXcP3IIdtNOOtJdZw==
-
-"@patternfly/react-tokens@^4.94.3":
+"@patternfly/react-tokens@^4.93.10", "@patternfly/react-tokens@^4.94.3":
   version "4.94.3"
   resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-4.94.3.tgz#efc7e61ed94299423443db7416a6a52d8b56d8c6"
   integrity sha512-Rq8RMJ/iu/nTDidEb/xQWUMXFW+W4MuoLBonTAFv/Bx8G3gFMHU2JGtv9R5SvAYU6Eux9EkjCG7h3xiLqwH3jg==


### PR DESCRIPTION
Pull request opened by the merge tool on behalf of #4488