### PR TITLE
Build(deps-dev): Bump regenerator-runtime from 0.13.11 to 0.14.0 (#5036)

### DIFF
--- a/changelogs/unreleased/5036-dependabot.yml
+++ b/changelogs/unreleased/5036-dependabot.yml
@@ -1,0 +1,6 @@
+change-type: patch
+description: 'Build(deps-dev): Bump regenerator-runtime from 0.13.11 to 0.14.0'
+destination-branches:
+- master
+- iso6
+sections: {}

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "prettier": "^3.0.0",
     "raw-loader": "^4.0.2",
     "react-svg-loader": "^3.0.3",
-    "regenerator-runtime": "^0.13.11",
+    "regenerator-runtime": "^0.14.0",
     "rimraf": "^5.0.1",
     "style-loader": "^3.3.3",
     "svg-url-loader": "^8.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1210,7 +1210,7 @@ __metadata:
     react-router-dom: ^6.14.2
     react-svg-loader: ^3.0.3
     react-syntax-highlighter: ^15.5.0
-    regenerator-runtime: ^0.13.11
+    regenerator-runtime: ^0.14.0
     rimraf: ^5.0.1
     style-loader: ^3.3.3
     styled-components: ^5.3.11
@@ -12736,6 +12736,13 @@ __metadata:
   version: 0.13.11
   resolution: "regenerator-runtime@npm:0.13.11"
   checksum: 27481628d22a1c4e3ff551096a683b424242a216fee44685467307f14d58020af1e19660bf2e26064de946bad7eff28950eae9f8209d55723e2d9351e632bbb4
+  languageName: node
+  linkType: hard
+
+"regenerator-runtime@npm:^0.14.0":
+  version: 0.14.0
+  resolution: "regenerator-runtime@npm:0.14.0"
+  checksum: 1c977ad82a82a4412e4f639d65d22be376d3ebdd30da2c003eeafdaaacd03fc00c2320f18120007ee700900979284fc78a9f00da7fb593f6e6eeebc673fba9a3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Pull request opened by the merge tool on behalf of #5036