### PR TITLE
update query to get rounded timestamps + fix display

### DIFF
--- a/changelogs/unreleased/5081-timestamps-dashboard.yml
+++ b/changelogs/unreleased/5081-timestamps-dashboard.yml
@@ -1,0 +1,8 @@
+change-type: patch
+description: "Timestamps in the dashboard are now rounded to full hours"
+issue-nr: 5081
+destination-branches:
+  - master
+  - iso6
+sections:
+  minor-improvement: "{{description}}"

--- a/src/Data/Managers/GetMetrics/QueryManager.ts
+++ b/src/Data/Managers/GetMetrics/QueryManager.ts
@@ -16,7 +16,7 @@ export function GetMetricsQueryManager(
         "metrics=lsm.service_count&metrics=lsm.service_instance_count&";
       return `/api/v2/metrics?${
         isLsmAvailable ? lsmMetrics : ""
-      }metrics=orchestrator.compile_time&metrics=orchestrator.compile_waiting_time&metrics=orchestrator.compile_rate&metrics=resource.agent_count&metrics=resource.resource_count&start_interval=${startDate}&end_interval=${endDate}&nb_datapoints=15`;
+      }metrics=orchestrator.compile_time&metrics=orchestrator.compile_waiting_time&metrics=orchestrator.compile_rate&metrics=resource.agent_count&metrics=resource.resource_count&start_interval=${startDate}&end_interval=${endDate}&nb_datapoints=15&round_timestamps=true`;
     },
     identity,
   );

--- a/src/Slices/Dashboard/UI/Charts/LineChart.tsx
+++ b/src/Slices/Dashboard/UI/Charts/LineChart.tsx
@@ -147,7 +147,7 @@ export const LineChart: React.FC<LineChartProps> = ({
               <ChartArea
                 data={data.map((value, index) => {
                   return {
-                    x: timestamps[index] + "Z",
+                    x: timestamps[index],
                     y: formatValueForChart(value),
                   };
                 })}
@@ -174,7 +174,7 @@ export const LineChart: React.FC<LineChartProps> = ({
               <ChartLine
                 data={interpolateMetrics(data).map((value, index) => {
                   return {
-                    x: timestamps[index] + "Z",
+                    x: timestamps[index],
                     y: formatValueForChart(value),
                   };
                 })}
@@ -198,7 +198,7 @@ export const LineChart: React.FC<LineChartProps> = ({
               <ChartScatter
                 data={data.map((value, index) => {
                   return {
-                    x: timestamps[index] + "Z",
+                    x: timestamps[index],
                     y: formatValueForChart(value),
                   };
                 })}


### PR DESCRIPTION
# Description

As mentioned [here](https://inmanta.slack.com/archives/C045Y42N49W/p1701243958171489?thread_ts=1701183990.053659&cid=C045Y42N49W), rounding seems odd to me as it set last timestamp in the future - If bart won't respond I'll point it on the stand-up

closes #5081 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Code is clear and sufficiently documented
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
