### PR TITLE
Fix suggestions popover event listener bug

### DIFF
--- a/changelogs/unreleased/5531-bugfix.yml
+++ b/changelogs/unreleased/5531-bugfix.yml
@@ -1,0 +1,4 @@
+description: bugfix for closing behaviour suggestions in the forms
+issue-nr: 5531
+change-type: patch
+destination-branches: [master, iso7]

--- a/src/UI/Components/ServiceInstanceForm/Components/SuggestionsPopover.tsx
+++ b/src/UI/Components/ServiceInstanceForm/Components/SuggestionsPopover.tsx
@@ -179,7 +179,7 @@ export const SuggestionsPopover = forwardRef<
       window.removeEventListener("click", handleClickOutside);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [isOpen]);
 
   return (
     <Popper


### PR DESCRIPTION
# Description

With an empty dependency array, the container wasn't closing anymore. 
