### PR TITLE
Improve hover behavior on icons in codeHighlight blocks

### DIFF
--- a/changelogs/unreleased/4916-Firefox-hover-issue.yml
+++ b/changelogs/unreleased/4916-Firefox-hover-issue.yml
@@ -1,0 +1,6 @@
+description: Improve the behavior on Firefox when hovering over code-block icons.
+issue-nr: 4916
+change-type: patch
+destination-branches: [master, iso6]
+sections:
+  bugfix: "{{description}}"

--- a/src/Slices/CompileDetails/UI/CompileStageReportTableRow.tsx
+++ b/src/Slices/CompileDetails/UI/CompileStageReportTableRow.tsx
@@ -64,7 +64,11 @@ export const CompileStageReportTableRow: React.FC<Props> = ({
                 {words("compileDetails.stages.columns.command")}
               </DescriptionListTerm>
               <DescriptionListDescription>
-                <CodeHighlighter code={row.command} language="bash" />
+                <CodeHighlighter
+                  keyId="command"
+                  code={row.command}
+                  language="bash"
+                />
               </DescriptionListDescription>
             </DescriptionListGroup>
             <DescriptionListGroup>
@@ -81,6 +85,7 @@ export const CompileStageReportTableRow: React.FC<Props> = ({
               </DescriptionListTerm>
               <DescriptionListDescription>
                 <CodeHighlighter
+                  keyId="outstream"
                   scrollBottom
                   code={row.outstream}
                   language="python"
@@ -93,6 +98,7 @@ export const CompileStageReportTableRow: React.FC<Props> = ({
               </DescriptionListTerm>
               <DescriptionListDescription>
                 <CodeHighlighter
+                  keyId="error-stream"
                   scrollBottom
                   code={row.errstream}
                   language="python"

--- a/src/UI/Components/CodeHighlighter/index.tsx
+++ b/src/UI/Components/CodeHighlighter/index.tsx
@@ -21,7 +21,7 @@ import bash from "react-syntax-highlighter/dist/esm/languages/hljs/bash";
 import json from "react-syntax-highlighter/dist/esm/languages/hljs/json";
 import xml from "react-syntax-highlighter/dist/esm/languages/hljs/xml";
 import docco from "react-syntax-highlighter/dist/esm/styles/hljs/docco";
-import styled, { css } from "styled-components";
+import styled from "styled-components";
 import { scrollRowIntoView } from "@/UI/Utils";
 import { words } from "@/UI/words";
 
@@ -30,6 +30,7 @@ SyntaxHighlighter.registerLanguage("xml", xml);
 SyntaxHighlighter.registerLanguage("bash", bash);
 
 interface Props {
+  keyId: string;
   code: string;
   language: "json" | "xml" | "text" | "python" | "bash";
   scrollBottom?: boolean;
@@ -41,6 +42,7 @@ export const CodeHighlighter: React.FC<Props> = ({
   language,
   scrollBottom = false,
   close,
+  keyId,
 }) => {
   const [copied, setCopied] = useState(false);
   const [zoomed, setZoomed] = useState(false);
@@ -61,34 +63,28 @@ export const CodeHighlighter: React.FC<Props> = ({
 
   const dropdownActions = [
     <ToggleTooltip
-      id="wrap-longlines-tooltip"
       enabled={wrapLongLines}
       enabledContent={words("codehighlighter.lineWrapping.off")}
       disabledContent={words("codehighlighter.lineWrapping.on")}
-      key="wraplonglines"
+      key={`wraplonglines-${keyId}`}
     >
-      <StyledDropdownItem
-        $isEnabled={wrapLongLines}
-        onClick={() => setWraplongLines(!wrapLongLines)}
-      >
-        <TextWidthIcon />
-      </StyledDropdownItem>
+      <DropdownItem onClick={() => setWraplongLines(!wrapLongLines)}>
+        <Icon style={{ opacity: wrapLongLines ? "1" : "0.4" }}>
+          <TextWidthIcon />
+        </Icon>
+      </DropdownItem>
     </ToggleTooltip>,
     <ToggleTooltip
-      id="show-linenumbers-tooltip"
       enabled={showLineNumbers}
       enabledContent={words("codehighlighter.lineNumbers.off")}
       disabledContent={words("codehighlighter.lineNumbers.on")}
-      key="showlinenumbers"
+      key={`showlinenumbers-${keyId}`}
     >
-      <StyledDropdownItem
-        $isEnabled={showLineNumbers}
-        onClick={() => {
-          setShowLineNumbers(!showLineNumbers);
-        }}
-      >
-        <ListOlIcon />
-      </StyledDropdownItem>
+      <DropdownItem onClick={() => setShowLineNumbers(!showLineNumbers)}>
+        <Icon style={{ opacity: showLineNumbers ? "1" : "0.4" }}>
+          <ListOlIcon />
+        </Icon>
+      </DropdownItem>
     </ToggleTooltip>,
   ];
 
@@ -102,7 +98,6 @@ export const CodeHighlighter: React.FC<Props> = ({
   const actions = (
     <>
       <ToggleTooltip
-        id="copy-tooltip"
         enabled={copied}
         disabledContent="Copy to clipboard"
         enabledContent="Successfully copied to clipboard!"
@@ -117,7 +112,6 @@ export const CodeHighlighter: React.FC<Props> = ({
         </Icon>
       )}
       <ToggleTooltip
-        id="zoomed-tooltip"
         enabled={zoomed}
         enabledContent={words("codehighlighter.zoom.off")}
         disabledContent={words("codehighlighter.zoom.on")}
@@ -292,8 +286,8 @@ const BorderedArea = styled.div`
 const IconSettings: React.FC<{ actions: JSX.Element[] }> = ({ actions }) => {
   const [isOpen, setIsOpen] = useState(false);
   return (
-    <CenteredDropdown
-      toggle={<CenteredToggle onToggle={() => setIsOpen(!isOpen)} />}
+    <Dropdown
+      toggle={<KebabToggle onToggle={() => setIsOpen(!isOpen)} />}
       isOpen={isOpen}
       isPlain
       dropdownItems={actions}
@@ -301,39 +295,18 @@ const IconSettings: React.FC<{ actions: JSX.Element[] }> = ({ actions }) => {
   );
 };
 
-const StyledDropdownItem = styled(DropdownItem)<{ $isEnabled: boolean }>`
-  ${({ $isEnabled }) => ($isEnabled ? "opacity: 1;" : "opacity: 0.4;")}
-`;
-
-const centeredSidebarStyles = css`
-  padding-left: 0;
-  padding-right: 0;
-  margin: auto;
-  width: 100%;
-`;
-
-const CenteredDropdown = styled(Dropdown)`
-  ${centeredSidebarStyles}
-`;
-const CenteredToggle = styled(KebabToggle)`
-  ${centeredSidebarStyles}
-`;
-
 const ToggleTooltip: React.FC<{
-  id: string;
   enabled: boolean;
   enabledContent: string;
   disabledContent: string;
   children?: React.ReactNode;
-}> = ({ id, enabled, enabledContent, disabledContent, children }) => {
+}> = ({ enabled, enabledContent, disabledContent, children }) => {
   return (
     <Tooltip
-      id={id}
       entryDelay={200}
       animationDuration={0}
       position="left"
       content={<div>{enabled ? enabledContent : disabledContent}</div>}
-      style={{ width: "150px" }}
     >
       <>{children}</>
     </Tooltip>

--- a/src/UI/Components/DesiredStateAttributes/AttributeList.tsx
+++ b/src/UI/Components/DesiredStateAttributes/AttributeList.tsx
@@ -76,12 +76,22 @@ const AttributeValue: React.FC<{
       return <FileBlock hash={attribute.value} />;
 
     case "Json":
-      return <CodeHighlighter code={attribute.value} language="json" />;
+      return (
+        <CodeHighlighter keyId="json" code={attribute.value} language="json" />
+      );
 
     case "Xml":
-      return <CodeHighlighter code={attribute.value} language="xml" />;
+      return (
+        <CodeHighlighter keyId="xml" code={attribute.value} language="xml" />
+      );
     case "Python":
-      return <CodeHighlighter code={attribute.value} language="python" />;
+      return (
+        <CodeHighlighter
+          keyId="python"
+          code={attribute.value}
+          language="python"
+        />
+      );
   }
 };
 

--- a/src/UI/Components/DesiredStateAttributes/FileBlock.tsx
+++ b/src/UI/Components/DesiredStateAttributes/FileBlock.tsx
@@ -54,7 +54,12 @@ export const FileBlock: React.FC<{ hash: string }> = ({ hash }) => {
             </Alert>
           ),
           success: (content) => (
-            <CodeHighlighter code={content} language="text" close={close} />
+            <CodeHighlighter
+              keyId="fileblock"
+              code={content}
+              language="text"
+              close={close}
+            />
           ),
         },
         fileContent,

--- a/src/UI/Components/ResourceStatus/ColorConfig.ts
+++ b/src/UI/Components/ResourceStatus/ColorConfig.ts
@@ -1,13 +1,4 @@
 import { LabelProps } from "@patternfly/react-core";
-import {
-  global_danger_color_100,
-  global_Color_100,
-  global_disabled_color_200,
-  global_info_color_100,
-  global_palette_purple_300,
-  global_success_color_100,
-  global_warning_color_100,
-} from "@patternfly/react-tokens";
 import { Resource } from "@/Core";
 
 export const labelColorConfig: Record<
@@ -28,15 +19,16 @@ export const labelColorConfig: Record<
 };
 
 export const colorConfig: Record<Resource.Status, string> = {
-  [Resource.Status.deployed]: global_success_color_100.var,
-  [Resource.Status.skipped]: global_Color_100.var,
-  [Resource.Status.skipped_for_undefined]: global_Color_100.var,
-  [Resource.Status.cancelled]: global_Color_100.var,
-  [Resource.Status.failed]: global_danger_color_100.var,
-  [Resource.Status.unavailable]: global_warning_color_100.var,
-  [Resource.Status.undefined]: global_warning_color_100.var,
-  [Resource.Status.deploying]: global_info_color_100.var,
-  [Resource.Status.available]: global_disabled_color_200.var,
-  [Resource.Status.dry]: global_palette_purple_300.var,
-  [Resource.Status.orphaned]: global_palette_purple_300.var,
+  [Resource.Status.deployed]: "var(--pf-v5-global--success-color--100)",
+  [Resource.Status.skipped]: "var(--pf-v5-global--palette--cyan-100)",
+  [Resource.Status.skipped_for_undefined]:
+    "var(--pf-v5-global--palette--cyan-100)",
+  [Resource.Status.cancelled]: "var(--pf-v5-global--palette--cyan-100)",
+  [Resource.Status.failed]: "var(--pf-v5-global--danger-color--100)",
+  [Resource.Status.unavailable]: "var(--pf-v5-global--warning-color--100)",
+  [Resource.Status.undefined]: "var(--pf-v5-global--warning-color--100)",
+  [Resource.Status.deploying]: "var(--pf-v5-global--info-color--100)",
+  [Resource.Status.available]: "var(--pf-v5-global--disabled-color--200)",
+  [Resource.Status.dry]: "var(--pf-v5-global--palette--purple-300)",
+  [Resource.Status.orphaned]: "var(--pf-v5-global--palette--purple-300)",
 };

--- a/src/UI/Components/TextWithCopy/TextWithCopy.tsx
+++ b/src/UI/Components/TextWithCopy/TextWithCopy.tsx
@@ -22,7 +22,7 @@ export const TextWithCopy: React.FC<React.PropsWithChildren<Props>> = ({
 };
 
 const StyledCopyIcon = styled(ClipboardCopyButton)`
-  opacity: 0;
+  opacity: 0.6;
   padding-left: 5px;
 `;
 


### PR DESCRIPTION
# Description

I tried to figure out which was the root cause of the problem, I changed the implementations a few times, removed elements but it's still not clear what caused the glitches. It only happens when the codeblocks contain a lot of information, impacting performance. Most of the glitching could be either related to the Tooltips (they have minimal glitches on the PF site on Firefox) combined with the styled components "´css" declaration. I removed any superficial wrapper/customization of elements.  

It does still glitch once in a while when clicking on the kebab-menu and then clicking outside of it multiple times. This might be resolved once the deprecated version of the kebab menu is updated. But since I've been tackling that in another ticket, I kept it separated. 


https://github.com/inmanta/web-console/assets/44098050/ea1dcce3-af45-4875-b0f9-923710ca350e

