### PR TITLE
Correct highlight delete action button in DeleteAction component

### DIFF
--- a/changelogs/unreleased/5400-correct-disabled-highlight.yml
+++ b/changelogs/unreleased/5400-correct-disabled-highlight.yml
@@ -1,0 +1,7 @@
+description: Corrected the disabled highlight for disabled delete button in the Service Inventory
+issue-nr: 5400
+change-type: patch
+destination-branches: [master, iso7]
+sections:
+  minor-improvement: "{{description}}"
+

--- a/src/Slices/ServiceInventory/UI/Components/RowActionsMenu/DeleteAction/DeleteAction.tsx
+++ b/src/Slices/ServiceInventory/UI/Components/RowActionsMenu/DeleteAction/DeleteAction.tsx
@@ -68,7 +68,7 @@ export const DeleteAction: React.FC<Props> = ({
           onClick={handleModalToggle}
           isDisabled={isDisabled || isHalted}
           icon={<TrashAltIcon />}
-          isDanger
+          {...(!isDisabled && !isHalted && { isDanger: true })}
         >
           {words("inventory.deleteInstance.button")}
         </MenuItem>


### PR DESCRIPTION
# Description

closes #5400 

The delete button wasn't grayed out before. The isDanger attribute doesn't make the element fade when disabled. Made it conditional.

https://github.com/inmanta/web-console/assets/44098050/bac13754-d574-4c1f-9e08-7088505eb917


