### PR TITLE
adjust duplicate instance based on feedback

### DIFF
--- a/changelogs/unreleased/5166-duplicate-instance-feedback.yml
+++ b/changelogs/unreleased/5166-duplicate-instance-feedback.yml
@@ -1,0 +1,4 @@
+description: Duplicate Instance feature adjust small details
+issue-nr: 5166
+change-type: patch
+destination-branches: [master, iso6]

--- a/src/Slices/DuplicateInstance/UI/DuplicateForm.tsx
+++ b/src/Slices/DuplicateInstance/UI/DuplicateForm.tsx
@@ -8,7 +8,6 @@ import {
 import { AttributeInputConverterImpl } from "@/Data";
 import {
   CreateModifierHandler,
-  Description,
   ToastAlert,
   FieldCreator,
   ServiceInstanceForm,
@@ -71,9 +70,6 @@ export const DuplicateForm: React.FC<Props> = ({ serviceEntity, instance }) => {
           setMessage={setErrorMessage}
         />
       )}
-      <Description withSpace>
-        {words("inventory.addInstance.title")(serviceEntity.name)}
-      </Description>
       <ServiceInstanceForm
         fields={fields}
         onSubmit={onSubmit}

--- a/src/Slices/DuplicateInstance/UI/DuplicateInstancePage.tsx
+++ b/src/Slices/DuplicateInstance/UI/DuplicateInstancePage.tsx
@@ -22,7 +22,7 @@ export const DuplicateInstancePage: React.FC<{
       <ServiceInstanceDescription
         instanceId={instanceId}
         serviceName={serviceEntity.name}
-        getDescription={words("inventory.editInstance.header")}
+        getDescription={words("inventory.duplicateInstance.header")}
         data={data}
         withSpace
       />

--- a/src/Slices/DuplicateInstance/UI/Page.tsx
+++ b/src/Slices/DuplicateInstance/UI/Page.tsx
@@ -8,7 +8,7 @@ const PageWrapper: React.FC<React.PropsWithChildren<unknown>> = ({
   children,
   ...props
 }) => (
-  <PageContainer {...props} title={words("inventory.editInstance.title")}>
+  <PageContainer {...props} title={words("inventory.duplicateInstance.title")}>
     {children}
   </PageContainer>
 );

--- a/src/Slices/ServiceInventory/UI/InstanceRow.tsx
+++ b/src/Slices/ServiceInventory/UI/InstanceRow.tsx
@@ -105,7 +105,7 @@ export const InstanceRow: React.FC<Props> = ({
         <Td dataLabel={words("inventory.column.updatedAt")}>
           <DateWithTooltip timestamp={row.updatedAt} />
         </Td>
-        <Td dataLabel="options">{rowActions}</Td>
+        <Td dataLabel="actions">{rowActions}</Td>
       </StyledRow>
       <Tr
         isExpanded={isExpanded}

--- a/src/Slices/ServiceInventory/UI/Presenters/InventoryTablePresenter.test.ts
+++ b/src/Slices/ServiceInventory/UI/Presenters/InventoryTablePresenter.test.ts
@@ -102,7 +102,7 @@ describe("TablePresenter with Actions", () => {
   test("TablePresenter converts column name to index correctly", () => {
     expect(presenterWithActions.getIndexForColumnName("id")).toEqual(-1);
     expect(presenterWithActions.getIndexForColumnName("state")).toEqual(1);
-    expect(presenterWithActions.getIndexForColumnName("options")).toEqual(6);
+    expect(presenterWithActions.getIndexForColumnName("actions")).toEqual(6);
     expect(presenterWithActions.getIndexForColumnName("history")).toEqual(-1);
     expect(presenterWithActions.getIndexForColumnName(undefined)).toEqual(-1);
   });

--- a/src/Slices/ServiceInventory/UI/Presenters/InventoryTablePresenter.ts
+++ b/src/Slices/ServiceInventory/UI/Presenters/InventoryTablePresenter.ts
@@ -56,7 +56,7 @@ export class InventoryTablePresenter
         displayName: words("inventory.column.updatedAt"),
         apiName: "last_updated",
       },
-      { displayName: words("inventory.column.options"), apiName: "options" },
+      { displayName: words("inventory.column.actions"), apiName: "actions" },
     ];
     this.numberOfColumns = this.columnHeads.length + 1;
   }

--- a/src/UI/words.tsx
+++ b/src/UI/words.tsx
@@ -92,6 +92,7 @@ const dict = {
   "inventory.column.createdAt": "Created",
   "inventory.column.updatedAt": "Updated",
   "inventory.column.options": "Options",
+  "inventory.column.actions": "Actions",
   "inventory.column.resources": "Resources",
   "inventory.tabs.attributes": "Attributes",
   "inventory.tabs.collapse": "Collapse all",
@@ -139,11 +140,14 @@ const dict = {
     amount === 1 ? "1 item" : `${amount} items`,
   "inventory.editInstance.button": "Edit",
   "inventory.editInstance.title": "Edit instance",
+  "inventory.duplicateInstance.title": "Duplicate instance",
   "inventory.editInstance.failed": "Editing instance failed",
   "inventory.editInstance.noAttributes":
     "There are no attributes to edit. Click confirm to move into the update state",
   "inventory.editInstance.header": (instanceId: string) =>
     `Change attributes of instance ${instanceId}`,
+  "inventory.duplicateInstance.header": (instanceId: string) =>
+    `Create an instance based of instance ${instanceId}`,
   "inventory.form.typeHint.list": (listBaseType: string) =>
     `A list of ${listBaseType}s`,
   "inventory.form.typeHint.dict":


### PR DESCRIPTION
# Description

Fixed the title of the duplicate page. And changed the header of the column to be Actions. 
