### PR TITLE
update select for compare functionality

### DIFF
--- a/changelogs/unreleased/update-compare-functionality.yml
+++ b/changelogs/unreleased/update-compare-functionality.yml
@@ -1,0 +1,8 @@
+change-type: patch
+description: 'The select for compare functionality on the Desired State page has been updated.'
+issue-nr: 4391
+destination-branches:
+- master
+- iso6
+sections: 
+  minor-improvement: "{{description}}"

--- a/src/Slices/DesiredState/UI/Components/CompareSelectionLabel.tsx
+++ b/src/Slices/DesiredState/UI/Components/CompareSelectionLabel.tsx
@@ -14,26 +14,21 @@ interface Props {
 export const CompareSelectionLabel: React.FC<Props> = ({
   selection,
   onDelete,
-}) => (
-  <Container>
-    <Title>{words("desiredState.compare.selectionLabel")}</Title>
-    <Selection>
-      <SelectionText>
-        {Maybe.isSome(selection) && (
-          <>
-            <b>{selection.value}</b> &amp;
-          </>
-        )}{" "}
-        ...
-      </SelectionText>
-      {Maybe.isSome(selection) && (
+}) => {
+  return Maybe.isSome(selection) ? (
+    <Container>
+      <Title>{words("desiredState.compare.selectionLabel")}</Title>
+      <Selection>
+        <SelectionText>
+          <b>{selection.value}</b>;
+        </SelectionText>
         <SelectionAction onClick={onDelete} variant="plain">
           <TimesIcon size="sm" />
         </SelectionAction>
-      )}
-    </Selection>
-  </Container>
-);
+      </Selection>
+    </Container>
+  ) : null;
+};
 
 const Container = styled.div`
   display: inline-flex;

--- a/src/Slices/DesiredState/UI/Components/TableControls.tsx
+++ b/src/Slices/DesiredState/UI/Components/TableControls.tsx
@@ -29,11 +29,10 @@ export const TableControls: React.FC<Props> = ({
       <FilterWidget filter={filter} setFilter={setFilter} />
       <ToolbarItem variant="separator" />
       <ToolbarGroup>
-        <CompareSelectionWidget />
-      </ToolbarGroup>
-      <ToolbarItem variant="separator" />
-      <ToolbarGroup>
         <CompileWidget isToastVisible />
+      </ToolbarGroup>
+      <ToolbarGroup>
+        <CompareSelectionWidget />
       </ToolbarGroup>
       <ToolbarItem variant="pagination">{paginationWidget}</ToolbarItem>
     </ToolbarContent>


### PR DESCRIPTION
# Description

Updated the behavior of the select for compare functionality to be more intuitive. The selection chip will only be visible when you selected an item in the table. 

closes *#4391*



https://github.com/inmanta/web-console/assets/44098050/354f11f5-8b0f-4ff7-8e15-5a050f6aa754

