### PR TITLE
Revert "fix to repair the E2E tests for scenario 9 (PR #5600)"

### DIFF
--- a/changelogs/unreleased/fix-e2e-scenario-9.yml
+++ b/changelogs/unreleased/fix-e2e-scenario-9.yml
@@ -1,3 +1,0 @@
-description: "fix to repair the E2E tests for scenario 9"
-change-type: patch
-destination-branches: [master, iso7]

--- a/cypress/e2e/scenario-9-orders.cy.js
+++ b/cypress/e2e/scenario-9-orders.cy.js
@@ -196,7 +196,7 @@ if (Cypress.env("edition") === "iso") {
       cy.get('[aria-label="Expanded-Discovered-Row"]')
         .eq(0)
         .find('[aria-label="Expanded-Details"]')
-        .should("contain", "Creation failed");
+        .should("contain", "An error occurred during deployment");
       cy.get('[aria-label="Expanded-Discovered-Row"]')
         .eq(0)
         .find('[aria-label="Expanded-Details"]')


### PR DESCRIPTION
This reverts commit 2c18dcf9b7540496892163655c0966748da060cb.

The fix for failing e2e scenario got outdated, and now we are back to original message

* Short description here *

closes *Add ticket reference here*

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Code is clear and sufficiently documented
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
