### PR TITLE
fix collapsing logs

### DIFF
--- a/changelogs/unreleased/4480-resource-logs-fix.yml
+++ b/changelogs/unreleased/4480-resource-logs-fix.yml
@@ -1,0 +1,9 @@
+description: Fix resource logs issue
+issue-nr: 4480
+change-type: patch
+destination-branches:
+  - master
+  - iso5
+  - iso6
+sections: 
+  bugfix: "{{description}}"

--- a/src/Slices/ResourceDetails/UI/Tabs/LogTab/ResourceLogsTable.tsx
+++ b/src/Slices/ResourceDetails/UI/Tabs/LogTab/ResourceLogsTable.tsx
@@ -58,9 +58,9 @@ export const ResourceLogsTable: React.FC<Props> = ({
       {logs.map((log, index) => (
         <Row
           index={index}
-          onToggle={onExpansion(getUniqueId(log, index))}
-          isExpanded={isExpanded(getUniqueId(log, index))}
-          key={getUniqueId(log, index)}
+          onToggle={onExpansion(getUniqueId(log))}
+          isExpanded={isExpanded(getUniqueId(log))}
+          key={getUniqueId(log)}
           log={log}
           numberOfColumns={6}
           toggleActionType={toggleActionType}
@@ -70,8 +70,8 @@ export const ResourceLogsTable: React.FC<Props> = ({
   );
 };
 
-function getUniqueId(log: ResourceLog, index: number): string {
-  return `${log.action_id}_${log.timestamp}_${index}`;
+function getUniqueId(log: ResourceLog): string {
+  return `${log.action_id}_${log.timestamp}`;
 }
 
 const LogLevelTh = styled(Th)`


### PR DESCRIPTION
# Description

Had to delete index parameter because with every update that given index doesn't corresponds to deleted value, now logs stays open after refresh.
closes #4480 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Code is clear and sufficiently documented
~~- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)~~
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
