### PR TITLE
metrics axis fix

### DIFF
--- a/changelogs/unreleased/4626-metrics-axis-scale.yml
+++ b/changelogs/unreleased/4626-metrics-axis-scale.yml
@@ -1,0 +1,8 @@
+change-type: patch
+description: 'Fix incorrect Y-axis values on stacked charts on dashboard'
+issue-nr: 4626
+destination-branches:
+- master
+- iso6
+sections: 
+  bugfix: "{{description}}"

--- a/src/Slices/Dashboard/UI/helper.ts
+++ b/src/Slices/Dashboard/UI/helper.ts
@@ -54,14 +54,15 @@ export const formatMetricsToStacked = (
       data.map((object) => {
         let tempMax = 0;
         keys.forEach((key, index) => {
-          tempMax += object === null ? 0 : object[key];
-          tempCharState[index].data.push(object === null ? null : object[key]);
+          tempMax += object === null ? 0 : Math.round(object[key]);
+          tempCharState[index].data.push(
+            object === null ? null : Math.round(object[key])
+          );
         });
         if (max < tempMax) {
           max = tempMax;
         }
       });
-      tempCharState = tempCharState.map((metric) => formatValues(metric));
     }
   } else {
     tempCharState = [


### PR DESCRIPTION
# Description

max value for stacked charts wasn't affected by rounding ,that caused chart going out of the view

closes #4626 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Code is clear and sufficiently documented
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
~~- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~
