### PR TITLE
Improve inventory table UI

### DIFF
--- a/changelogs/unreleased/5280-inventory-table-improvements.yml
+++ b/changelogs/unreleased/5280-inventory-table-improvements.yml
@@ -1,0 +1,7 @@
+description: "Improve overal UI of the inventory table, and remove the Attribute Summary Column"
+issue-nr: 5280
+change-type: patch
+destination-branches: [master, iso6]
+sections:
+  minor-improvement: "{{description}}"
+  bugfix: "Repair the drilldown height issue for the Actions dropdown."

--- a/cypress/e2e/scenario-2.1-basic-service.cy.js
+++ b/cypress/e2e/scenario-2.1-basic-service.cy.js
@@ -253,7 +253,7 @@ if (Cypress.env("edition") === "iso") {
 
       // delete but cancel deletion in modal
       cy.get('[aria-label="row actions toggle"]', { timeout: 60000 }).click();
-      cy.get(".pf-v5-c-menu__item").contains("More options").click();
+      cy.get(".pf-v5-c-menu__item").contains("More actions").click();
       cy.get(".pf-v5-c-menu__item").contains("Delete").click();
       cy.get(".pf-v5-c-modal-box__title-text").should(
         "contain",
@@ -263,7 +263,7 @@ if (Cypress.env("edition") === "iso") {
 
       // delete the instance.
       cy.get('[aria-label="row actions toggle"]', { timeout: 60000 }).click();
-      cy.get(".pf-v5-c-menu__item").contains("More options").click();
+      cy.get(".pf-v5-c-menu__item").contains("More actions").click();
       cy.get(".pf-v5-c-menu__item").contains("Delete").click();
       cy.get(".pf-v5-c-modal-box__title-text").should(
         "contain",

--- a/cypress/e2e/scenario-2.2-child-parent-service.cy.js
+++ b/cypress/e2e/scenario-2.2-child-parent-service.cy.js
@@ -147,7 +147,7 @@ if (Cypress.env("edition") === "iso") {
 
       // try delete item (Should not be possible)
       cy.get('[aria-label="row actions toggle"]', { timeout: 60000 }).click();
-      cy.get(".pf-v5-c-menu__item").contains("More options").click();
+      cy.get(".pf-v5-c-menu__item").contains("More actions").click();
       cy.get(".pf-v5-c-menu__item").contains("Delete").click();
 
       cy.get(".pf-v5-c-modal-box__title-text").should(
@@ -177,7 +177,7 @@ if (Cypress.env("edition") === "iso") {
 
       // try delete item (Should be possible)
       cy.get('[aria-label="row actions toggle"]', { timeout: 60000 }).click();
-      cy.get(".pf-v5-c-menu__item").contains("More options").click();
+      cy.get(".pf-v5-c-menu__item").contains("More actions").click();
       cy.get(".pf-v5-c-menu__item").contains("Delete").click();
 
       cy.get(".pf-v5-c-modal-box__title-text").should(

--- a/cypress/e2e/scenario-2.3-embedded-entity.cy.js
+++ b/cypress/e2e/scenario-2.3-embedded-entity.cy.js
@@ -171,7 +171,7 @@ if (Cypress.env("edition") === "iso") {
         .should("contain", "up");
 
       cy.get('[aria-label="row actions toggle"]', { timeout: 60000 }).click();
-      cy.get(".pf-v5-c-menu__item").contains("More options").click();
+      cy.get(".pf-v5-c-menu__item").contains("More actions").click();
       cy.get(".pf-v5-c-menu__item").contains("History").click();
 
       // History sub-page should open and be empty then go to Home page
@@ -197,7 +197,7 @@ if (Cypress.env("edition") === "iso") {
 
       // delete but cancel deletion in modal
       cy.get('[aria-label="row actions toggle"]', { timeout: 60000 }).click();
-      cy.get(".pf-v5-c-menu__item").contains("More options").click();
+      cy.get(".pf-v5-c-menu__item").contains("More actions").click();
       cy.get(".pf-v5-c-menu__item").contains("Delete").click();
 
       cy.get(".pf-v5-c-modal-box__title-text").should(
@@ -207,7 +207,7 @@ if (Cypress.env("edition") === "iso") {
       cy.get(".pf-v5-c-form__actions").contains("No").click();
 
       cy.get('[aria-label="row actions toggle"]', { timeout: 60000 }).click();
-      cy.get(".pf-v5-c-menu__item").contains("More options").click();
+      cy.get(".pf-v5-c-menu__item").contains("More actions").click();
       cy.get(".pf-v5-c-menu__item").contains("Delete").click();
 
       cy.get(".pf-v5-c-modal-box__title-text").should(

--- a/cypress/e2e/scenario-2.4-expert-mode.cy.js
+++ b/cypress/e2e/scenario-2.4-expert-mode.cy.js
@@ -335,7 +335,7 @@ if (Cypress.env("edition") === "iso") {
 
       // Click on destroy button
       cy.get('[aria-label="row actions toggle"]', { timeout: 60000 }).click();
-      cy.get(".pf-v5-c-menu__item").contains("More options").click();
+      cy.get(".pf-v5-c-menu__item").contains("More actions").click();
       cy.get(".pf-v5-c-menu__item").contains("Destroy").click();
 
       // Modal title for confirmation of Destroying instance should be visible

--- a/cypress/e2e/scenario-3-service-details.cy.js
+++ b/cypress/e2e/scenario-3-service-details.cy.js
@@ -83,7 +83,7 @@ if (Cypress.env("edition") === "iso") {
       // Expect to be redirected on Service Details: basic-service
       cy.get("h1")
         .contains("Service Details: basic-service")
-        .should("to.be.visible");
+        .should("to.exist");
 
       // Expect  the current tab to be Details
       cy.get(".pf-m-current").should("contain", "Details");
@@ -218,7 +218,7 @@ if (Cypress.env("edition") === "iso") {
       // Expect to be redirected on Service Details: basic-service
       cy.get("h1", { timeout: 20000 })
         .contains("Service Details: basic-service")
-        .should("to.be.visible");
+        .should("to.exist");
 
       // Click on Details tab
       cy.get("button").contains("Details").click();
@@ -308,7 +308,7 @@ if (Cypress.env("edition") === "iso") {
       // Expect to be redirected on Service Details: basic-service
       cy.get("h1")
         .contains("Service Details: basic-service")
-        .should("to.be.visible");
+        .should("to.exist");
 
       // Expect to be Details tab
       cy.get(".pf-m-current").should("contain", "Details");
@@ -342,7 +342,7 @@ if (Cypress.env("edition") === "iso") {
       // Expect to be redirected on Service Details: basic-service
       cy.get("h1", { timeout: 20000 })
         .contains("Service Details: basic-service")
-        .should("to.be.visible");
+        .should("to.exist");
 
       // Go to the callback tab
       cy.get("button").contains("Callbacks").click();
@@ -479,7 +479,7 @@ if (Cypress.env("edition") === "iso") {
       cy.get('[aria-label="row actions toggle"]', { timeout: 60000 })
         .eq(0)
         .click();
-      cy.get(".pf-v5-c-menu__item").contains("More options").click();
+      cy.get(".pf-v5-c-menu__item").contains("More actions").click();
       cy.get(".pf-v5-c-menu__item").contains("Delete").click();
 
       // Confirm deletion
@@ -489,7 +489,7 @@ if (Cypress.env("edition") === "iso") {
       cy.get('[aria-label="row actions toggle"]', { timeout: 60000 })
         .eq(1)
         .click();
-      cy.get(".pf-v5-c-menu__item").contains("More options").click();
+      cy.get(".pf-v5-c-menu__item").contains("More actions").click();
       cy.get(".pf-v5-c-menu__item").contains("Delete").click();
 
       // Confirm deletion

--- a/cypress/e2e/scenario-5-compile-reports.cy.js
+++ b/cypress/e2e/scenario-5-compile-reports.cy.js
@@ -314,7 +314,7 @@ describe("5 Compile reports", () => {
       cy.get('[aria-label="row actions toggle"]', { timeout: 60000 })
         .eq(0)
         .click();
-      cy.get(".pf-v5-c-menu__item").contains("More options").click();
+      cy.get(".pf-v5-c-menu__item").contains("More actions").click();
       cy.get(".pf-v5-c-menu__item").contains("Delete").click();
 
       // confirm modal

--- a/src/Core/Domain/InventoryTable.ts
+++ b/src/Core/Domain/InventoryTable.ts
@@ -23,7 +23,7 @@ export interface Attributes {
 
 export interface Row {
   id: Uuid;
-  attributesSummary: AttributesSummary;
+  attributesSummary?: AttributesSummary;
   attributes: Attributes;
   createdAt: string;
   updatedAt: string;

--- a/src/Slices/ServiceInventory/UI/Components/RowActionsMenu/RowActions.tsx
+++ b/src/Slices/ServiceInventory/UI/Components/RowActionsMenu/RowActions.tsx
@@ -61,9 +61,13 @@ export const RowActions: React.FunctionComponent<InstanceActionsProps> = ({
   // the height of the drilled down menus differ based on how many options preceeds the drilldown. This is a bug on PF side.
   // and setting the insetHeight manually is a workaround for that issue.
   const getInsetHeight = () => {
-    // -100 for each default option present above the first drilldown.
-    let insetHeight = -300;
-    if (features && features.includes("instanceComposer")) {
+    // -100 for each default option present above the first drilldown that is enabled.
+    // diagnose and duplicate are always enabled, so this means it starts at -200
+    let insetHeight = -200;
+    if (features && features.includes("instanceComposer") && !editDisabled) {
+      insetHeight = insetHeight - 100;
+    }
+    if (!editDisabled) {
       insetHeight = insetHeight - 100;
     }
 
@@ -257,7 +261,7 @@ export const RowActions: React.FunctionComponent<InstanceActionsProps> = ({
               </DrilldownMenu>
             }
           >
-            More options
+            More actions
           </MenuItem>
           {environmentModifier.useIsExpertModeEnabled() && (
             <ForceStateAction

--- a/src/Slices/ServiceInventory/UI/Components/RowActionsMenu/RowActions.tsx
+++ b/src/Slices/ServiceInventory/UI/Components/RowActionsMenu/RowActions.tsx
@@ -261,7 +261,7 @@ export const RowActions: React.FunctionComponent<InstanceActionsProps> = ({
               </DrilldownMenu>
             }
           >
-            More actions
+            {words("inventory.actions.drilldown")}
           </MenuItem>
           {environmentModifier.useIsExpertModeEnabled() && (
             <ForceStateAction

--- a/src/Slices/ServiceInventory/UI/InstanceRow.tsx
+++ b/src/Slices/ServiceInventory/UI/InstanceRow.tsx
@@ -3,11 +3,7 @@ import React, { useRef, useState } from "react";
 import { Tbody, Tr, Td, ExpandableRowContent } from "@patternfly/react-table";
 import styled from "styled-components";
 import { Row, ServiceModel, VersionedServiceInstanceIdentifier } from "@/Core";
-import {
-  DateWithTooltip,
-  TextWithCopy,
-  AttributesSummaryView,
-} from "@/UI/Components";
+import { DateWithTooltip, TextWithCopy } from "@/UI/Components";
 import { scrollRowIntoView } from "@/UI/Utils";
 import { words } from "@/UI/words";
 import { DeploymentProgressBar, IdWithCopy } from "./Components";
@@ -81,16 +77,6 @@ export const InstanceRow: React.FC<Props> = ({
           </Td>
         )}
         <Td dataLabel={words("inventory.column.state")}>{state}</Td>
-        <Td
-          dataLabel={words("inventory.column.attributesSummary")}
-          id={`instance-row-summary-${row.id.short}`}
-        >
-          <span ref={rowRef} />
-          <AttributesSummaryView
-            summary={row.attributesSummary}
-            onClick={openTabAndScrollTo(TabKey.Attributes)}
-          />
-        </Td>
         <Td dataLabel={words("inventory.collumn.deploymentProgress")}>
           <ActionWrapper
             id={`instance-row-resources-${row.id.short}`}

--- a/src/Slices/ServiceInventory/UI/InventoryTable.tsx
+++ b/src/Slices/ServiceInventory/UI/InventoryTable.tsx
@@ -36,6 +36,17 @@ export const InventoryTable: React.FC<Props> = ({
       order,
     });
   };
+  // Define the column width in percentage for specific columns.
+  const getColumnWidth = (apiName: string) => {
+    switch (apiName) {
+      case tablePresenter.getIdColumnApiName():
+        return 20;
+      case "deployment_progress":
+        return 30;
+      default:
+        return undefined;
+    }
+  };
   const activeSortIndex = tablePresenter.getIndexForColumnName(sort.name);
   const heads = tablePresenter.getColumnHeads().map((column, columnIndex) => {
     const sortParams = tablePresenter
@@ -53,7 +64,11 @@ export const InventoryTable: React.FC<Props> = ({
         }
       : {};
     return (
-      <Th key={column.displayName} {...sortParams}>
+      <Th
+        width={getColumnWidth(column.apiName)}
+        key={column.displayName}
+        {...sortParams}
+      >
         {column.displayName}
       </Th>
     );

--- a/src/Slices/ServiceInventory/UI/Presenters/InventoryTablePresenter.test.ts
+++ b/src/Slices/ServiceInventory/UI/Presenters/InventoryTablePresenter.test.ts
@@ -102,7 +102,7 @@ describe("TablePresenter with Actions", () => {
   test("TablePresenter converts column name to index correctly", () => {
     expect(presenterWithActions.getIndexForColumnName("id")).toEqual(-1);
     expect(presenterWithActions.getIndexForColumnName("state")).toEqual(1);
-    expect(presenterWithActions.getIndexForColumnName("actions")).toEqual(6);
+    expect(presenterWithActions.getIndexForColumnName("actions")).toEqual(5);
     expect(presenterWithActions.getIndexForColumnName("history")).toEqual(-1);
     expect(presenterWithActions.getIndexForColumnName(undefined)).toEqual(-1);
   });

--- a/src/Slices/ServiceInventory/UI/Presenters/InventoryTablePresenter.ts
+++ b/src/Slices/ServiceInventory/UI/Presenters/InventoryTablePresenter.ts
@@ -26,8 +26,8 @@ export class InventoryTablePresenter
   readonly numberOfColumns: number;
 
   constructor(
-    private datePresenter: DatePresenter,
-    private attributesPresenter: AttributesPresenter,
+    private _datePresenter: DatePresenter,
+    private _attributesPresenter: AttributesPresenter,
     private actionPresenter: ActionPresenter,
     private statePresenter: StatePresenter,
     private serviceIdentity?: string,
@@ -40,10 +40,6 @@ export class InventoryTablePresenter
         apiName: this.getIdColumnApiName(),
       },
       { displayName: words("inventory.column.state"), apiName: "state" },
-      {
-        displayName: words("inventory.column.attributesSummary"),
-        apiName: "attributes",
-      },
       {
         displayName: words("inventory.collumn.deploymentProgress"),
         apiName: "deployment_progress",
@@ -147,11 +143,6 @@ export class InventoryTablePresenter
 
     return {
       id: getUuidFromRaw(id),
-      attributesSummary: this.attributesPresenter.getSummary(
-        candidate_attributes,
-        active_attributes,
-        rollback_attributes,
-      ),
       attributes: {
         candidate: candidate_attributes,
         active: active_attributes,

--- a/src/Slices/ServiceInventory/UI/Spec/AttributesFilter.spec.ts
+++ b/src/Slices/ServiceInventory/UI/Spec/AttributesFilter.spec.ts
@@ -65,14 +65,4 @@ test("GIVEN The Service Inventory WHEN the user filters on AttributeSet ('Active
     name: "InstanceRow-Intro",
   });
   expect(rowsAfter.length).toEqual(1);
-
-  const summary = within(rowsAfter[0]).getByRole("list", {
-    name: "AttributesSummary",
-  });
-
-  expect(
-    within(summary).getByRole("listitem", {
-      name: "Active-NotEmpty",
-    }),
-  ).toBeInTheDocument();
 });

--- a/src/UI/words.tsx
+++ b/src/UI/words.tsx
@@ -94,6 +94,7 @@ const dict = {
   "inventory.column.options": "Options",
   "inventory.column.actions": "Actions",
   "inventory.column.resources": "Resources",
+  "inventory.actions.drilldown": "More actions",
   "inventory.tabs.attributes": "Attributes",
   "inventory.tabs.collapse": "Collapse all",
   "inventory.tabs.expand": "Expand all",


### PR DESCRIPTION
# Description

- Removed the Attribute Summary column.
- Modified the text to drilldown in the actions menu
- Improved calculation for the menu height for the drilldown. 
- Made sure the Deploy Progress column had enough width, made a switch case if we need to finetune the width of other columns. 
- Updated E2E tests for flake in Scenario 3. 

Closes #5280  and #5278 and #4934


https://github.com/inmanta/web-console/assets/44098050/152672e9-3f42-4644-aed2-96fb09a50a75

