### PR TITLE
4555 agent table improvement

### DIFF
--- a/changelogs/unreleased/4555-agent-table.yml
+++ b/changelogs/unreleased/4555-agent-table.yml
@@ -1,6 +1,6 @@
 description: "Improve behaviour of the agents table when the environment is halted"
 issue-nr: 4555
 change-type: patch
-destination-branches: [master, iso7]
+destination-branches: [master]
 sections:
   minor-improvement: "{{description}}"

--- a/changelogs/unreleased/4555-agent-table.yml
+++ b/changelogs/unreleased/4555-agent-table.yml
@@ -1,6 +1,6 @@
 description: "Improve behaviour of the agents table when the environment is halted"
 issue-nr: 4555
 change-type: patch
-destination-branches: [master]
+destination-branches: [master, iso6]
 sections:
   minor-improvement: "{{description}}"

--- a/changelogs/unreleased/4555-agent-table.yml
+++ b/changelogs/unreleased/4555-agent-table.yml
@@ -1,0 +1,6 @@
+description: "Improve behaviour of the agents table when the environment is halted"
+issue-nr: 4555
+change-type: patch
+destination-branches: [master, iso7]
+sections:
+  minor-improvement: "{{description}}"

--- a/src/Slices/Agents/UI/Agents.test.tsx
+++ b/src/Slices/Agents/UI/Agents.test.tsx
@@ -512,3 +512,43 @@ test("Given the Agents view with the environment halted, When setting unpause_on
   });
   expect(apiHelper.pendingRequests).toHaveLength(0);
 });
+
+test("Given the Agents view with the environment NOT halted, THEN the on resume column shouldn't be shown", async () => {
+  const { component, apiHelper } = setup();
+  render(component);
+
+  await act(async () => {
+    await apiHelper.resolve(Either.right(AgentsMock.response));
+  });
+
+  const tableHeaders = await screen.findAllByRole("columnheader");
+
+  expect(tableHeaders).toHaveLength(4);
+
+  const onResumeColumnHeader = tableHeaders.find(
+    (header) => header.textContent === "On resume",
+  );
+  expect(onResumeColumnHeader).toBeUndefined();
+});
+
+test("Given the Agents view with the environment halted, THEN the on resume column should be shown", async () => {
+  const { component, apiHelper, store } = setup();
+  store.dispatch.environment.setEnvironmentDetailsById({
+    id: "env",
+    value: RemoteData.success({ ...EnvironmentDetails.halted, id: "env" }),
+  });
+  render(component);
+
+  await act(async () => {
+    await apiHelper.resolve(Either.right(AgentsMock.response));
+  });
+
+  const tableHeaders = await screen.findAllByRole("columnheader");
+
+  expect(tableHeaders).toHaveLength(5);
+
+  const onResumeColumnHeader = tableHeaders.find(
+    (header) => header.textContent === "On resume",
+  );
+  expect(onResumeColumnHeader).toBeDefined();
+});

--- a/src/Slices/Agents/UI/AgentsTableRow.tsx
+++ b/src/Slices/Agents/UI/AgentsTableRow.tsx
@@ -19,6 +19,7 @@ interface Props {
 export const AgentsTableRow: React.FC<Props> = ({ row }) => {
   const { routeManager, environmentModifier } = useContext(DependencyContext);
   const isHalted = environmentModifier.useIsHalted();
+
   return (
     <Tbody isExpanded={false}>
       <Tr aria-label="Agents Table Row">
@@ -41,11 +42,6 @@ export const AgentsTableRow: React.FC<Props> = ({ row }) => {
           {row.last_failover && (
             <DateWithTooltip timestamp={row.last_failover} />
           )}
-        </Td>
-        <Td width={10} dataLabel={words("agents.columns.unpause")}>
-          {row.unpause_on_resume !== null && row.unpause_on_resume !== undefined
-            ? JSON.stringify(row.unpause_on_resume)
-            : null}
         </Td>
         {isHalted && (
           <Td width={10} dataLabel={words("agents.columns.unpause")}>


### PR DESCRIPTION
# Description

Resolved the glitch in the "on-resume" column, for the agents table. 

closes #4555 

https://github.com/inmanta/web-console/assets/44098050/6964f077-b923-479e-a53b-7be2c3831497

