### PR TITLE
Build(deps-dev): Bump @types/react-syntax-highlighter from 15.5.9 to 15.5.10 (#5284)

### DIFF
--- a/changelogs/unreleased/5284-dependabot.yml
+++ b/changelogs/unreleased/5284-dependabot.yml
@@ -1,0 +1,7 @@
+change-type: patch
+description: 'Build(deps-dev): Bump @types/react-syntax-highlighter from 15.5.9 to
+    15.5.10'
+destination-branches:
+- master
+- iso6
+sections: {}

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@types/qs": "^6.9.8",
     "@types/react-dom": "^18.2.15",
     "@types/react-router-dom": "^5.3.3",
-    "@types/react-syntax-highlighter": "^15.5.9",
+    "@types/react-syntax-highlighter": "^15.5.10",
     "@types/styled-components": "^5.1.26",
     "@types/webpack": "^5.28.2",
     "@types/xml-formatter": "^2.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1339,7 +1339,7 @@ __metadata:
     "@types/qs": ^6.9.8
     "@types/react-dom": ^18.2.15
     "@types/react-router-dom": ^5.3.3
-    "@types/react-syntax-highlighter": ^15.5.9
+    "@types/react-syntax-highlighter": ^15.5.10
     "@types/styled-components": ^5.1.26
     "@types/webpack": ^5.28.2
     "@types/xml-formatter": ^2.1.1
@@ -2830,12 +2830,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react-syntax-highlighter@npm:^15.5.9":
-  version: 15.5.9
-  resolution: "@types/react-syntax-highlighter@npm:15.5.9"
+"@types/react-syntax-highlighter@npm:^15.5.10":
+  version: 15.5.10
+  resolution: "@types/react-syntax-highlighter@npm:15.5.10"
   dependencies:
     "@types/react": "*"
-  checksum: b03c2b4b62a950f29cb46a5eae95b81add333b0d2b107d1d35c4efe639529ba424dab364d09b3d57ecef0f0394369d6680caaed80872184ebf5fb84749095808
+  checksum: 07da5fa432883130289aac2547bd5ddcb568c33b834983829933067c379ddb9a6de200d10174dabb0b4476ba3fce54761c7c8be1ede8a51cd0c1b1ca9cb6867e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Pull request opened by the merge tool on behalf of #5284