### PR TITLE
5181 repair oss e2e

### DIFF
--- a/changelogs/unreleased/5181-update-oss-tests.yml
+++ b/changelogs/unreleased/5181-update-oss-tests.yml
@@ -1,0 +1,5 @@
+description: "Update the oss test suite."
+issue-nr: 5181
+change-type: patch
+destination-branches: [master, iso6]
+

--- a/cypress/e2e/scenario-4-desired-state.cy.js
+++ b/cypress/e2e/scenario-4-desired-state.cy.js
@@ -291,13 +291,18 @@ describe("Scenario 4 Desired State", () => {
     cy.get(".pf-v5-c-dropdown__menu-item").contains("Delete").click();
     cy.get("#submit").click();
 
-    // Only the active version should remain in the table.
+    // The active version should remain in the table.
     cy.get("@TABLE_LENGTH").then((length) => {
       cy.get("tbody", { timeout: 30000 }).should(
         "have.length",
         isIso ? length - 1 : length + 1,
       );
     });
+
+    cy.get("tbody")
+      .eq(0)
+      .find('[data-label="Status"]')
+      .should("have.text", "active");
 
     // Recompile to get at least one older version ready to promote.
     cy.get("button", { timeout: 60000 }).contains("Recompile").click();

--- a/cypress/e2e/scenario-4-desired-state.cy.js
+++ b/cypress/e2e/scenario-4-desired-state.cy.js
@@ -287,7 +287,7 @@ describe("Scenario 4 Desired State", () => {
       );
     });
 
-    cy.get("tbody").eq(0).find('[aria-label="Actions"]').click();
+    cy.get("tbody").eq(1).find('[aria-label="Actions"]').click();
     cy.get(".pf-v5-c-dropdown__menu-item").contains("Delete").click();
     cy.get("#submit").click();
 

--- a/cypress/e2e/scenario-4-desired-state.cy.js
+++ b/cypress/e2e/scenario-4-desired-state.cy.js
@@ -404,12 +404,19 @@ describe("Scenario 4 Desired State", () => {
     cy.get(".pf-v5-c-card__expandable-content", { timeout: 20000 }).should(
       ($expandableRow) => {
         expect($expandableRow).to.have.length(isIso ? 2 : 5);
+
         expect($expandableRow.eq(0), "first-row").to.have.text(
           "This resource has not been modified.",
         );
-        expect($expandableRow.eq(1), "second-row").to.have.text(
-          "This resource has not been modified.",
-        );
+        if (isIso) {
+          expect($expandableRow.eq(1), "second-row").to.have.text(
+            "next_version-3+4",
+          );
+        } else {
+          expect($expandableRow.eq(1), "second-row").to.have.text(
+            "This resource has not been modified.",
+          );
+        }
       },
     );
 

--- a/cypress/e2e/scenario-5-compile-reports.cy.js
+++ b/cypress/e2e/scenario-5-compile-reports.cy.js
@@ -83,7 +83,7 @@ describe("5 Compile reports", () => {
     cy.get("tbody").should(($tableBody) => {
       const $rows = $tableBody.find("tr");
 
-      expect($rows).to.have.length(isIso ? 1 : 4);
+      expect($rows).to.have.length(isIso ? 1 : 3);
 
       expect($rows.eq(0), "top-row-message").to.contain(
         isIso
@@ -104,7 +104,7 @@ describe("5 Compile reports", () => {
         "Compile triggered from the console",
       );
 
-      expect($rows).length.to.be.at.least(isIso ? 2 : 5);
+      expect($rows).length.to.be.at.least(isIso ? 2 : 4);
     });
 
     // await end of compilation and expect it to be success


### PR DESCRIPTION
# Description

closes #5181 

Some tests weren't accurate, causing it to fail when we updated PF5. 
The test case has been enforced to make sure the top row is in an active status. 
