### PR TITLE
Build(deps-dev): Bump eslint-plugin-testing-library from 5.11.1 to 6.1.0 (#5233)

### DIFF
--- a/changelogs/unreleased/5233-dependabot.yml
+++ b/changelogs/unreleased/5233-dependabot.yml
@@ -1,0 +1,6 @@
+change-type: patch
+description: "Build(deps-dev): Bump eslint-plugin-testing-library from 5.11.1 to 6.1.0"
+destination-branches:
+  - master
+  - iso6
+sections: {}

--- a/changelogs/unreleased/5233-dependabot.yml
+++ b/changelogs/unreleased/5233-dependabot.yml
@@ -1,6 +1,6 @@
 change-type: patch
-description: "Build(deps-dev): Bump eslint-plugin-testing-library from 5.11.1 to 6.1.0"
+description: 'Build(deps-dev): Bump eslint-plugin-testing-library from 5.11.1 to 6.1.0'
 destination-branches:
-  - master
-  - iso6
+- master
+- iso6
 sections: {}

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "eslint-plugin-prettier": "5.0.0",
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",
-    "eslint-plugin-testing-library": "^5.11.1",
+    "eslint-plugin-testing-library": "^6.1.0",
     "fetch-mock": "^9.11.0",
     "file-loader": "^6.2.0",
     "git-revision-webpack-plugin": "^5.0.0",

--- a/src/Slices/Dashboard/UI/GraphCard.test.tsx
+++ b/src/Slices/Dashboard/UI/GraphCard.test.tsx
@@ -24,6 +24,8 @@ describe("Test GraphCard with LineChart component", () => {
         name: words(`dashboard.${availableKeys[1] as MetricName}.title`),
       }),
     ).toBeVisible();
+
+    // eslint-disable-next-line testing-library/no-node-access
     expect(await container.querySelector(".pf-v5-c-chart")).toBeVisible();
   });
 
@@ -44,6 +46,8 @@ describe("Test GraphCard with LineChart component", () => {
         name: words(`dashboard.${availableKeys[6] as MetricName}.title`),
       }),
     ).toBeVisible();
+
+    // eslint-disable-next-line testing-library/no-node-access
     expect(await container.querySelector(".pf-v5-c-chart")).toBeVisible();
   });
 });

--- a/src/UI/Components/Diagram/Canvas.test.tsx
+++ b/src/UI/Components/Diagram/Canvas.test.tsx
@@ -1,3 +1,4 @@
+/*eslint-disable testing-library/no-node-access*/
 import React from "react";
 import { Route, Routes, useLocation } from "react-router-dom";
 import {

--- a/src/UI/Components/PaginationWidget/Indicator.test.tsx
+++ b/src/UI/Components/PaginationWidget/Indicator.test.tsx
@@ -1,3 +1,5 @@
+/*eslint-disable testing-library/no-node-access*/
+
 import React from "react";
 import { screen, render } from "@testing-library/react";
 import { Indicator } from "./Indicator";

--- a/src/UI/Components/ServiceInstanceForm/Components/TextListFormInput.test.tsx
+++ b/src/UI/Components/ServiceInstanceForm/Components/TextListFormInput.test.tsx
@@ -1,3 +1,5 @@
+/*eslint-disable testing-library/no-node-access*/
+
 import React from "react";
 import { TextInputTypes } from "@patternfly/react-core";
 import { act, render, screen } from "@testing-library/react";

--- a/yarn.lock
+++ b/yarn.lock
@@ -1366,7 +1366,7 @@ __metadata:
     eslint-plugin-prettier: 5.0.0
     eslint-plugin-react: ^7.33.2
     eslint-plugin-react-hooks: ^4.6.0
-    eslint-plugin-testing-library: ^5.11.1
+    eslint-plugin-testing-library: ^6.1.0
     fetch-mock: ^9.11.0
     file-loader: ^6.2.0
     file-saver: ^2.0.5
@@ -7182,14 +7182,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-testing-library@npm:^5.11.1":
-  version: 5.11.1
-  resolution: "eslint-plugin-testing-library@npm:5.11.1"
+"eslint-plugin-testing-library@npm:^6.1.0":
+  version: 6.1.0
+  resolution: "eslint-plugin-testing-library@npm:6.1.0"
   dependencies:
     "@typescript-eslint/utils": ^5.58.0
   peerDependencies:
     eslint: ^7.5.0 || ^8.0.0
-  checksum: 9f3fc68ef9f13016a4381b33ab5dbffcc189e5de3eaeba184bcf7d2771faa7f54e59c04b652162fb1c0f83fb52428dd909db5450a25508b94be59eba69fcc990
+  checksum: 67d2f521a6af623c157d05bbefa743d9aa360d5462a9b38a82a79b0ba008cb4d6ba3f604f54ac9d12405c53b6744695fc7fde7875f2b83aa3f85a8ced7687be3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Pull request opened by the merge tool on behalf of #5233