### PR TITLE
Build(deps): Bump @patternfly/react-table from 5.1.1 to 5.1.2 (#5429)

### DIFF
--- a/changelogs/unreleased/5429-dependabot.yml
+++ b/changelogs/unreleased/5429-dependabot.yml
@@ -1,0 +1,6 @@
+change-type: patch
+description: 'Build(deps): Bump @patternfly/react-table from 5.1.1 to 5.1.2'
+destination-branches:
+- master
+- iso7
+sections: {}

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "@patternfly/react-core": "^5.1.1",
     "@patternfly/react-icons": "^5.1.2",
     "@patternfly/react-styles": "^5.1.1",
-    "@patternfly/react-table": "^5.1.1",
+    "@patternfly/react-table": "^5.1.2",
     "@patternfly/react-tokens": "^5.1.1",
     "@react-keycloak/web": "^3.4.0",
     "copy-to-clipboard": "^3.3.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1420,7 +1420,7 @@ __metadata:
     "@patternfly/react-core": ^5.1.1
     "@patternfly/react-icons": ^5.1.2
     "@patternfly/react-styles": ^5.1.1
-    "@patternfly/react-table": ^5.1.1
+    "@patternfly/react-table": ^5.1.2
     "@patternfly/react-tokens": ^5.1.1
     "@react-keycloak/web": ^3.4.0
     "@testing-library/dom": ^9.3.1
@@ -2027,6 +2027,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@patternfly/react-core@npm:^5.1.2":
+  version: 5.1.2
+  resolution: "@patternfly/react-core@npm:5.1.2"
+  dependencies:
+    "@patternfly/react-icons": ^5.1.2
+    "@patternfly/react-styles": ^5.1.2
+    "@patternfly/react-tokens": ^5.1.2
+    focus-trap: 7.5.2
+    react-dropzone: ^14.2.3
+    tslib: ^2.5.0
+  peerDependencies:
+    react: ^17 || ^18
+    react-dom: ^17 || ^18
+  checksum: 850e0cff69273c36b1da8e38dd9a2037ec8fd5954c69cd5be8516c14b87152b0a725a6c97f9d0d9b46b54ec6dcd92d389cd4d14774f64a29467836a3a78009e6
+  languageName: node
+  linkType: hard
+
 "@patternfly/react-icons@npm:^5.1.1":
   version: 5.1.1
   resolution: "@patternfly/react-icons@npm:5.1.1"
@@ -2054,20 +2071,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@patternfly/react-table@npm:^5.1.1":
-  version: 5.1.1
-  resolution: "@patternfly/react-table@npm:5.1.1"
+"@patternfly/react-styles@npm:^5.1.2":
+  version: 5.1.2
+  resolution: "@patternfly/react-styles@npm:5.1.2"
+  checksum: 49f0f05744a94cb4ba9aa071807efb9beb804a532a97a78ca60b567c3f65262456e997c18a480ad8823684a248a2af4cc873ccae703ab77b081184296dcef2c3
+  languageName: node
+  linkType: hard
+
+"@patternfly/react-table@npm:^5.1.2":
+  version: 5.1.2
+  resolution: "@patternfly/react-table@npm:5.1.2"
   dependencies:
-    "@patternfly/react-core": ^5.1.1
-    "@patternfly/react-icons": ^5.1.1
-    "@patternfly/react-styles": ^5.1.1
-    "@patternfly/react-tokens": ^5.1.1
+    "@patternfly/react-core": ^5.1.2
+    "@patternfly/react-icons": ^5.1.2
+    "@patternfly/react-styles": ^5.1.2
+    "@patternfly/react-tokens": ^5.1.2
     lodash: ^4.17.19
     tslib: ^2.5.0
   peerDependencies:
     react: ^17 || ^18
     react-dom: ^17 || ^18
-  checksum: 76aff8220a237744c27a7996d0910360b0045a120df72e878feaf6fc59a9455254a73df2a716e34a4c7d0bf7de14a317c9853060c43368b937f1b8cdd3082178
+  checksum: b043489395594cb83485459a2bd27289d08f4a85bbe64121fe4b4285dca70149b4cf6dcf9bdac642c42d8c9c741bbeab615136ecc31a8ae9433668104835641b
   languageName: node
   linkType: hard
 
@@ -2075,6 +2099,13 @@ __metadata:
   version: 5.1.1
   resolution: "@patternfly/react-tokens@npm:5.1.1"
   checksum: 6e87e7cc411d6b4ec1f52b813d2361e8401d604718a31cd4325143fdd2771554d65927b85eedcc4c3a99caa2cb1756286679f4194af4e950064b9f85a3ca33f1
+  languageName: node
+  linkType: hard
+
+"@patternfly/react-tokens@npm:^5.1.2":
+  version: 5.1.2
+  resolution: "@patternfly/react-tokens@npm:5.1.2"
+  checksum: e7e4df34254aa474889c1f571b6a232ebe67210d302f8b86ef68371f66d56c6ba72c785ba6dcb41c57b30dbd0977b4e9ccecffaac599a158ae83bad8e11bbb8f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Pull request opened by the merge tool on behalf of #5429