### PR TITLE
new icons

### DIFF
--- a/changelogs/unreleased/4609-events-icons.yml
+++ b/changelogs/unreleased/4609-events-icons.yml
@@ -1,0 +1,8 @@
+change-type: patch
+description: 'Add new icons for new event types in Service Inventory'
+issue-nr: 4609
+destination-branches:
+- master
+- iso6
+sections: 
+  minor-improvement: "{{description}}"

--- a/cypress/e2e/scenario-3-service-details.cy.js
+++ b/cypress/e2e/scenario-3-service-details.cy.js
@@ -373,7 +373,7 @@ describe("Scenario 3 - Service Details", () => {
     // Expect to see all values except ALLOCATION_UPDATE to have text-decoration: line-through
     cy.get(".pf-c-description-list__description ul").should(($ul) => {
       const $list = $ul.find("li");
-      expect($list).to.have.length(8);
+      expect($list).to.have.length(10);
     });
 
     cy.get(".pf-c-description-list__description li")

--- a/src/Core/Domain/EventType.ts
+++ b/src/Core/Domain/EventType.ts
@@ -7,6 +7,8 @@ export enum EventType {
   RESOURCE_EVENT = "RESOURCE_EVENT",
   AUTO_TRANSITION = "AUTO_TRANSITION",
   ALLOCATION_UPDATE = "ALLOCATION_UPDATE",
+  FORCE_UPDATE = "FORCE_UPDATE",
+  FORCE_DELETE = "FORCE_DELETE",
 }
 
 export const EventTypesList = Object.values(EventType).sort();

--- a/src/UI/Components/EventIcon/EventIcon.tsx
+++ b/src/UI/Components/EventIcon/EventIcon.tsx
@@ -9,6 +9,8 @@ import {
   ResourcesAlmostFullIcon,
   RunningIcon,
   TrashIcon,
+  SyncAltIcon,
+  TrashAltIcon,
 } from "@patternfly/react-icons";
 import { EventType } from "@/Core";
 
@@ -41,5 +43,9 @@ function getIconFor(eventType: EventType): React.ReactElement {
       return <PencilAltIcon />;
     case EventType.ON_DELETE_TRANSITION:
       return <TrashIcon />;
+    case EventType.FORCE_UPDATE:
+      return <SyncAltIcon />;
+    case EventType.FORCE_DELETE:
+      return <TrashAltIcon />;
   }
 }


### PR DESCRIPTION
# Description

I decided to go with those icons, as there is no other that could indicate "force" keyword, as there is no exclamation mark in trash icons, or in these arrows ones.
![Screenshot 2023-02-15 at 12 36 49](https://user-images.githubusercontent.com/113331659/219017532-84173d9b-200d-4ece-b7a3-40baf5259004.png)


closes #4609 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Code is clear and sufficiently documented
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
~~- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~
