### PR TITLE
Build(deps-dev): Bump @types/react-dom from 18.2.7 to 18.2.8 (#5164)

### DIFF
--- a/changelogs/unreleased/5164-dependabot.yml
+++ b/changelogs/unreleased/5164-dependabot.yml
@@ -1,0 +1,6 @@
+change-type: patch
+description: 'Build(deps-dev): Bump @types/react-dom from 18.2.7 to 18.2.8'
+destination-branches:
+- master
+- iso6
+sections: {}

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@types/lodash-es": "^4.17.8",
     "@types/node": "^20.6.0",
     "@types/qs": "^6.9.8",
-    "@types/react-dom": "^18.2.7",
+    "@types/react-dom": "^18.2.8",
     "@types/react-router-dom": "^5.3.3",
     "@types/react-syntax-highlighter": "^15.5.7",
     "@types/styled-components": "^5.1.26",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1337,7 +1337,7 @@ __metadata:
     "@types/lodash-es": ^4.17.8
     "@types/node": ^20.6.0
     "@types/qs": ^6.9.8
-    "@types/react-dom": ^18.2.7
+    "@types/react-dom": ^18.2.8
     "@types/react-router-dom": ^5.3.3
     "@types/react-syntax-highlighter": ^15.5.7
     "@types/styled-components": ^5.1.26
@@ -2778,12 +2778,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react-dom@npm:^18.2.7":
-  version: 18.2.7
-  resolution: "@types/react-dom@npm:18.2.7"
+"@types/react-dom@npm:^18.2.8":
+  version: 18.2.8
+  resolution: "@types/react-dom@npm:18.2.8"
   dependencies:
     "@types/react": "*"
-  checksum: e02ea908289a7ad26053308248d2b87f6aeafd73d0e2de2a3d435947bcea0422599016ffd1c3e38ff36c42f5e1c87c7417f05b0a157e48649e4a02f21727d54f
+  checksum: d36264631028d021b73cd9e015f10b95c4959ae1ce8f7a7419f318d1f05b1d063e6afffcd2a349a6bccd64ccc9ee9d2d976e1f0437643f0e7db621fa035bca65
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Pull request opened by the merge tool on behalf of #5164