### PR TITLE
fix issue that missing setting and it's definition crash the app

### DIFF
--- a/changelogs/unreleased/4772-fix-env-settings-error.yml
+++ b/changelogs/unreleased/4772-fix-env-settings-error.yml
@@ -1,0 +1,8 @@
+change-type: patch
+description: 'fix the issue that crash the app when using missing environment setting and it's definition'
+issue-nr: 4772
+destination-branches:
+- master
+- iso6
+sections: 
+  bugfix: "{{description}}"

--- a/src/UI/Dependency/EnvironmentModifier.test.tsx
+++ b/src/UI/Dependency/EnvironmentModifier.test.tsx
@@ -3,8 +3,10 @@ import { render, screen } from "@testing-library/react";
 import { StoreProvider } from "easy-peasy";
 import { act } from "react-dom/test-utils";
 import { EnvironmentModifier, RemoteData } from "@/Core";
+import { DefinitionMap } from "@/Core/Domain/EnvironmentSettings";
 import { getStoreInstance } from "@/Data";
 import { EnvironmentDetails, EnvironmentSettings } from "@/Test";
+import ErrorBoundary from "../Utils/ErrorBoundary";
 import { EnvironmentModifierImpl } from "./EnvironmentModifier";
 
 const DummyComponent: React.FC<{
@@ -17,28 +19,32 @@ const DummyComponent: React.FC<{
   );
 };
 
-function setup() {
+function setup(definition: DefinitionMap) {
   const environmentId = "env";
   const store = getStoreInstance();
   store.dispatch.environment.setSettingsData({
     environment: environmentId,
     value: RemoteData.success({
       settings: {},
-      definition: EnvironmentSettings.definition,
+      definition,
     }),
   });
   const environmentModifier = EnvironmentModifierImpl();
   environmentModifier.setEnvironment(environmentId);
   const component = (
-    <StoreProvider store={store}>
-      <DummyComponent environmentModifier={environmentModifier} />
-    </StoreProvider>
+    <ErrorBoundary>
+      <StoreProvider store={store}>
+        <DummyComponent environmentModifier={environmentModifier} />
+      </StoreProvider>
+    </ErrorBoundary>
   );
   return { component, store, environmentId };
 }
 
 test("Given the environmentModifier When the server compile setting is requested Then returns the correct value", async () => {
-  const { component, store, environmentId } = setup();
+  const { component, store, environmentId } = setup(
+    EnvironmentSettings.definition
+  );
   // No setting is specified, and the default is true
   store.dispatch.environment.setEnvironmentDetailsById({
     id: environmentId,
@@ -77,5 +83,23 @@ test("Given the environmentModifier When the server compile setting is requested
   });
   expect(
     await screen.findByRole("generic", { name: "server-compile-enabled" })
+  ).toBeVisible();
+});
+
+test("Given the environmentModifier When the missing setting is requested Then returns false without crashing the component", async () => {
+  delete EnvironmentSettings.definition.server_compile;
+  const { component, store, environmentId } = setup(
+    EnvironmentSettings.definition
+  );
+  // No setting is specified, and the dafault is missing
+  store.dispatch.environment.setEnvironmentDetailsById({
+    id: environmentId,
+    value: RemoteData.success({ ...EnvironmentDetails.a, settings: {} }),
+  });
+
+  render(component);
+  //expect to see div as the value would be false insteand of error boundary page
+  expect(
+    await screen.findByRole("generic", { name: "server-compile-disabled" })
   ).toBeVisible();
 });

--- a/src/UI/Dependency/EnvironmentModifier.tsx
+++ b/src/UI/Dependency/EnvironmentModifier.tsx
@@ -60,7 +60,7 @@ export function EnvironmentModifierImpl(): EnvironmentModifier {
     ) {
       return Boolean(environmentDetails.settings[settingName]);
     } else {
-      return Boolean(environmentSettings.definition[settingName].default);
+      return Boolean(environmentSettings.definition[settingName]?.default);
     }
   }
 


### PR DESCRIPTION
# Description

useSetting implementation is based with approach that envSetting definition will be fallback source of information which wasn't the case for the expertMode issue reported by Sander

closes #4772 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Code is clear and sufficiently documented
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
