### PR TITLE
update keycloak setup script

### DIFF
--- a/changelogs/unreleased/update-script-keycloak.yml
+++ b/changelogs/unreleased/update-script-keycloak.yml
@@ -1,0 +1,5 @@
+description: Updated script to test against keycloak
+change-type: patch
+destination-branches:
+  - iso6
+  - master

--- a/shell-scripts/setup-keycloak.sh
+++ b/shell-scripts/setup-keycloak.sh
@@ -47,9 +47,4 @@ sleep 2
 echo "Starting container..."
 yarn start:keycloak
 
-for i in {0..30} 
-do 
-    curl -k --connect-timeout 1 https://localhost:8888/api/v1/serverstatus > /dev/null && echo "Server up " && break
-    echo "Waiting $i"
-    sleep 1 
-done && [[ $i == 30 ]] && exit 1
+sleep 3


### PR DESCRIPTION
removed the ping to the server since it was rather behaving oddly with the https. Also, not really needed anymore for the keycloak setup since we don't require an installation of lsm or a specific project for the test. These can be done manually if ever needed. 