### PR TITLE
Build(deps): Bump @patternfly/react-tokens from 5.1.1 to 5.1.2 (#5432)

### DIFF
--- a/changelogs/unreleased/5432-dependabot.yml
+++ b/changelogs/unreleased/5432-dependabot.yml
@@ -1,0 +1,6 @@
+change-type: patch
+description: 'Build(deps): Bump @patternfly/react-tokens from 5.1.1 to 5.1.2'
+destination-branches:
+- master
+- iso7
+sections: {}

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "@patternfly/react-icons": "^5.1.2",
     "@patternfly/react-styles": "^5.1.1",
     "@patternfly/react-table": "^5.1.2",
-    "@patternfly/react-tokens": "^5.1.1",
+    "@patternfly/react-tokens": "^5.1.2",
     "@react-keycloak/web": "^3.4.0",
     "copy-to-clipboard": "^3.3.3",
     "dagre": "^0.8.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1421,7 +1421,7 @@ __metadata:
     "@patternfly/react-icons": ^5.1.2
     "@patternfly/react-styles": ^5.1.1
     "@patternfly/react-table": ^5.1.2
-    "@patternfly/react-tokens": ^5.1.1
+    "@patternfly/react-tokens": ^5.1.2
     "@react-keycloak/web": ^3.4.0
     "@testing-library/dom": ^9.3.1
     "@testing-library/jest-dom": ^6.1.6


### PR DESCRIPTION
Pull request opened by the merge tool on behalf of #5432