### PR TITLE
Build(deps-dev): Bump regenerator-runtime from 0.14.0 to 0.14.1 (#5579)

### DIFF
--- a/changelogs/unreleased/5579-dependabot.yml
+++ b/changelogs/unreleased/5579-dependabot.yml
@@ -1,0 +1,6 @@
+change-type: patch
+description: 'Build(deps-dev): Bump regenerator-runtime from 0.14.0 to 0.14.1'
+destination-branches:
+- master
+- iso7
+sections: {}

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "prettier": "^3.2.4",
     "raw-loader": "^4.0.2",
     "react-svg-loader": "^3.0.3",
-    "regenerator-runtime": "^0.14.0",
+    "regenerator-runtime": "^0.14.1",
     "rimraf": "^5.0.5",
     "style-loader": "^3.3.3",
     "svg-url-loader": "^8.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -958,7 +958,7 @@ __metadata:
     react-router-dom: "npm:^6.18.0"
     react-svg-loader: "npm:^3.0.3"
     react-syntax-highlighter: "npm:^15.5.0"
-    regenerator-runtime: "npm:^0.14.0"
+    regenerator-runtime: "npm:^0.14.1"
     rimraf: "npm:^5.0.5"
     style-loader: "npm:^3.3.3"
     styled-components: "npm:^5.3.11"
@@ -12382,6 +12382,13 @@ __metadata:
   version: 0.14.0
   resolution: "regenerator-runtime@npm:0.14.0"
   checksum: 10/6c19495baefcf5fbb18a281b56a97f0197b5f219f42e571e80877f095320afac0bdb31dab8f8186858e6126950068c3f17a1226437881e3e70446ea66751897c
+  languageName: node
+  linkType: hard
+
+"regenerator-runtime@npm:^0.14.1":
+  version: 0.14.1
+  resolution: "regenerator-runtime@npm:0.14.1"
+  checksum: 10/5db3161abb311eef8c45bcf6565f4f378f785900ed3945acf740a9888c792f75b98ecb77f0775f3bf95502ff423529d23e94f41d80c8256e8fa05ed4b07cf471
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Pull request opened by the merge tool on behalf of #5579