### PR TITLE
Build(deps): Bump @patternfly/react-icons from 4.93.0 to 4.93.3 (#4585)

### DIFF
--- a/changelogs/unreleased/4585-dependabot.yml
+++ b/changelogs/unreleased/4585-dependabot.yml
@@ -1,0 +1,6 @@
+change-type: patch
+description: 'Build(deps): Bump @patternfly/react-icons from 4.93.0 to 4.93.3'
+destination-branches:
+- master
+- iso6
+sections: {}

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
   "dependencies": {
     "@patternfly/react-charts": "^6.94.15",
     "@patternfly/react-core": "^4.267.6",
-    "@patternfly/react-icons": "^4.92.10",
+    "@patternfly/react-icons": "^4.93.3",
     "@patternfly/react-styles": "^4.92.3",
     "@patternfly/react-table": "^4.112.6",
     "@patternfly/react-tokens": "^4.93.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1007,11 +1007,6 @@
     tippy.js "5.1.2"
     tslib "^2.0.0"
 
-"@patternfly/react-icons@^4.92.10":
-  version "4.93.0"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-4.93.0.tgz#523034461307711e40cb92975a3a7360e8a184db"
-  integrity sha512-OH0vORVioL+HLWMEog8/3u8jsiMCeJ0pFpvRKRhy5Uk4CdAe40k1SOBvXJP6opr+O8TLbz0q3bm8Jsh/bPaCuQ==
-
 "@patternfly/react-icons@^4.93.3":
   version "4.93.3"
   resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-4.93.3.tgz#ba617b1daefce81ba903bc702ff66060413e2a9f"


### PR DESCRIPTION
Pull request opened by the merge tool on behalf of #4585