### PR TITLE
repair timepicker

### DIFF
--- a/changelogs/unreleased/timepicker-issue.yml
+++ b/changelogs/unreleased/timepicker-issue.yml
@@ -1,0 +1,7 @@
+change-type: patch
+description: 'Repair timepicker.'
+destination-branches:
+- master
+- iso6
+sections: 
+  bugfix: "{{description}}"

--- a/src/UI/Components/Filters/TimestampPicker.tsx
+++ b/src/UI/Components/Filters/TimestampPicker.tsx
@@ -56,7 +56,7 @@ export const TimestampPicker: React.FC<Props> = ({
     }
   };
 
-  const onTimeChange = (time) => {
+  const onTimeChange = (_event, time) => {
     setTimeText(time);
     if (timestamp && isValidDate(timestamp) && time.split(":").length === 2) {
       const [hour, minute] = time.split(":");


### PR DESCRIPTION
# Description

Repair timepicker bug reported earlier. Some order in the onchange method occured on Patternfly's side and cause the first argument to be the "event" object instead of the time string.
