### PR TITLE
4708 add a warning for expired license

### DIFF
--- a/changelogs/unreleased/4708-license-banner.yml
+++ b/changelogs/unreleased/4708-license-banner.yml
@@ -1,0 +1,8 @@
+change-type: patch
+description: 'A banner will now be shown if your license is about to expire, or if it already has expired.'
+issue-nr: 4708
+destination-branches:
+- master
+- iso6
+sections: 
+  minor-improvement: "{{description}}"

--- a/cypress/e2e/scenario-2.4-expert-mode.cy.js
+++ b/cypress/e2e/scenario-2.4-expert-mode.cy.js
@@ -119,7 +119,7 @@ if (Cypress.env("edition") === "iso") {
         .find('[aria-label="SaveAction"]')
         .click();
       cy.get('[aria-label="Warning"]').should("not.exist");
-      cy.get(".pf-c-banner.pf-m-danger.pf-m-sticky")
+      cy.get("[id='expert-mode-banner']")
         .should("exist")
         .and("contain", "LSM expert mode is enabled, proceed with caution.");
 
@@ -351,7 +351,7 @@ if (Cypress.env("edition") === "iso") {
         .find('[aria-label="SaveAction"]')
         .click();
       cy.get('[aria-label="Warning"]').should("not.exist");
-      cy.get(".pf-c-banner.pf-m-danger.pf-m-sticky").should("not.exist");
+      cy.get("[id='expert-mode-banner']").should("not.exist");
     });
   });
 }

--- a/src/Core/Contracts/FeatureManager.ts
+++ b/src/Core/Contracts/FeatureManager.ts
@@ -9,4 +9,10 @@ export interface FeatureManager {
   getJsonParser(): JsonParserId;
   getCommitHash(): string;
   getAppVersion(): string;
+  getLicenseInformation(): StatusLicense;
+}
+
+export interface StatusLicense {
+  cert_valid_until?: string;
+  entitlement_valid_until?: string;
 }

--- a/src/Core/Contracts/FeatureManager.ts
+++ b/src/Core/Contracts/FeatureManager.ts
@@ -9,7 +9,7 @@ export interface FeatureManager {
   getJsonParser(): JsonParserId;
   getCommitHash(): string;
   getAppVersion(): string;
-  getLicenseInformation(): StatusLicense;
+  getLicenseInformation(): StatusLicense | undefined;
 }
 
 export interface StatusLicense {

--- a/src/Data/Common/PrimaryFeatureManager.ts
+++ b/src/Data/Common/PrimaryFeatureManager.ts
@@ -5,6 +5,7 @@ import {
   RemoteData,
   ServerStatus,
   StateHelper,
+  StatusLicense,
 } from "@/Core";
 import { VoidLogger } from "./VoidLogger";
 
@@ -71,5 +72,13 @@ export class PrimaryFeatureManager implements FeatureManager {
 
   getEdition(): string {
     return this.get().edition;
+  }
+
+  getLicenseInformation(): StatusLicense | undefined {
+    const serverStatus = this.get();
+    const licenceInformation = serverStatus.slices.find(
+      (slice) => slice.name === "license.license",
+    );
+    return licenceInformation?.status;
   }
 }

--- a/src/Test/Mock/MockFeatureManager.ts
+++ b/src/Test/Mock/MockFeatureManager.ts
@@ -1,4 +1,4 @@
-import { FeatureManager, JsonParserId } from "@/Core";
+import { FeatureManager, JsonParserId, StatusLicense } from "@/Core";
 
 export class MockFeatureManager implements FeatureManager {
   getCommitHash(): string {
@@ -31,6 +31,13 @@ export class MockFeatureManager implements FeatureManager {
 
   getEdition(): string {
     return "Standard Edition";
+  }
+
+  getLicenseInformation(): StatusLicense {
+    return {
+      cert_valid_until: "2025-10-01T08:59:00.000000",
+      entitlement_valid_until: "2021-11-01T19:04:14.000000",
+    };
   }
 }
 
@@ -65,5 +72,12 @@ export class MockEditableFeatureManager implements FeatureManager {
 
   getEdition(): string {
     return "Open Source";
+  }
+
+  getLicenseInformation(): StatusLicense {
+    return {
+      cert_valid_until: "2025-10-01T08:59:00.000000",
+      entitlement_valid_until: "2021-11-01T19:04:14.000000",
+    };
   }
 }

--- a/src/UI/Components/CodeHighlighter/index.tsx
+++ b/src/UI/Components/CodeHighlighter/index.tsx
@@ -147,11 +147,13 @@ export const CodeHighlighter: React.FC<Props> = ({
           </SidebarButton>
         )}
       </ToggleTooltip>
-      <Tooltip content={words("codehighlighter.scrollToBottom")}>
-        <SidebarButton variant="plain" onClick={resumeAutoScroll}>
-          <LongArrowAltDownIcon />
-        </SidebarButton>
-      </Tooltip>
+      {scrollBottom && (
+        <Tooltip content={words("codehighlighter.scrollToBottom")}>
+          <SidebarButton variant="plain" onClick={resumeAutoScroll}>
+            <LongArrowAltDownIcon />
+          </SidebarButton>
+        </Tooltip>
+      )}
       <IconSettings actions={dropdownActions} />
     </>
   );

--- a/src/UI/Components/ExpertBanner/ExpertBanner.tsx
+++ b/src/UI/Components/ExpertBanner/ExpertBanner.tsx
@@ -7,7 +7,7 @@ export const ExpertBanner = () => {
 
   return environmentModifier.useIsExpertModeEnabled() ? (
     <React.Fragment>
-      <Banner isSticky variant="danger">
+      <Banner isSticky variant="danger" id="expert-mode-banner">
         LSM expert mode is enabled, proceed with caution.
       </Banner>
     </React.Fragment>

--- a/src/UI/Components/LicenseBanner/LicenseBanner.tsx
+++ b/src/UI/Components/LicenseBanner/LicenseBanner.tsx
@@ -10,8 +10,8 @@ export const LicenseBanner: React.FC = () => {
   const { featureManager } = useContext(DependencyContext);
   const status = featureManager.getLicenseInformation();
   const expirationMessage = getExpirationMessage(
-    status.entitlement_valid_until,
-    status.cert_valid_until,
+    status?.entitlement_valid_until,
+    status?.cert_valid_until,
   );
 
   return expirationMessage ? (
@@ -47,6 +47,10 @@ const checkExpiration = (validUntilDate: string) => {
  * or either null if not expired.
  */
 const getExpirationMessage = (entitlementDate, certificateDate) => {
+  if (!entitlementDate || !certificateDate) {
+    return null;
+  }
+
   const diffTimeCertificate = checkExpiration(certificateDate);
   const diffTimeEntitlement = checkExpiration(entitlementDate);
 

--- a/src/UI/Components/LicenseBanner/LicenseBanner.tsx
+++ b/src/UI/Components/LicenseBanner/LicenseBanner.tsx
@@ -1,0 +1,65 @@
+import React, { useContext } from "react";
+import { Banner } from "@patternfly/react-core";
+import { DependencyContext } from "@/UI/Dependency";
+import { words } from "@/UI/words";
+
+/**
+ * @returns Either a banner informing the user his/her license has expired.
+ */
+export const LicenseBanner: React.FC = () => {
+  const { featureManager } = useContext(DependencyContext);
+  const status = featureManager.getLicenseInformation();
+  const expirationMessage = getExpirationMessage(
+    status.entitlement_valid_until,
+    status.cert_valid_until,
+  );
+
+  return expirationMessage ? (
+    <Banner isSticky variant="danger">
+      {expirationMessage}
+    </Banner>
+  ) : null;
+};
+
+/**
+ * cert_valid_until
+ * entitlement_valid_until
+ *
+ * Will calculate the time difference in days between today and the arg date.
+ * If the return value is negative, this means the date is expired.
+ * @param validUntilDate
+ * @returns number
+ */
+const checkExpiration = (validUntilDate: string) => {
+  const today = new Date();
+  const validityDate = new Date(validUntilDate);
+
+  const timeDifference = validityDate.getTime() - today.getTime();
+
+  return Math.round(timeDifference / 86400000);
+};
+
+/**
+ *
+ * @param entitlementDate
+ * @param certificateDate
+ * @returns either a message containing the amount of days the certificate has expired,
+ * or either null if not expired.
+ */
+const getExpirationMessage = (entitlementDate, certificateDate) => {
+  const diffTimeCertificate = checkExpiration(certificateDate);
+  const diffTimeEntitlement = checkExpiration(entitlementDate);
+
+  if (diffTimeCertificate < 0) {
+    return words("banner.certificate.expired")(Math.abs(diffTimeCertificate));
+  }
+  if (diffTimeCertificate < 15) {
+    return words("banner.certificate.will.expire")(
+      Math.abs(diffTimeCertificate),
+    );
+  } else if (diffTimeEntitlement < 0) {
+    return words("banner.entitlement.expired")(Math.abs(diffTimeEntitlement));
+  }
+
+  return null;
+};

--- a/src/UI/Components/LicenseBanner/index.tsx
+++ b/src/UI/Components/LicenseBanner/index.tsx
@@ -1,0 +1,1 @@
+export * from "./LicenseBanner";

--- a/src/UI/Dependency/Dummy/DummyFeatureManager.ts
+++ b/src/UI/Dependency/Dummy/DummyFeatureManager.ts
@@ -1,4 +1,4 @@
-import { FeatureManager, JsonParserId } from "@/Core";
+import { FeatureManager, JsonParserId, StatusLicense } from "@/Core";
 
 export class DummyFeatureManager implements FeatureManager {
   getCommitHash(): string {
@@ -23,6 +23,9 @@ export class DummyFeatureManager implements FeatureManager {
     throw new Error("Method not implemented.");
   }
   getServerMajorVersion(): string {
+    throw new Error("Method not implemented.");
+  }
+  getLicenseInformation(): StatusLicense {
     throw new Error("Method not implemented.");
   }
 }

--- a/src/UI/Root/Components/PageFrame/PageFrame.tsx
+++ b/src/UI/Root/Components/PageFrame/PageFrame.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Page } from "@patternfly/react-core";
+import { LicenseBanner } from "@/UI/Components/LicenseBanner";
 import { Header } from "@/UI/Root/Components/Header";
 import { PageBreadcrumbs } from "@/UI/Root/Components/PageBreadcrumbs";
 import { Sidebar } from "@/UI/Root/Components/Sidebar";
@@ -21,23 +22,26 @@ export const PageFrame: React.FC<React.PropsWithChildren<Props>> = ({
   } = useDrawer(Boolean(environmentId));
 
   return (
-    <Page
-      {...{
-        notificationDrawer,
-        onNotificationDrawerExpand,
-        isNotificationDrawerExpanded,
-      }}
-      isManagedSidebar
-      breadcrumb={<PageBreadcrumbs />}
-      header={
-        <Header
-          {...{ onNotificationsToggle }}
-          noEnv={!Boolean(environmentId)}
-        />
-      }
-      sidebar={<Sidebar environment={environmentId} />}
-    >
-      {children}
-    </Page>
+    <>
+      <LicenseBanner />
+      <Page
+        {...{
+          notificationDrawer,
+          onNotificationDrawerExpand,
+          isNotificationDrawerExpanded,
+        }}
+        isManagedSidebar
+        breadcrumb={<PageBreadcrumbs />}
+        header={
+          <Header
+            {...{ onNotificationsToggle }}
+            noEnv={!Boolean(environmentId)}
+          />
+        }
+        sidebar={<Sidebar environment={environmentId} />}
+      >
+        {children}
+      </Page>
+    </>
   );
 };

--- a/src/UI/Styles/Global.ts
+++ b/src/UI/Styles/Global.ts
@@ -27,6 +27,7 @@ export const GlobalStyles = createGlobalStyle`
   }
   .pf-c-page__sidebar-body {
     height: 100%;
+    max-height: calc(100vh - var(--pf-c-page__header--MinHeight) - 60px);
   }
   .pf-c-chip__text {
     max-width: fit-content;

--- a/src/UI/words.tsx
+++ b/src/UI/words.tsx
@@ -623,6 +623,16 @@ const dict = {
     "Are you sure you want to leave this page? You have unsaved changes",
 
   /**
+   * Banners
+   */
+  "banner.entitlement.expired": (days: number) =>
+    `Your entitlement certificate has expired ${days} days ago!`,
+  "banner.certificate.expired": (days: number) =>
+    `Your certificate has expired ${days} days ago!`,
+  "banner.certificate.will.expire": (days: number) =>
+    `Your certificate will expire in ${days} days.`,
+
+  /**
    * Common
    */
   "common.serviceInstance.select": (attribute: string) =>

--- a/src/UI/words.tsx
+++ b/src/UI/words.tsx
@@ -626,11 +626,11 @@ const dict = {
    * Banners
    */
   "banner.entitlement.expired": (days: number) =>
-    `Your entitlement certificate has expired ${days} days ago!`,
+    `Your license has expired ${days} days ago!`,
   "banner.certificate.expired": (days: number) =>
-    `Your certificate has expired ${days} days ago!`,
+    `Your license has expired ${days} days ago!`,
   "banner.certificate.will.expire": (days: number) =>
-    `Your certificate will expire in ${days} days.`,
+    `Your license will expire in ${days} days.`,
 
   /**
    * Common


### PR DESCRIPTION
# Description

The banner will be displayed from the moment either the license or the entitlement certificate is expired. A different message is displayed 15 days before the expiration date of the License, informing the user his license is about to expire. 

closes *#4708*

![image](https://github.com/inmanta/web-console/assets/44098050/2e68a7e5-98de-473a-939e-8e0ec7152afb)
