### PR TITLE
Build(deps-dev): Bump @types/react-syntax-highlighter from 15.5.6 to 15.5.7 (#4901)

### DIFF
--- a/changelogs/unreleased/4901-dependabot.yml
+++ b/changelogs/unreleased/4901-dependabot.yml
@@ -1,0 +1,7 @@
+change-type: patch
+description: 'Build(deps-dev): Bump @types/react-syntax-highlighter from 15.5.6 to
+    15.5.7'
+destination-branches:
+- master
+- iso6
+sections: {}

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@types/qs": "^6.9.7",
     "@types/react-dom": "^18.0.10",
     "@types/react-router-dom": "^5.3.3",
-    "@types/react-syntax-highlighter": "^15.5.6",
+    "@types/react-syntax-highlighter": "^15.5.7",
     "@types/styled-components": "^5.1.26",
     "@types/webpack": "^5.28.1",
     "@types/xml-formatter": "^2.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -888,7 +888,7 @@ __metadata:
     "@types/qs": ^6.9.7
     "@types/react-dom": ^18.0.10
     "@types/react-router-dom": ^5.3.3
-    "@types/react-syntax-highlighter": ^15.5.6
+    "@types/react-syntax-highlighter": ^15.5.7
     "@types/styled-components": ^5.1.26
     "@types/webpack": ^5.28.1
     "@types/xml-formatter": ^2.1.1
@@ -2173,12 +2173,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react-syntax-highlighter@npm:^15.5.6":
-  version: 15.5.6
-  resolution: "@types/react-syntax-highlighter@npm:15.5.6"
+"@types/react-syntax-highlighter@npm:^15.5.7":
+  version: 15.5.7
+  resolution: "@types/react-syntax-highlighter@npm:15.5.7"
   dependencies:
     "@types/react": "*"
-  checksum: 81a9f26da41606ff595d42a064ec4097cd17c4ef242558aa5b3b76a1063729b2ae73f063350069a4692218cf6843d7ea59d3eaeac4df2a4894d969d911fb80b2
+  checksum: 1918d01baaa9bf485093fb04167d0dc87131be708bd68d32d3f614c0e7dba05de765fc62df139fa1972836b13e27983a2d89552eda5b5a38691a4ec300949648
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Pull request opened by the merge tool on behalf of #4901