### PR TITLE
Build(deps): Bump keycloak-js from 20.0.2 to 21.0.2 (#4809)

### DIFF
--- a/changelogs/unreleased/4809-dependabot.yml
+++ b/changelogs/unreleased/4809-dependabot.yml
@@ -1,0 +1,6 @@
+change-type: patch
+description: 'Build(deps): Bump keycloak-js from 20.0.2 to 21.0.2'
+destination-branches:
+- master
+- iso6
+sections: {}

--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "history": "^5.3.0",
     "json-bigint": "^1.0.0",
     "jszip": "^3.10.1",
-    "keycloak-js": "^20.0.2",
+    "keycloak-js": "^21.0.2",
     "lodash": "^4.17.21",
     "lodash-es": "^4.17.21",
     "moment": "^2.29.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6805,10 +6805,10 @@ junk@^3.1.0:
   resolved "https://registry.yarnpkg.com/junk/-/junk-3.1.0.tgz#31499098d902b7e98c5d9b9c80f43457a88abfa1"
   integrity sha512-pBxcB3LFc8QVgdggvZWyeys+hnrNWg4OcZIU/1X59k5jQdLBlCsYGRQaz234SqoRLTCgMH00fY0xRJH+F9METQ==
 
-keycloak-js@^20.0.2:
-  version "20.0.2"
-  resolved "https://registry.yarnpkg.com/keycloak-js/-/keycloak-js-20.0.2.tgz#31c337a33eb44fc2aaaed342519cc6d5e959e4bd"
-  integrity sha512-RPLeBdrsB4ybc2tWL5R+tUqdUd62ytZLVT7AWcCCqMWKuQ0AbmrOtGaPnnWMzS/3XJH447nDq1ulUOGzpj41LQ==
+keycloak-js@^21.0.2:
+  version "21.0.2"
+  resolved "https://registry.yarnpkg.com/keycloak-js/-/keycloak-js-21.0.2.tgz#1d3c2079d3c23850df4f253a868926861c51c488"
+  integrity sha512-i05i3VBPhQ867EgjA+OYPlf8YUPiUwtrU2zv4j8tvZIdRvhJY8f+mp1ZvRJl/GMRb+XhJs9BDknyBMrIspwDkw==
   dependencies:
     base64-js "^1.5.1"
     js-sha256 "^0.9.0"


### PR DESCRIPTION
Pull request opened by the merge tool on behalf of #4809