### PR TITLE
Updated the default filtering on Compliance check page and Compare page

### DIFF
--- a/changelogs/unreleased/default-filtering-diff.yml
+++ b/changelogs/unreleased/default-filtering-diff.yml
@@ -1,0 +1,8 @@
+change-type: patch
+description: 'Updated the default filtering on Compliance check page and Compare page to exclude the unmodified files.'
+issue-nr: 4681
+destination-branches:
+- master
+- iso6
+sections: 
+  minor-improvement: "{{description}}"

--- a/cypress/e2e/scenario-4-desired-state.cy.js
+++ b/cypress/e2e/scenario-4-desired-state.cy.js
@@ -371,10 +371,6 @@ describe("Scenario 4 Desired State", () => {
     //go back
     cy.get(".pf-c-nav__link").contains("Desired State").click();
 
-    // cy.get("@TABLE_LENGTH").then((length) => {
-    //   cy.get("tbody").eq(length).find('[aria-label="Actions"]').click();
-    // });
-
     cy.get("tbody").eq(-1).find('[aria-label="Actions"]').click();
 
     cy.get(".pf-c-dropdown__menu-item")
@@ -384,6 +380,11 @@ describe("Scenario 4 Desired State", () => {
     cy.get(".pf-c-title").should("have.text", "Compliance Check");
     cy.get(".pf-c-select").contains("No dry runs exist").should("be.visible");
     cy.get(".pf-c-button").contains("Perform dry run").click();
+
+    cy.get('[aria-label="StatusFilter"]').click();
+    cy.get('[aria-label="StatusFilterOption"]').contains("unmodified").click();
+    cy.get('[aria-label="StatusFilter"]').click();
+
     cy.get('[aria-label="DiffItemList"]', { timeout: 20000 }).should(
       "be.visible"
     );
@@ -425,6 +426,11 @@ describe("Scenario 4 Desired State", () => {
 
     cy.get(".pf-c-select").contains("No dry runs exist").should("be.visible");
     cy.get(".pf-c-button").contains("Perform dry run").click();
+
+    cy.get('[aria-label="StatusFilter"]').click();
+    cy.get('[aria-label="StatusFilterOption"]').contains("unmodified").click();
+    cy.get('[aria-label="StatusFilter"]').click();
+
     // perform dry-run
     // await the end of the dry-run and expect to find two rows with expandable content.
     cy.get(".pf-c-card__expandable-content", { timeout: 20000 }).should(
@@ -478,6 +484,10 @@ describe("Scenario 4 Desired State", () => {
     cy.get(".pf-c-dropdown__menu-item")
       .contains("Compare with current state")
       .click();
+
+    cy.get('[aria-label="StatusFilter"]').click();
+    cy.get('[aria-label="StatusFilterOption"]').contains("unmodified").click();
+    cy.get('[aria-label="StatusFilter"]').click();
 
     // expect the view to still contain the diff of the last dry-run comparison
     cy.get(".pf-c-card__expandable-content", { timeout: 20000 }).should(

--- a/src/Core/Domain/Diff/Diff.ts
+++ b/src/Core/Domain/Diff/Diff.ts
@@ -17,6 +17,15 @@ export const statuses: Status[] = [
   "skipped_for_undefined",
 ];
 
+export const defaultStatuses: Status[] = [
+  "added",
+  "modified",
+  "deleted",
+  "agent_down",
+  "undefined",
+  "skipped_for_undefined",
+];
+
 export interface ValueSet {
   from_value: unknown;
   to_value: unknown;

--- a/src/Slices/ComplianceCheck/UI/Page.test.tsx
+++ b/src/Slices/ComplianceCheck/UI/Page.test.tsx
@@ -83,7 +83,7 @@ test("GIVEN ComplianceCheck page THEN user sees latest dry run report", async ()
   });
 
   const blocks = await screen.findAllByRole("article", { name: "DiffBlock" });
-  expect(blocks).toHaveLength(12);
+  expect(blocks).toHaveLength(11);
 });
 
 test("GIVEN ComplianceCheck page When a report is selected from the list THEN the user sees the selected dry run report", async () => {
@@ -252,11 +252,11 @@ test("GIVEN ComplianceCheck page WHEN StatusFilter = 'Added' THEN only 'Added' r
 
   expect(
     screen.getAllByRole("listitem", { name: "DiffSummaryListItem" })
-  ).toHaveLength(12);
+  ).toHaveLength(11);
 
   expect(
     await screen.findAllByRole("article", { name: "DiffBlock" })
-  ).toHaveLength(12);
+  ).toHaveLength(11);
 
   expect(
     screen.queryByRole("listbox", { name: "StatusFilterOptions" })
@@ -274,6 +274,11 @@ test("GIVEN ComplianceCheck page WHEN StatusFilter = 'Added' THEN only 'Added' r
     name: "StatusFilterOption",
   });
   expect(statusOptions).toHaveLength(7);
+  await act(async () => {
+    await userEvent.click(
+      screen.getByRole("button", { name: words("showAll") })
+    );
+  });
   await act(async () => {
     await userEvent.click(
       screen.getByRole("button", { name: words("hideAll") })

--- a/src/Slices/ComplianceCheck/UI/Page.tsx
+++ b/src/Slices/ComplianceCheck/UI/Page.tsx
@@ -27,7 +27,7 @@ export const View: React.FC<Props> = ({ version }) => {
   });
   const [errorMessage, setErrorMessage] = useState("");
   const [updatedList, setUpdatedList] = useState(false);
-  const [statuses, setStatuses] = useState(Diff.statuses);
+  const [statuses, setStatuses] = useState(Diff.defaultStatuses);
   const [selectedReport, setSelectedReport] = useState<MaybeReport>(
     Maybe.none()
   );

--- a/src/Slices/DesiredStateCompare/UI/Page.test.tsx
+++ b/src/Slices/DesiredStateCompare/UI/Page.test.tsx
@@ -57,7 +57,7 @@ test("GIVEN DesiredStateCompare THEN shows list of diff blocks", async () => {
   });
 
   const blocks = await screen.findAllByRole("article", { name: "DiffBlock" });
-  expect(blocks).toHaveLength(12);
+  expect(blocks).toHaveLength(11);
 });
 
 test("GIVEN DesiredStateCompare THEN shows 'Jump To' action with dropdown", async () => {
@@ -85,7 +85,7 @@ test("GIVEN DesiredStateCompare THEN shows 'Jump To' action with dropdown", asyn
   const items = screen.getAllByRole("listitem", {
     name: "DiffSummaryListItem",
   });
-  expect(items).toHaveLength(12);
+  expect(items).toHaveLength(11);
 });
 
 test("GIVEN DesiredStateCompare WHEN StatusFilter = 'Added' THEN only 'Added' resources are shown", async () => {
@@ -104,11 +104,11 @@ test("GIVEN DesiredStateCompare WHEN StatusFilter = 'Added' THEN only 'Added' re
 
   expect(
     screen.getAllByRole("listitem", { name: "DiffSummaryListItem" })
-  ).toHaveLength(12);
+  ).toHaveLength(11);
 
   expect(
     await screen.findAllByRole("article", { name: "DiffBlock" })
-  ).toHaveLength(12);
+  ).toHaveLength(11);
 
   expect(
     screen.queryByRole("listbox", { name: "StatusFilterOptions" })
@@ -127,6 +127,11 @@ test("GIVEN DesiredStateCompare WHEN StatusFilter = 'Added' THEN only 'Added' re
   });
   expect(statusOptions).toHaveLength(7);
 
+  await act(async () => {
+    await userEvent.click(
+      screen.getByRole("button", { name: words("showAll") })
+    );
+  });
   await act(async () => {
     await userEvent.click(
       screen.getByRole("button", { name: words("hideAll") })

--- a/src/Slices/DesiredStateCompare/UI/Page.tsx
+++ b/src/Slices/DesiredStateCompare/UI/Page.tsx
@@ -21,7 +21,7 @@ export const Page: React.FC = () => {
 export const View: React.FC<Diff.Identifiers> = ({ from, to }) => {
   const { queryResolver } = useContext(DependencyContext);
   const refs: DiffWizard.Refs = useRef({});
-  const [statuses, setStatuses] = useState(Diff.statuses);
+  const [statuses, setStatuses] = useState(Diff.defaultStatuses);
 
   const [data] = queryResolver.useOneTime<"GetDesiredStateDiff">({
     kind: "GetDesiredStateDiff",


### PR DESCRIPTION
# Description

The default filtering is now excluding the "unmodified" resources. 

https://github.com/inmanta/web-console/assets/44098050/3a29f893-fd09-469b-af91-882092319bcd

