### PR TITLE
Build(deps-dev): Bump eslint-import-resolver-typescript from 3.6.0 to 3.6.1 (#5227)

### DIFF
--- a/changelogs/unreleased/5227-dependabot.yml
+++ b/changelogs/unreleased/5227-dependabot.yml
@@ -1,0 +1,7 @@
+change-type: patch
+description: 'Build(deps-dev): Bump eslint-import-resolver-typescript from 3.6.0 to
+    3.6.1'
+destination-branches:
+- master
+- iso6
+sections: {}

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "dotenv-webpack": "^8.0.1",
     "eslint": "^8.52.0",
     "eslint-config-prettier": "^9.0.0",
-    "eslint-import-resolver-typescript": "^3.6.0",
+    "eslint-import-resolver-typescript": "^3.6.1",
     "eslint-import-resolver-webpack": "^0.13.7",
     "eslint-plugin-import": "^2.28.1",
     "eslint-plugin-jest-dom": "^5.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1359,7 +1359,7 @@ __metadata:
     easy-peasy: ^6.0.2
     eslint: ^8.52.0
     eslint-config-prettier: ^9.0.0
-    eslint-import-resolver-typescript: ^3.6.0
+    eslint-import-resolver-typescript: ^3.6.1
     eslint-import-resolver-webpack: ^0.13.7
     eslint-plugin-import: ^2.28.1
     eslint-plugin-jest-dom: ^5.0.1
@@ -7011,9 +7011,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-import-resolver-typescript@npm:^3.6.0":
-  version: 3.6.0
-  resolution: "eslint-import-resolver-typescript@npm:3.6.0"
+"eslint-import-resolver-typescript@npm:^3.6.1":
+  version: 3.6.1
+  resolution: "eslint-import-resolver-typescript@npm:3.6.1"
   dependencies:
     debug: ^4.3.4
     enhanced-resolve: ^5.12.0
@@ -7025,7 +7025,7 @@ __metadata:
   peerDependencies:
     eslint: "*"
     eslint-plugin-import: "*"
-  checksum: 57b1b3859149f847e0d4174ff979cf35362d60c951df047f01b96f4c3794a7ea0d4e1ec85be25e610d3706902c3acfb964a66b825c1a55e3ce3a124b9a7a13bd
+  checksum: 454fa0646533050fb57f13d27daf8c71f51b0bb9156d6a461290ccb8576d892209fcc6702a89553f3f5ea8e5b407395ca2e5de169a952c953685f1f7c46b4496
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Pull request opened by the merge tool on behalf of #5227