### PR TITLE
Feature/4321 add tooltip halt resume buttons

### DIFF
--- a/changelogs/unreleased/4341-add-tooltips.yml
+++ b/changelogs/unreleased/4341-add-tooltips.yml
@@ -1,0 +1,9 @@
+change-type: patch
+description: 'Adding Tooltips for halted and resume buttons in the sidebar.'
+issue-nr: 4341
+destination-branches:
+- master
+- iso6
+- iso5
+sections: 
+  minor-improvement: "{{description}}"

--- a/src/UI/Root/Components/Sidebar/EnvironmentControls/HaltDialog.tsx
+++ b/src/UI/Root/Components/Sidebar/EnvironmentControls/HaltDialog.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useState } from "react";
-import { Button, Modal } from "@patternfly/react-core";
+import { Button, Modal, Tooltip } from "@patternfly/react-core";
 import { StopIcon } from "@patternfly/react-icons";
 import { DependencyContext } from "@/UI/Dependency";
 import { words } from "@/UI/words";
@@ -15,9 +15,15 @@ export const HaltDialog: React.FC = () => {
     });
   return (
     <>
-      <Button variant="danger" icon={<StopIcon />} onClick={handleModalToggle}>
-        {words("environment.halt.button")}
-      </Button>
+      <Tooltip content={<div>{words("environment.halt.button.tooltip")}</div>}>
+        <Button
+          variant="danger"
+          icon={<StopIcon />}
+          onClick={handleModalToggle}
+        >
+          {words("environment.halt.button")}
+        </Button>
+      </Tooltip>
       <Modal
         variant="small"
         title={words("environment.halt.title")}

--- a/src/UI/Root/Components/Sidebar/EnvironmentControls/ResumeDialog.tsx
+++ b/src/UI/Root/Components/Sidebar/EnvironmentControls/ResumeDialog.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useState } from "react";
-import { Button, Modal } from "@patternfly/react-core";
+import { Button, Modal, Tooltip } from "@patternfly/react-core";
 import { PlayIcon } from "@patternfly/react-icons";
 import styled from "styled-components";
 import { DependencyContext } from "@/UI/Dependency";
@@ -16,9 +16,11 @@ export const ResumeDialog: React.FC = () => {
     });
   return (
     <>
-      <GreenButton icon={<PlayIcon />} onClick={handleModalToggle}>
-        {words("environment.resume.button")}
-      </GreenButton>
+      <Tooltip content={<div>{words("environment.resume.tooltip")}</div>}>
+        <GreenButton icon={<PlayIcon />} onClick={handleModalToggle}>
+          {words("environment.resume.button")}
+        </GreenButton>
+      </Tooltip>
       <Modal
         variant="small"
         title={words("environment.resume.title")}

--- a/src/UI/words.tsx
+++ b/src/UI/words.tsx
@@ -258,6 +258,10 @@ const dict = {
    */
   "environment.resume.button": "Resume",
   "environment.halt.button": "STOP",
+  "environment.resume.tooltip":
+    "Resume all halted operations in the current environment",
+  "environment.halt.button.tooltip":
+    "Emergency stop to halt all operations in the current environment",
   "environment.halt.title": "Halt environment",
   "environment.halt.details":
     "Are you sure you want to initiate an emergency stop and halt all operations in the current environment?",


### PR DESCRIPTION
# Description

Adding the tooltips to the buttons in the sidebar. 

closes *#4341*

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Changelog entry
- [x] Code is clear and sufficiently documented
