### PR TITLE
improve user feedback for the repair and deploy buttons.

### DIFF
--- a/changelogs/unreleased/improve-user-feedback-repair.yml
+++ b/changelogs/unreleased/improve-user-feedback-repair.yml
@@ -1,0 +1,8 @@
+change-type: patch
+description: 'Improve the user-feedback when pressing either the repair or deploy button on the ressource page.'
+issue-nr: 4349
+destination-branches:
+- master
+- iso6
+sections: 
+  minor-improvement: "{{description}}"

--- a/src/Slices/Resource/UI/ResourcesPage/Components/ActionButton.tsx
+++ b/src/Slices/Resource/UI/ResourcesPage/Components/ActionButton.tsx
@@ -1,0 +1,63 @@
+import React, { useContext, useEffect, useState } from "react";
+import { Button, Tooltip } from "@patternfly/react-core";
+import { ActionDisabledTooltip } from "@/UI/Components";
+import { DependencyContext } from "@/UI/Dependency";
+import { words } from "@/UI/words";
+import { DotIndication } from "./DotIndicator";
+
+interface Props {
+  kind: "Deploy" | "Repair";
+  tooltip: string;
+  textContent: string;
+}
+
+export const ResourcePageActionButton: React.FC<Props> = ({
+  kind,
+  tooltip,
+  textContent,
+}) => {
+  const [showSpinner, setShowSpinner] = useState(false);
+  const { environmentModifier, commandResolver } =
+    useContext(DependencyContext);
+  const isHalted = environmentModifier.useIsHalted();
+
+  const trigger = commandResolver.useGetTrigger<typeof kind>({ kind: kind });
+
+  const handleClick = () => {
+    trigger();
+    setShowSpinner(true);
+  };
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setShowSpinner(false);
+    }, 5000);
+
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [showSpinner]);
+
+  return isHalted ? (
+    <ActionDisabledTooltip
+      ariaLabel={textContent}
+      tooltipContent={words("environment.halt.tooltip")}
+      isDisabled
+    >
+      <Button variant="secondary" isDisabled>
+        {textContent}
+      </Button>
+    </ActionDisabledTooltip>
+  ) : (
+    <Tooltip content={tooltip} entryDelay={400}>
+      <Button
+        variant="secondary"
+        isDisabled={showSpinner}
+        onClick={() => handleClick()}
+      >
+        {textContent}
+        {showSpinner && <DotIndication data-testid="dot-indication" />}
+      </Button>
+    </Tooltip>
+  );
+};

--- a/src/Slices/Resource/UI/ResourcesPage/Components/DeployButton.tsx
+++ b/src/Slices/Resource/UI/ResourcesPage/Components/DeployButton.tsx
@@ -1,27 +1,13 @@
-import React, { useContext } from "react";
-import { Button } from "@patternfly/react-core";
-import { ActionDisabledTooltip } from "@/UI/Components";
-import { DependencyContext } from "@/UI/Dependency";
+import React from "react";
 import { words } from "@/UI/words";
+import { ResourcePageActionButton } from "./ActionButton";
 
 export const DeployButton: React.FC = () => {
-  const { environmentModifier, commandResolver } =
-    useContext(DependencyContext);
-  const isHalted = environmentModifier.useIsHalted();
-  const trigger = commandResolver.useGetTrigger<"Deploy">({ kind: "Deploy" });
   return (
-    <ActionDisabledTooltip
-      isDisabled={isHalted}
-      ariaLabel={words("resources.deploySummary.deploy")}
-      tooltipContent={words("environment.halt.tooltip")}
-    >
-      <Button
-        variant="secondary"
-        isDisabled={isHalted}
-        onClick={() => trigger()}
-      >
-        {words("resources.deploySummary.deploy")}
-      </Button>
-    </ActionDisabledTooltip>
+    <ResourcePageActionButton
+      kind="Deploy"
+      tooltip={words("resources.deploy.tooltip")}
+      textContent={words("resources.deploySummary.deploy")}
+    />
   );
 };

--- a/src/Slices/Resource/UI/ResourcesPage/Components/DotIndicator.tsx
+++ b/src/Slices/Resource/UI/ResourcesPage/Components/DotIndicator.tsx
@@ -1,0 +1,26 @@
+import styled, { keyframes } from "styled-components";
+
+//Indication colors based on <Label color="blue" /> component
+const pendingAnimation = keyframes`
+ 0% { opacity: .2}
+ 50% { opacity: 1}
+ 100% { opacity: .2}
+`;
+
+export const DotIndication = styled.span`
+  width: 10px;
+  height: 10px;
+  margin-left: 10px;
+  position: relative;
+  &::before {
+    position: absolute;
+    top: 5px;
+    content: "";
+    background-color: var(--pf-global--primary-color--100);
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    border: 1px solid #bee1f4;
+    animation: ${pendingAnimation} 2s infinite;
+  }
+`;

--- a/src/Slices/Resource/UI/ResourcesPage/Components/RepairButton.tsx
+++ b/src/Slices/Resource/UI/ResourcesPage/Components/RepairButton.tsx
@@ -1,27 +1,13 @@
-import React, { useContext } from "react";
-import { Button } from "@patternfly/react-core";
-import { ActionDisabledTooltip } from "@/UI/Components";
-import { DependencyContext } from "@/UI/Dependency";
+import React from "react";
 import { words } from "@/UI/words";
+import { ResourcePageActionButton } from "./ActionButton";
 
 export const RepairButton: React.FC = () => {
-  const { environmentModifier, commandResolver } =
-    useContext(DependencyContext);
-  const isHalted = environmentModifier.useIsHalted();
-  const trigger = commandResolver.useGetTrigger<"Repair">({ kind: "Repair" });
   return (
-    <ActionDisabledTooltip
-      isDisabled={isHalted}
-      ariaLabel={words("resources.deploySummary.repair")}
-      tooltipContent={words("environment.halt.tooltip")}
-    >
-      <Button
-        variant="secondary"
-        isDisabled={isHalted}
-        onClick={() => trigger()}
-      >
-        {words("resources.deploySummary.repair")}
-      </Button>
-    </ActionDisabledTooltip>
+    <ResourcePageActionButton
+      kind="Repair"
+      tooltip={words("resources.repair.tooltip")}
+      textContent={words("resources.deploySummary.repair")}
+    />
   );
 };

--- a/src/Slices/Resource/UI/ResourcesPage/Page.test.tsx
+++ b/src/Slices/Resource/UI/ResourcesPage/Page.test.tsx
@@ -749,6 +749,14 @@ test("Given the ResourcesView When clicking on deploy, then the approriate backe
     );
   });
 
+  expect(
+    await screen.findByRole("button", {
+      name: words("resources.deploySummary.deploy"),
+    }),
+  ).toBeDisabled();
+
+  expect(screen.getByTestId("dot-indication")).toBeInTheDocument();
+
   expect(apiHelper.pendingRequests).toEqual([
     {
       method: "POST",
@@ -780,6 +788,12 @@ test("Given the ResourcesView When clicking on repair, then the approriate backe
       }),
     );
   });
+
+  expect(
+    await screen.findByRole("button", {
+      name: words("resources.deploySummary.repair"),
+    }),
+  ).toBeDisabled();
 
   expect(apiHelper.pendingRequests).toEqual([
     {

--- a/src/UI/words.tsx
+++ b/src/UI/words.tsx
@@ -380,6 +380,10 @@ const dict = {
   "resources.facts.columns.name": "Name",
   "resources.facts.columns.updated": "Last Updated",
   "resources.facts.columns.value": "Value",
+  "resources.deploy.tooltip":
+    "Request the agents to check the current state of each resource in a state different from the deployed state and make the current state of those resources in line with the desired state.",
+  "resources.repair.tooltip":
+    "Request the agents to check the current state of each resource and make the current state in-line with the desired state.",
 
   /** Compile report related text */
   "compileReports.title": "Compile Reports",


### PR DESCRIPTION
# Description

Disabling and adding an indication on the Repair and Deploy buttons when they are being clicked. I didn't want to affect too much the current implementation of the ActionDisabledTooltip component, hence the two different outputs for the ActionButton for the ResourcePage. Normal Tooltip component from Paternfly doesn't show on disabled items. 

closes *#4349*

https://github.com/inmanta/web-console/assets/44098050/78785e7d-12f0-47cc-8705-33812fb99bac




