### PR TITLE
Build(deps-dev): Bump mini-css-extract-plugin from 2.7.5 to 2.7.6 (#4889)

### DIFF
--- a/changelogs/unreleased/4889-dependabot.yml
+++ b/changelogs/unreleased/4889-dependabot.yml
@@ -1,0 +1,6 @@
+change-type: patch
+description: 'Build(deps-dev): Bump mini-css-extract-plugin from 2.7.5 to 2.7.6'
+destination-branches:
+- master
+- iso6
+sections: {}

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "jest-junit": "^15.0.0",
     "lint-staged": "^13.2.1",
     "madge": "^6.0.0",
-    "mini-css-extract-plugin": "^2.7.0",
+    "mini-css-extract-plugin": "^2.7.6",
     "mocha": "^10.2.0",
     "mocha-junit-reporter": "^2.2.0",
     "mochawesome": "^7.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -934,7 +934,7 @@ __metadata:
     lodash: ^4.17.21
     lodash-es: ^4.17.21
     madge: ^6.0.0
-    mini-css-extract-plugin: ^2.7.0
+    mini-css-extract-plugin: ^2.7.6
     mocha: ^10.2.0
     mocha-junit-reporter: ^2.2.0
     mochawesome: ^7.1.3
@@ -9853,14 +9853,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mini-css-extract-plugin@npm:^2.7.0":
-  version: 2.7.5
-  resolution: "mini-css-extract-plugin@npm:2.7.5"
+"mini-css-extract-plugin@npm:^2.7.6":
+  version: 2.7.6
+  resolution: "mini-css-extract-plugin@npm:2.7.6"
   dependencies:
     schema-utils: ^4.0.0
   peerDependencies:
     webpack: ^5.0.0
-  checksum: afc37cdfb765e8826a1babbab3cd8a99ffc4eaeabb6c013a6b3c80801e44ebc37d930b98c6f66168bb8cd545fcb2e8fc2630d72b4501a1bb8add1547c2534a53
+  checksum: be6f7cefc6275168eb0a6b8fe977083a18c743c9612c9f00e6c1a62c3393ca7960e93fba1a7ebb09b75f36a0204ad087d772c1ef574bc29c90c0e8175a3c0b83
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Pull request opened by the merge tool on behalf of #4889