### PR TITLE
update keycloak test to use ip-address

### DIFF
--- a/changelogs/unreleased/update-keycloak-test.yml
+++ b/changelogs/unreleased/update-keycloak-test.yml
@@ -1,0 +1,5 @@
+change-type: patch
+description: 'Change the url from localhost to ip address in tests.'
+destination-branches:
+- master
+- iso6

--- a/cypress/e2e/scenario-7-keycloak.cy.js
+++ b/cypress/e2e/scenario-7-keycloak.cy.js
@@ -2,7 +2,7 @@ if (Cypress.env("keycloak")) {
   it("should be able to login and logout", () => {
     cy.visit("/console/");
 
-    cy.origin("http://localhost:8080", () => {
+    cy.origin("http://127.0.0.1:8080", () => {
       cy.get("[id=username]").type("admin");
       cy.get("[id=password]").type("admin{enter}");
     });
@@ -14,7 +14,7 @@ if (Cypress.env("keycloak")) {
 
     cy.get("a").contains("Logout").click();
 
-    cy.origin("http://localhost:8080", () => {
+    cy.origin("http://127.0.0.1:8080", () => {
       cy.get("[id=username]").should("be.visible");
       cy.get("[id=password]").should("be.visible");
     });


### PR DESCRIPTION
# Description

In order for this to work, we still need to update the certificates in the local-setup. `cert.key `and `cert.pem`. 

