### PR TITLE
5159 increase default page size logs

### DIFF
--- a/changelogs/unreleased/5159-increase-page-size-logs.yml
+++ b/changelogs/unreleased/5159-increase-page-size-logs.yml
@@ -1,0 +1,8 @@
+change-type: patch
+description: Increase default page size to 100 for Resource logs in the Resource details page.
+issue-nr: 5159
+destination-branches:
+  - master
+  - iso6
+sections:
+  minor-improvement: "{{description}}"

--- a/cypress/e2e/scenario-6-resources.cy.js
+++ b/cypress/e2e/scenario-6-resources.cy.js
@@ -556,6 +556,9 @@ describe("Scenario 6 : Resources", () => {
         15,
       );
 
+      // make sure the default is 100 instead of 20 like on other pages with pagination.
+      cy.get('[aria-label="PaginationWidget"]').should("contain", "1 - 100");
+
       // Expect last log message to be "Setting deployed due to known good status"
       cy.get('[aria-label="ResourceLogRow"]')
         .eq(0)

--- a/src/Core/Domain/PageSize.ts
+++ b/src/Core/Domain/PageSize.ts
@@ -7,7 +7,7 @@ export interface PageSize {
 
 export type Type = PageSize;
 
-const listOfValues: string[] = ["5", "10", "20", "50", "100"];
+const listOfValues: string[] = ["5", "10", "20", "50", "100", "250"];
 
 const valueIsValid = (value: unknown): value is Value =>
   typeof value === "string" && listOfValues.includes(value);
@@ -19,7 +19,7 @@ export const from = (value: string): PageSize => {
 
 export const list = listOfValues.map(from);
 
-export const initial = from("100");
+export const initial = from("20");
 
 export const equals = (a: PageSize, b: PageSize): boolean =>
   a.value === b.value;

--- a/src/Core/Domain/PageSize.ts
+++ b/src/Core/Domain/PageSize.ts
@@ -19,7 +19,7 @@ export const from = (value: string): PageSize => {
 
 export const list = listOfValues.map(from);
 
-export const initial = from("20");
+export const initial = from("100");
 
 export const equals = (a: PageSize, b: PageSize): boolean =>
   a.value === b.value;

--- a/src/Data/Common/UrlState/useUrlStateWithPageSize.ts
+++ b/src/Data/Common/UrlState/useUrlStateWithPageSize.ts
@@ -1,4 +1,5 @@
 import { PageSize } from "@/Core";
+import { from } from "@/Core/Domain/PageSize";
 import { provide, Location, Replace, StateConfig, Update } from "./helpers";
 import { handleUrlState } from "./useUrlState";
 
@@ -9,9 +10,12 @@ export function handleUrlStateWithPageSize(
   location: Location,
   replace: Replace,
 ): [PageSize.Type, Update<PageSize.Type>] {
+  const defaultPageSize =
+    config.route === "ResourceDetails" ? from("100") : PageSize.initial;
+
   return handleUrlState<PageSize.Type>(
     {
-      default: PageSize.initial,
+      default: defaultPageSize,
       key: "pageSize",
       route: config.route,
       serialize: PageSize.serialize,

--- a/src/Slices/ResourceDetails/UI/Tabs/HistoryTab/ResourceHistoryView.test.tsx
+++ b/src/Slices/ResourceDetails/UI/Tabs/HistoryTab/ResourceHistoryView.test.tsx
@@ -109,7 +109,7 @@ test("ResourceHistory shows success table", async () => {
   expect(apiHelper.pendingRequests).toHaveLength(1);
   expect(apiHelper.pendingRequests[0]).toEqual({
     environment: "env",
-    url: `/api/v2/resource/${Resource.encodedId}/history?limit=20&sort=date.desc`,
+    url: `/api/v2/resource/${Resource.encodedId}/history?limit=100&sort=date.desc`,
     method: "GET",
   });
 

--- a/src/Slices/ResourceDetails/UI/Tabs/LogTab/ResourceLogsTable.tsx
+++ b/src/Slices/ResourceDetails/UI/Tabs/LogTab/ResourceLogsTable.tsx
@@ -32,7 +32,7 @@ export const ResourceLogsTable: React.FC<Props> = ({
     route: "ResourceDetails",
   });
 
-  const onSort: OnSort = (event, index, order) => {
+  const onSort: OnSort = (_event, _index, order) => {
     setSort({ ...sort, order });
   };
 

--- a/src/Slices/ResourceDetails/UI/Tabs/LogTab/View.spec.tsx
+++ b/src/Slices/ResourceDetails/UI/Tabs/LogTab/View.spec.tsx
@@ -61,7 +61,7 @@ test("GIVEN ResourceLogsView THEN shows resource logs", async () => {
   expect(apiHelper.pendingRequests).toHaveLength(1);
   expect(apiHelper.pendingRequests[0]).toEqual({
     environment: "env",
-    url: `/api/v2/resource/${Resource.encodedId}/logs?limit=20&sort=timestamp.desc`,
+    url: `/api/v2/resource/${Resource.encodedId}/logs?limit=100&sort=timestamp.desc`,
     method: "GET",
   });
 


### PR DESCRIPTION
# Description

closes #5159 

Increased the default page size for the resource log details. Added coverage in the E2E. 

<img width="707" alt="image" src="https://github.com/inmanta/web-console/assets/44098050/ff04c586-98df-4117-a0ee-11130948fc12">

