### PR TITLE
4885/redirect keycloak

### DIFF
--- a/changelogs/unreleased/4885-redirection-keycloak.yml
+++ b/changelogs/unreleased/4885-redirection-keycloak.yml
@@ -1,0 +1,8 @@
+change-type: patch
+description: 'Page redirection has been fixed when the authentication token expires.'
+issue-nr: 4885
+destination-branches:
+- master
+- iso6
+sections: 
+  bugfix: "{{description}}"

--- a/src/Data/API/BaseApiHelper.ts
+++ b/src/Data/API/BaseApiHelper.ts
@@ -21,7 +21,10 @@ export class BaseApiHelper implements ApiHelper {
 
   async head(url: string): Promise<number> {
     try {
-      const response = await fetch(this.getFullUrl(url), { method: "HEAD" });
+      const response = await fetch(this.getFullUrl(url), {
+        method: "HEAD",
+        headers: this.getHeaders(),
+      });
       return response.status;
     } catch (error) {
       return 500;

--- a/src/UI/Root/Components/Header/Actions/Profile/Profile.tsx
+++ b/src/UI/Root/Components/Header/Actions/Profile/Profile.tsx
@@ -1,19 +1,17 @@
 import React from "react";
 import { TextContent } from "@patternfly/react-core";
-import Keycloak from "keycloak-js";
+import { useKeycloak } from "@react-keycloak/web";
 import styled from "styled-components";
 
-interface Props {
-  keycloak: Keycloak | undefined;
-}
+export const Profile: React.FC = () => {
+  const { keycloak } = useKeycloak();
 
-export const Profile: React.FC<Props> = ({ keycloak }) => {
-  const [name, setName] = React.useState("unknown user");
-  if (keycloak && keycloak.profile && keycloak.profile.username !== name) {
-    setName(keycloak.profile.username as string);
-  }
-
-  return <StyledText>{name}</StyledText>;
+  return (
+    <StyledText>
+      {(keycloak && keycloak.profile && keycloak.profile.username) ||
+        "Unknown user"}
+    </StyledText>
+  );
 };
 
 const StyledText = styled(TextContent)`

--- a/src/UI/Root/Components/Header/Actions/Profile/Profile.tsx
+++ b/src/UI/Root/Components/Header/Actions/Profile/Profile.tsx
@@ -1,17 +1,19 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import { TextContent } from "@patternfly/react-core";
 import { useKeycloak } from "@react-keycloak/web";
 import styled from "styled-components";
 
 export const Profile: React.FC = () => {
   const { keycloak } = useKeycloak();
+  const [name, setName] = useState("Unknown user");
 
-  return (
-    <StyledText>
-      {(keycloak && keycloak.profile && keycloak.profile.username) ||
-        "Unknown user"}
-    </StyledText>
-  );
+  useEffect(() => {
+    if (keycloak && keycloak.profile && keycloak.profile.username) {
+      setName(keycloak.profile.username);
+    }
+  }, [keycloak, keycloak.profile]);
+
+  return <StyledText>{name}</StyledText>;
 };
 
 const StyledText = styled(TextContent)`

--- a/src/UI/Root/Components/Header/EnvSelector/EnvSelector.tsx
+++ b/src/UI/Root/Components/Header/EnvSelector/EnvSelector.tsx
@@ -72,7 +72,7 @@ export const EnvSelector: React.FC<Props> = ({
                 <UserCircleIcon />
               </StyledIcon>
               <div>
-                <Profile keycloak={keycloakController.getInstance()} />
+                <Profile />
                 <div>
                   {toggleText.length > 28
                     ? toggleText.slice(0, 20) + "..."

--- a/src/config.js
+++ b/src/config.js
@@ -1,8 +1,8 @@
-window.auth = {
-  realm: "inmanta",
-  url: "http://localhost:8080",
-  clientId: "inmantaso",
-};
+// window.auth = {
+//   realm: "inmanta",
+//   url: "http://localhost:8080",
+//   clientId: "inmantaso",
+// };
 
 export const features = {
   instanceComposer: false,

--- a/src/config.js
+++ b/src/config.js
@@ -1,8 +1,9 @@
-// window.auth = {
-//   realm: "inmanta",
-//   url: "http://localhost:8080",
-//   clientId: "inmantaso",
-// }
+window.auth = {
+  realm: "inmanta",
+  url: "http://localhost:8080",
+  clientId: "inmantaso",
+};
+
 export const features = {
   instanceComposer: false,
 };

--- a/src/index.html
+++ b/src/index.html
@@ -6,11 +6,11 @@
   <title>Inmanta Web Console</title>
   <meta id="appName" name="application-name" content="Inmanta Web Console">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <script type="module" src="config.js"></script>
 </head>
 
 <body>
   <noscript>Enabling JavaScript is required to run this app.</noscript>
   <div id="root"></div>
 </body>
-<script type="module" src="config.js"></script>
 </html>


### PR DESCRIPTION
# Description

The redirection will be solved in the local-setup configuration since as of 18+ version of Keycloak server, we need a valid redirection URI set on the server-side.

Aside from that, the problem with the HEAD-calls are now resolved. They weren't sending the headers with the bearer, causing them to fail when Keycloak was enabled.

Lastly, there was still an issue when the token expired. The page would stay stuck and show a 403. It will now redirect to the login page. 

The only issue remaining, is the state update in the profile dropdown, this will be resolved in a next ticket.

https://github.com/inmanta/web-console/assets/44098050/0e934a49-1bbb-4154-b74d-fff21de5b685

