### PR TITLE
Build(deps): Bump @patternfly/react-tokens from 4.94.3 to 4.94.6 (#4628)

### DIFF
--- a/changelogs/unreleased/4628-dependabot.yml
+++ b/changelogs/unreleased/4628-dependabot.yml
@@ -1,0 +1,6 @@
+change-type: patch
+description: 'Build(deps): Bump @patternfly/react-tokens from 4.94.3 to 4.94.6'
+destination-branches:
+- master
+- iso6
+sections: {}

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "@patternfly/react-icons": "^4.93.3",
     "@patternfly/react-styles": "^4.92.3",
     "@patternfly/react-table": "^4.112.6",
-    "@patternfly/react-tokens": "^4.93.10",
+    "@patternfly/react-tokens": "^4.94.6",
     "@react-keycloak/web": "^3.4.0",
     "copy-to-clipboard": "^3.3.3",
     "easy-peasy": "^5.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1051,10 +1051,10 @@
     lodash "^4.17.19"
     tslib "^2.0.0"
 
-"@patternfly/react-tokens@^4.93.10", "@patternfly/react-tokens@^4.94.3":
-  version "4.94.3"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-4.94.3.tgz#efc7e61ed94299423443db7416a6a52d8b56d8c6"
-  integrity sha512-Rq8RMJ/iu/nTDidEb/xQWUMXFW+W4MuoLBonTAFv/Bx8G3gFMHU2JGtv9R5SvAYU6Eux9EkjCG7h3xiLqwH3jg==
+"@patternfly/react-tokens@^4.94.3", "@patternfly/react-tokens@^4.94.6":
+  version "4.94.6"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-4.94.6.tgz#47c715721ad3dd315a523f352ba1a0de2b03f0bc"
+  integrity sha512-tm7C6nat+uKMr1hrapis7hS3rN9cr41tpcCKhx6cod6FLU8KwF2Yt5KUxakhIOCEcE/M/EhXhAw/qejp8w0r7Q==
 
 "@pkgr/utils@^2.3.1":
   version "2.3.1"


### PR DESCRIPTION
Pull request opened by the merge tool on behalf of #4628