### PR TITLE
Feedback on deploy + block Deploy button when no changes/input + redirect

### DIFF
--- a/changelogs/unreleased/5128-composer-feedback.yml
+++ b/changelogs/unreleased/5128-composer-feedback.yml
@@ -1,0 +1,4 @@
+description: "Instance Composer from now has blocked Deploy button if there were no interaction from the user with the services and also user receives feedback in form of ToastAlert, and after succesfull request user will be redirected back to the inventory"
+issue-nr: 5128
+change-type: patch
+destination-branches: [master, iso6]

--- a/src/UI/Components/Diagram/Canvas.tsx
+++ b/src/UI/Components/Diagram/Canvas.tsx
@@ -233,7 +233,6 @@ const Canvas = ({
         onConfirm={(entity, selected) => {
           if (diagramHandlers) {
             if (cellToEdit) {
-              console.log(cellToEdit);
               //deep copy
               const shape = diagramHandlers.editEntity(
                 cellToEdit,

--- a/src/UI/Components/Diagram/components/FormModal.tsx
+++ b/src/UI/Components/Diagram/components/FormModal.tsx
@@ -164,6 +164,7 @@ const FormModal = ({
       },
     ]);
     setPossibleForms(tempPossibleForms);
+
     if (cellView) {
       const entity = cellView.model as ServiceEntityBlock;
       const entityName = entity.getName();
@@ -178,6 +179,7 @@ const FormModal = ({
       );
     }
   }, [services, cellView, onEntityChosen]);
+
   return (
     <StyledModal
       disableFocusTrap

--- a/src/UI/Components/Diagram/components/Toolbar.tsx
+++ b/src/UI/Components/Diagram/components/Toolbar.tsx
@@ -12,10 +12,12 @@ const Toolbar = ({
   openEntityModal,
   handleDeploy,
   serviceName,
+  isDeployDisabled,
 }: {
   openEntityModal: () => void;
   handleDeploy: () => void;
   serviceName: string;
+  isDeployDisabled: boolean;
 }) => {
   const { routeManager } = useContext(DependencyContext);
   const navigate = useNavigate();
@@ -37,7 +39,7 @@ const Toolbar = ({
           alignItems={{ default: "alignItemsCenter" }}
         >
           <FlexItem>
-            <StyledButton
+            <IconButton
               variant="secondary"
               onClick={openEntityModal}
               aria-label="new-entity-button"
@@ -47,19 +49,19 @@ const Toolbar = ({
                 alt="Create new entity icon"
                 aria-label="new-entity-icon"
               />
-            </StyledButton>
+            </IconButton>
           </FlexItem>
           <FlexItem>
             <Spacer />
           </FlexItem>
           <FlexItem>
-            <StyledButton variant="secondary" aria-label="label-toggle-button">
+            <IconButton variant="secondary" aria-label="label-toggle-button">
               <img
                 src={labelIcon}
                 alt="Label Toggle Icon"
                 aria-label="label-toggle-icon"
               />
-            </StyledButton>
+            </IconButton>
           </FlexItem>
         </Flex>
       </FlexItem>
@@ -68,16 +70,17 @@ const Toolbar = ({
           spacer={{ default: "spacerMd" }}
           alignItems={{ default: "alignItemsCenter" }}
         >
-          <StyledButtonTwo
-            variant="tertiary"
-            width={200}
-            onClick={handleRedirect}
-          >
+          <StyledButton variant="tertiary" width={200} onClick={handleRedirect}>
             {words("cancel")}
-          </StyledButtonTwo>
-          <StyledButtonTwo variant="primary" width={200} onClick={handleDeploy}>
+          </StyledButton>
+          <StyledButton
+            variant="primary"
+            width={200}
+            onClick={handleDeploy}
+            isDisabled={isDeployDisabled}
+          >
             {words("deploy")}
-          </StyledButtonTwo>
+          </StyledButton>
         </Flex>
       </FlexItem>
     </Container>
@@ -89,7 +92,7 @@ const Container = styled(Flex)`
   padding: 0 0 20px;
 `;
 
-const StyledButton = styled(Button)`
+const IconButton = styled(Button)`
   --pf-v5-c-button--PaddingTop: 5px;
   --pf-v5-c-button--PaddingRight: 3px;
   --pf-v5-c-button--PaddingBottom: 3px;
@@ -98,7 +101,7 @@ const StyledButton = styled(Button)`
   width: 30px;
 `;
 
-const StyledButtonTwo = styled(Button)`
+const StyledButton = styled(Button)`
   --pf-v5-c-button--PaddingTop: px;
   --pf-v5-c-button--PaddingBottom: 0px;
   width: 101px;

--- a/src/UI/Components/Diagram/helpers.ts
+++ b/src/UI/Components/Diagram/helpers.ts
@@ -331,3 +331,29 @@ export const shapesDataTransform = (
   delete instance.relatedTo;
   return instance;
 };
+
+/**
+ * Function that takes Map of standalone instances that include core, embedded and related entities and
+ * bundle in proper Instance Objects that could be accepted by the order_api request
+ *
+ * @param {Map<string, InstanceForApi>}instances Map of Instances
+ * @param {ServiceModel[]} services
+ * @returns InstanceForApi[]
+ */
+export const bundleInstances = (
+  instances: Map<string, InstanceForApi>,
+  services: ServiceModel[],
+) => {
+  const mapToArray = Array.from(instances, (instance) => instance[1]); //only value, the id is stored in the object anyway
+  const topServicesNames = services.map((service) => service.name);
+  const topInstances = mapToArray.filter((instance) =>
+    topServicesNames.includes(instance.service_entity),
+  );
+  const embeddedInstances = mapToArray.filter(
+    (instance) => !topServicesNames.includes(instance.service_entity),
+  );
+
+  return topInstances.map((instance) =>
+    shapesDataTransform(embeddedInstances, instance),
+  );
+};

--- a/src/UI/words.tsx
+++ b/src/UI/words.tsx
@@ -158,6 +158,9 @@ const dict = {
   "inventory.form.placeholder.stringList": "Add a list of values",
   "inventory.form.placeholder.dict": '{"key": "value"}',
   "inventory.instanceComposer.editButton": "Edit in Composer",
+  "inventory.instanceComposer.success": "The request got sent succesfully",
+  "inventory.instanceComposer.success.title": "Instance Composed succesfully",
+  "inventory.instanceComposer.failed.title": "Instance Composing failed",
   "inventory.instanceComposer.dictModal": (valueName: string) =>
     `Values of ${valueName}`,
   "inventory.deleteInstance.button": "Delete",


### PR DESCRIPTION
# Description

Bundled "Blocking Deploy button" ticket with deploy feedback, currently forms "updates" on confirm even though there is no changes, do we want to block the button, or just in case of no changes then just close the modal? I would personally opt for the second one, but want to read what you think.

**Sidenote:** This bug with suggestions tooltip is due to the me recording mobile devTools version of the app, which is set to 75% of normal size, when app is running "normally" then tooltip is where it should be

closes #5128 #5275 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Code is clear and sufficiently documented
~~- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)~~ I think that will be covered through e2e
- [x] Correct, in line with design
~~- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~


https://github.com/inmanta/web-console/assets/113331659/ea9426c7-6d05-4112-90cc-ae465a9d948d

