### PR TITLE
Build(deps-dev): Bump @types/react-syntax-highlighter from 15.5.7 to 15.5.9 (#5221)

### DIFF
--- a/changelogs/unreleased/5221-dependabot.yml
+++ b/changelogs/unreleased/5221-dependabot.yml
@@ -1,0 +1,7 @@
+change-type: patch
+description: 'Build(deps-dev): Bump @types/react-syntax-highlighter from 15.5.7 to
+    15.5.9'
+destination-branches:
+- master
+- iso6
+sections: {}

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@types/qs": "^6.9.8",
     "@types/react-dom": "^18.2.8",
     "@types/react-router-dom": "^5.3.3",
-    "@types/react-syntax-highlighter": "^15.5.7",
+    "@types/react-syntax-highlighter": "^15.5.9",
     "@types/styled-components": "^5.1.26",
     "@types/webpack": "^5.28.2",
     "@types/xml-formatter": "^2.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1339,7 +1339,7 @@ __metadata:
     "@types/qs": ^6.9.8
     "@types/react-dom": ^18.2.8
     "@types/react-router-dom": ^5.3.3
-    "@types/react-syntax-highlighter": ^15.5.7
+    "@types/react-syntax-highlighter": ^15.5.9
     "@types/styled-components": ^5.1.26
     "@types/webpack": ^5.28.2
     "@types/xml-formatter": ^2.1.1
@@ -2861,12 +2861,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react-syntax-highlighter@npm:^15.5.7":
-  version: 15.5.7
-  resolution: "@types/react-syntax-highlighter@npm:15.5.7"
+"@types/react-syntax-highlighter@npm:^15.5.9":
+  version: 15.5.9
+  resolution: "@types/react-syntax-highlighter@npm:15.5.9"
   dependencies:
     "@types/react": "*"
-  checksum: 1918d01baaa9bf485093fb04167d0dc87131be708bd68d32d3f614c0e7dba05de765fc62df139fa1972836b13e27983a2d89552eda5b5a38691a4ec300949648
+  checksum: b03c2b4b62a950f29cb46a5eae95b81add333b0d2b107d1d35c4efe639529ba424dab364d09b3d57ecef0f0394369d6680caaed80872184ebf5fb84749095808
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Pull request opened by the merge tool on behalf of #5221