### PR TITLE
4534/stringified dict attribute support

### DIFF
--- a/changelogs/unreleased/4534-add-support-for-type-migration.yml
+++ b/changelogs/unreleased/4534-add-support-for-type-migration.yml
@@ -1,0 +1,8 @@
+change-type: patch
+description: 'Add support for Attribute-Type migration in the attribute table.'
+issue-nr: 4534
+destination-branches:
+- master
+- iso6
+sections: 
+  minor-improvement: "{{description}}"

--- a/src/UI/Components/TreeTable/Helpers/TreeTableHelper.ts
+++ b/src/UI/Components/TreeTable/Helpers/TreeTableHelper.ts
@@ -1,3 +1,4 @@
+import { Attributes } from "@/Core";
 import {
   Cell,
   TreeRow,
@@ -41,6 +42,7 @@ export abstract class BaseTreeTableHelper<A extends AttributeTree>
       this.attributeHelper.getPaths(this.attributes)
     );
   }
+
   createRows(
     expansionState: ExpansionState,
     setState: (state: ExpansionState) => void
@@ -66,7 +68,8 @@ export abstract class BaseTreeTableHelper<A extends AttributeTree>
       isExpandedByParent,
       isChildExpanded,
       createOnToggle,
-      this.extractValues
+      this.extractValues,
+      this.attributes as Attributes
     );
 
     const nodes = this.attributeHelper.getMultiAttributeNodes(this.attributes);

--- a/src/UI/Components/TreeTable/Inventory/AttributeHelper.ts
+++ b/src/UI/Components/TreeTable/Inventory/AttributeHelper.ts
@@ -23,6 +23,12 @@ export class InventoryAttributeHelper
     private readonly service?: ServiceModel
   ) {}
 
+  /**
+   * Will create an array containing the path keys of the attributes.
+   *
+   * @param {Attributes} attributes
+   * @returns
+   */
   public getPaths(attributes: Attributes): string[] {
     return Object.keys(
       this.getSingleAttributeNodes("", {
@@ -72,6 +78,7 @@ export class InventoryAttributeHelper
     const matchingEmbeddedEntity = service.embedded_entities.find(
       (entity) => entity.name === prefix[0]
     );
+
     if (matchingEmbeddedEntity)
       return this.findInServiceLike(
         matchingEmbeddedEntity,
@@ -83,6 +90,7 @@ export class InventoryAttributeHelper
     if (fromRelations) {
       return fromRelations;
     }
+
     return undefined;
   }
 
@@ -95,8 +103,10 @@ export class InventoryAttributeHelper
     const matchingRelation = service.inter_service_relations?.find(
       (relation) => relation.name === key
     );
+
     return matchingRelation;
   }
+
   private findAttributeType(
     service: ServiceModel | EmbeddedEntity | undefined,
     prefix: string[],
@@ -105,9 +115,11 @@ export class InventoryAttributeHelper
     if (service === undefined) {
       return undefined;
     }
+
     const matchingEmbeddedEntity = service.embedded_entities.find(
       (entity) => entity.name === prefix[0]
     );
+
     if (matchingEmbeddedEntity) {
       return this.findAttributeType(
         matchingEmbeddedEntity,
@@ -115,9 +127,11 @@ export class InventoryAttributeHelper
         key
       );
     }
+
     const adequateAttribute = service.attributes.find(
       (attribute) => attribute.name === key
     );
+
     return adequateAttribute?.type;
   }
 
@@ -125,9 +139,14 @@ export class InventoryAttributeHelper
     prefix: string,
     subject: unknown
   ): AttributeNodeDict {
-    if (!this.isNested(subject)) return {};
+    if (!this.isNested(subject)) {
+      return {};
+    }
+
     let keys: AttributeNodeDict = {};
+
     const primaryKeys = Object.keys(subject).sort();
+
     primaryKeys.forEach((key) => {
       const type = this.findAttributeType(
         this.service,
@@ -157,6 +176,7 @@ export class InventoryAttributeHelper
         };
       }
     });
+
     return keys;
   }
 
@@ -241,6 +261,15 @@ export class InventoryAttributeHelper
     );
   }
 }
+
+/**
+ * Performs a check on all nodes and returns true if they are all of the type Leaf.
+ *
+ * @param {TreeNode | undefined} candidateNode
+ * @param {TreeNode | undefined} activeNode
+ * @param {TreeNode | undefined} rollbackNode
+ * @returns {boolean}
+ */
 export function isMultiLeaf(
   candidateNode: TreeNode | undefined,
   activeNode: TreeNode | undefined,
@@ -249,40 +278,83 @@ export function isMultiLeaf(
   return isLeaf(candidateNode) && isLeaf(activeNode) && isLeaf(rollbackNode);
 }
 
+/**
+ * Returns the type of the Node if the kind is a Leaf.
+ * Otherwise it will return undefined.
+ *
+ * @param {TreeNode | undefined} node
+ * @returns {string | undefined}
+ */
 export function getType(node: TreeNode | undefined): string | undefined {
   if (typeof node === "undefined") return undefined;
   if (node.kind !== "Leaf") return undefined;
   return node.type;
 }
 
+/**
+ * Will return the value of the Node if the kind is a Leaf.
+ * Otherwise it will return undefined.
+ *
+ * @param {TreeNode | undefined} node
+ * @returns {unknown}
+ */
 export function getValue(node: TreeNode | undefined): unknown {
   if (typeof node === "undefined") return undefined;
   if (node.kind !== "Leaf") return undefined;
   return node.value;
 }
 
+/**
+ * Performs a check if the node is of the Leaf kind.
+ * When the typeof node is undefined it will by default deduce it's a Leaf.
+ *
+ * @param {TreeNode | undefined} node
+ * @returns {boolean}
+ */
 export function isLeaf(node: TreeNode | undefined): boolean {
   if (typeof node === "undefined") return true;
   return node.kind === "Leaf";
 }
 
+/**
+ * Performs a check if the node has relations.
+ * Returns undefined if not.
+ *
+ * @param {TreeNode | undefined} node
+ * @returns {boolean | undefined}
+ */
 function getHasRelation(node: TreeNode | undefined): boolean | undefined {
   if (typeof node === "undefined") return undefined;
   if (node.kind !== "Leaf") return undefined;
   return node.hasRelation;
 }
 
+/**
+ * Will return the name of the entity if the Node has one and is of kind Leaf.
+ * Otherwise, it will return undefined.
+ *
+ * @param {TreeNode | undefined} node
+ * @returns {string | undefined}
+ */
 function getEntity(node: TreeNode | undefined): string | undefined {
   if (typeof node === "undefined") return undefined;
   if (node.kind !== "Leaf") return undefined;
   return node.entity;
 }
 
+/**
+ * Returns the name of the entity if there is one.
+ * It's expected to be used in combination with the getEntity method.
+ *
+ * @param {(string | undefined)[] } entities
+ * @returns {string | undefined}
+ */
 function chooseEntity(entities: (string | undefined)[]): string | undefined {
   // If there is an entity for either of the { candidate, active, rollback } attributes, it will be the same
   const notUndefined = entities.filter(isNotUndefined);
   if (notUndefined.length > 0) {
     return notUndefined[0];
   }
+
   return undefined;
 }

--- a/src/UI/Components/TreeTable/Inventory/AttributeHelper.ts
+++ b/src/UI/Components/TreeTable/Inventory/AttributeHelper.ts
@@ -27,7 +27,7 @@ export class InventoryAttributeHelper
    * Will create an array containing the path keys of the attributes.
    *
    * @param {Attributes} attributes
-   * @returns
+   * @returns {string[]}
    */
   public getPaths(attributes: Attributes): string[] {
     return Object.keys(

--- a/src/UI/Components/TreeTable/TreeRow/TreeRow.ts
+++ b/src/UI/Components/TreeTable/TreeRow/TreeRow.ts
@@ -32,7 +32,6 @@ interface Branch {
   onToggle: () => void;
   level: number;
   primaryCell: Cell;
-  hint?: string;
 }
 
 interface Leaf {

--- a/src/UI/Components/TreeTable/TreeRow/TreeRow.ts
+++ b/src/UI/Components/TreeTable/TreeRow/TreeRow.ts
@@ -5,6 +5,7 @@ export interface Cell {
   value: string;
   hasRelation?: boolean;
   serviceName?: string;
+  warning?: string;
 }
 
 interface Flat {
@@ -31,6 +32,7 @@ interface Branch {
   onToggle: () => void;
   level: number;
   primaryCell: Cell;
+  hint?: string;
 }
 
 interface Leaf {

--- a/src/UI/Components/TreeTable/TreeRow/TreeRowCreator.test.ts
+++ b/src/UI/Components/TreeTable/TreeRow/TreeRowCreator.test.ts
@@ -1,3 +1,4 @@
+import { Attributes } from "@/Core";
 import {
   InventoryAttributes,
   MultiAttributeNode,
@@ -10,13 +11,26 @@ const onToggle = () => {
   undefined;
 };
 
-const treeRowCreator = new TreeRowCreator(
-  new PathHelper("."),
-  () => false,
-  () => false,
-  () => onToggle,
-  extractInventoryValues
-);
+const attributes: Attributes = {
+  candidate: {
+    b: "a",
+  },
+  active: null,
+  rollback: null,
+};
+
+const setupTreeRowCreator = () => {
+  return new TreeRowCreator(
+    new PathHelper("."),
+    () => false,
+    () => false,
+    () => onToggle,
+    extractInventoryValues,
+    attributes
+  );
+};
+
+const treeRowCreator = setupTreeRowCreator();
 
 test("TreeRowCreator create returns Leaf for Leaf node", () => {
   const node: MultiAttributeNode<InventoryAttributes> = {
@@ -27,6 +41,7 @@ test("TreeRowCreator create returns Leaf for Leaf node", () => {
       rollback: undefined,
     },
   };
+
   const row: TreeRow = {
     kind: "Leaf",
     id: "a.b",
@@ -39,6 +54,7 @@ test("TreeRowCreator create returns Leaf for Leaf node", () => {
     ],
     level: 1,
   };
+
   expect(treeRowCreator.create("a.b", node)).toEqual(row);
 });
 
@@ -51,6 +67,7 @@ test("TreeRowCreator create returns Flat for flat Leaf node", () => {
       rollback: undefined,
     },
   };
+
   const row: TreeRow = {
     kind: "Flat",
     id: "b",
@@ -61,6 +78,7 @@ test("TreeRowCreator create returns Flat for flat Leaf node", () => {
     ],
     primaryCell: { label: "name", value: "b" },
   };
+
   expect(treeRowCreator.create("b", node)).toEqual(row);
 });
 
@@ -72,6 +90,7 @@ test("TreeRowCreator create returns Root for flat Branch node", () => {
     isChildExpanded: false,
     primaryCell: { label: "name", value: "a" },
   };
+
   expect(treeRowCreator.create("a", { kind: "Branch" })).toEqual(row);
 });
 
@@ -85,5 +104,6 @@ test("TreeRowCreator create returns Branch for nested Branch node", () => {
     level: 1,
     primaryCell: { label: "name", value: "b" },
   };
+
   expect(treeRowCreator.create("a.b", { kind: "Branch" })).toEqual(row);
 });

--- a/src/UI/Components/TreeTable/TreeRow/TreeRowCreator.ts
+++ b/src/UI/Components/TreeTable/TreeRow/TreeRowCreator.ts
@@ -1,3 +1,4 @@
+import { Attributes } from "@/Core/Domain/InventoryTable";
 import {
   CatalogAttributes,
   InventoryAttributes,
@@ -15,9 +16,83 @@ export class TreeRowCreator<T extends AttributeTree["target"]> {
     private readonly createOnToggle: (path: string) => () => void,
     private readonly extractValues: (
       node: Extract<MultiAttributeNode<T>, { kind: "Leaf" }>
-    ) => Cell[]
+    ) => Cell[],
+    private readonly attributes: Attributes
   ) {}
 
+  /**
+   * When a Branch is not conform, this method will return you the content of the warning object.
+   * If the Branch targeted by the path is conform, all attributes are either undefined or an object, then this method will return undefined.
+   *
+   * @param {string} path - Usually a dict that separates attribute names by a $ sign.
+   * @returns {string | undefined}
+   */
+  getBranchWarningObject = (path: string): string | undefined => {
+    const pathArr = path.split("$");
+
+    if (!pathArr || !pathArr.length) {
+      return "";
+    }
+
+    const candidate = (this.attributes.candidate as unknown) || {};
+    const active = (this.attributes.active as unknown) || {};
+    const rollback = (this.attributes.rollback as unknown) || {};
+
+    const candidateValue = pathArr.reduce(
+      (obj, key) => (obj && obj[key] !== "undefined" ? obj[key] : undefined),
+      candidate
+    );
+
+    const activeValue = pathArr.reduce(
+      (obj, key) => (obj && obj[key] !== "undefined" ? obj[key] : undefined),
+      active
+    );
+
+    const rollBackValue = pathArr.reduce(
+      (obj, key) => (obj && obj[key] !== "undefined" ? obj[key] : undefined),
+      rollback
+    );
+
+    /**
+     * The value can normally only be of type object or undefined if it's conform.
+     * If it's a string or a number it means that the type migrated at some point.
+     * That's when we want to display a warning to the user to inform there is a mismatch.
+     */
+    if (
+      typeof candidateValue === "string" ||
+      typeof activeValue === "string" ||
+      typeof rollBackValue === "string"
+    ) {
+      const candidateStringified =
+        typeof candidateValue !== "undefined"
+          ? JSON.stringify(candidateValue)
+          : candidateValue;
+      const activeStringified =
+        typeof activeValue !== "undefined"
+          ? JSON.stringify(activeValue)
+          : activeValue;
+      const rollbackStringified =
+        typeof rollBackValue !== "undefined"
+          ? JSON.stringify(rollBackValue)
+          : rollBackValue;
+
+      return `Candidate attributes : ${candidateStringified} \n  Active attributes : ${activeStringified} \n Rollback attributes : ${rollbackStringified}`;
+    }
+
+    return;
+  };
+
+  /**
+   * Depending on the targeted attribute and if it's nested or not,
+   * this method will return you a Leaf/Flat or a Branch/Root Row.
+   * There is an additional check for nested levels to define if they are conform or not.
+   * A warning property is added to the primaryCell object for these sections.
+   * If the warning has a string value, this will be handled further in the TreeRowView component.
+   *
+   * @param {string} path
+   * @param {MultiAttributeNode<T>} node
+   * @returns {TreeRow} a TreeRow object
+   */
   create(path: string, node: MultiAttributeNode<T>): TreeRow {
     if (node.kind === "Leaf") {
       if (this.pathHelper.isNested(path)) {
@@ -40,6 +115,8 @@ export class TreeRowCreator<T extends AttributeTree["target"]> {
         };
       }
     } else {
+      const warning = this.getBranchWarningObject(path);
+
       if (this.pathHelper.isNested(path)) {
         return {
           kind: "Branch",
@@ -48,7 +125,11 @@ export class TreeRowCreator<T extends AttributeTree["target"]> {
           isChildExpanded: this.isChildExpanded(path),
           onToggle: this.createOnToggle(path),
           level: this.pathHelper.getLevel(path),
-          primaryCell: { label: "name", value: this.pathHelper.getSelf(path) },
+          primaryCell: {
+            label: "name",
+            value: this.pathHelper.getSelf(path),
+            warning: warning,
+          },
         };
       } else {
         return {
@@ -56,7 +137,7 @@ export class TreeRowCreator<T extends AttributeTree["target"]> {
           id: path,
           isChildExpanded: this.isChildExpanded(path),
           onToggle: this.createOnToggle(path),
-          primaryCell: { label: "name", value: path },
+          primaryCell: { label: "name", value: path, warning: warning },
         };
       }
     }

--- a/src/UI/Components/TreeTable/TreeRow/TreeRowView.tsx
+++ b/src/UI/Components/TreeTable/TreeRow/TreeRowView.tsx
@@ -1,8 +1,11 @@
 import React from "react";
-import { Split, SplitItem } from "@patternfly/react-core";
+import { Icon, Split, SplitItem, Tooltip } from "@patternfly/react-core";
+import { ExclamationTriangleIcon } from "@patternfly/react-icons";
 import { Tr, Td } from "@patternfly/react-table";
+import styled from "styled-components";
 import { ParsedNumber } from "@/Core";
 import { Toggle } from "@/UI/Components/Toggle";
+import { ClipboardCopyButton } from "../../ClipboardCopyButton";
 import { CellWithCopy } from "./CellWithCopy";
 import { CellWithCopyExpert } from "./CellWithCopyExpert";
 import { Indent } from "./Indent";
@@ -76,6 +79,20 @@ export const TreeRowView: React.FC<RowProps> = ({
                   row.primaryCell.value === "null"
                     ? ""
                     : row.primaryCell.value}
+                  {row.primaryCell.warning ? (
+                    <Spacer>
+                      <Tooltip content="This attribute migrated to a different/new Type and can’t be displayed properly into the table. You can copy the object for further comparison through the Copy button. It will store the value of each state in your clipboard.">
+                        <Icon status="warning">
+                          <ExclamationTriangleIcon />
+                        </Icon>
+                      </Tooltip>
+                      <ClipboardCopyButton
+                        value={row.primaryCell.warning}
+                      ></ClipboardCopyButton>
+                    </Spacer>
+                  ) : (
+                    ""
+                  )}
                 </SplitItem>
               </Split>
             </Indent>
@@ -97,6 +114,20 @@ export const TreeRowView: React.FC<RowProps> = ({
               row.primaryCell.value === "null"
                 ? ""
                 : row.primaryCell.value}
+              {row.primaryCell.warning ? (
+                <Spacer>
+                  <Tooltip content="This attribute migrated to a different/new Type and can’t be displayed properly into the table. You can copy the object for further comparison through the Copy button. It will store the value of each state in your clipboard.">
+                    <Icon status="warning">
+                      <ExclamationTriangleIcon />
+                    </Icon>
+                  </Tooltip>
+                  <ClipboardCopyButton
+                    value={row.primaryCell.warning}
+                  ></ClipboardCopyButton>
+                </Spacer>
+              ) : (
+                ""
+              )}
             </Indent>
           </Td>
         </Tr>
@@ -140,3 +171,7 @@ export const TreeRowView: React.FC<RowProps> = ({
       );
   }
 };
+
+const Spacer = styled.span`
+  padding-left: 10px;
+`;

--- a/src/UI/Components/TreeTable/TreeRow/TreeRowView.tsx
+++ b/src/UI/Components/TreeTable/TreeRow/TreeRowView.tsx
@@ -19,6 +19,9 @@ interface RowProps {
   showExpertMode: boolean;
 }
 
+const warningMessage =
+  "This attribute migrated to a different/new Type and can’t be displayed properly into the table. You can copy the object for further comparison through the Copy button. It will store the value of each state in your clipboard.";
+
 export const TreeRowView: React.FC<RowProps> = ({
   row,
   id,
@@ -81,7 +84,7 @@ export const TreeRowView: React.FC<RowProps> = ({
                     : row.primaryCell.value}
                   {row.primaryCell.warning ? (
                     <Spacer>
-                      <Tooltip content="This attribute migrated to a different/new Type and can’t be displayed properly into the table. You can copy the object for further comparison through the Copy button. It will store the value of each state in your clipboard.">
+                      <Tooltip content={warningMessage}>
                         <Icon status="warning">
                           <ExclamationTriangleIcon />
                         </Icon>
@@ -116,7 +119,7 @@ export const TreeRowView: React.FC<RowProps> = ({
                 : row.primaryCell.value}
               {row.primaryCell.warning ? (
                 <Spacer>
-                  <Tooltip content="This attribute migrated to a different/new Type and can’t be displayed properly into the table. You can copy the object for further comparison through the Copy button. It will store the value of each state in your clipboard.">
+                  <Tooltip content={warningMessage}>
                     <Icon status="warning">
                       <ExclamationTriangleIcon />
                     </Icon>


### PR DESCRIPTION
# Description

![image](https://user-images.githubusercontent.com/44098050/233947781-06585076-7f13-4280-a4f3-3fd263c3f431.png)

The copy button will return a string such as this one : 

```
Candidate attributes : "{\"id\": \"ipxa://1000320xxx\", \"es_id\": null}" 
Active attributes : {"id":"ipxa://1000320xxx","es_id":null} 
Rollback attributes : undefined
```

The warning icon + copy button will only be displayed in case there is a mismatch in type, where one side is an object/Array and the other a string/number. 

closes #4534 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Code is clear and sufficiently documented
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
