### PR TITLE
Refactor SingleTextSelect and InstanceCellButton components

### DIFF
--- a/changelogs/unreleased/5561-inter-service-rel-issues.yml
+++ b/changelogs/unreleased/5561-inter-service-rel-issues.yml
@@ -5,4 +5,4 @@ destination-branches:
   - master
   - iso7
 sections:
-  bug: "{{description}}"
+  bugfix: "{{description}}"

--- a/changelogs/unreleased/5561-inter-service-rel-issues.yml
+++ b/changelogs/unreleased/5561-inter-service-rel-issues.yml
@@ -1,0 +1,8 @@
+description: "Fix display name in the form for inter-service relationship, and adjust filtering when clicking on a relation link in the attribute table."
+issue-nr: 5561
+change-type: patch
+destination-branches:
+  - master
+  - iso7
+sections:
+  bug: "{{description}}"

--- a/src/UI/Components/SingleTextSelect/SingleTextSelect.tsx
+++ b/src/UI/Components/SingleTextSelect/SingleTextSelect.tsx
@@ -119,17 +119,22 @@ export const SingleTextSelect: React.FC<Props> = ({
   }, [options]);
 
   useEffect(() => {
-    setInputValue(selected || "");
+    setInputValue(getDisplayValue(selected));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selected]);
 
   const onToggleClick = () => {
     setIsOpen(!isOpen);
   };
 
-  const getDisplayValue = (value: string | number | undefined) => {
+  const getDisplayValue = (value: string | null) => {
     const selectedItem = options.find((option) => option.value === value);
 
-    return selectedItem?.children || value;
+    if (selectedItem && selectedItem.children) {
+      return selectedItem.children as string;
+    }
+
+    return value || "";
   };
 
   const onSelect = (
@@ -145,7 +150,7 @@ export const SingleTextSelect: React.FC<Props> = ({
       default:
         if (value && value !== "no results") {
           setFilterValue("");
-          setInputValue(getDisplayValue(value) as string);
+          setInputValue(getDisplayValue(value as string));
           setSelected(value as string);
         }
         break;

--- a/src/UI/Components/SingleTextSelect/SingleTextSelect.tsx
+++ b/src/UI/Components/SingleTextSelect/SingleTextSelect.tsx
@@ -131,7 +131,7 @@ export const SingleTextSelect: React.FC<Props> = ({
     const selectedItem = options.find((option) => option.value === value);
 
     if (selectedItem && selectedItem.children) {
-      return selectedItem.children as string;
+      return String(selectedItem.children);
     }
 
     return value || "";
@@ -150,8 +150,8 @@ export const SingleTextSelect: React.FC<Props> = ({
       default:
         if (value && value !== "no results") {
           setFilterValue("");
-          setInputValue(getDisplayValue(value as string));
-          setSelected(value as string);
+          setInputValue(getDisplayValue(String(value)));
+          setSelected(String(value));
         }
         break;
     }
@@ -215,13 +215,13 @@ export const SingleTextSelect: React.FC<Props> = ({
       // Select the first available option
       case "Enter":
         if (isOpen && focusedItem.value !== "no results") {
-          //   setInputValue(String(focusedItem.children));
+          setInputValue(String(focusedItem.children));
           setFilterValue("");
           setSelected(String(focusedItem.children));
         }
 
         if (checkIfOptionMatchInput(options, filterValue)) {
-          setSelected(filterValue as string);
+          setSelected(String(filterValue));
         }
 
         setIsOpen((prevIsOpen) => !prevIsOpen);

--- a/src/UI/Components/TreeTable/TreeRow/InstanceCellButton.tsx
+++ b/src/UI/Components/TreeTable/TreeRow/InstanceCellButton.tsx
@@ -30,20 +30,7 @@ export const InstanceCellButton: React.FC<Props> = ({
           variant="link"
           isInline
           onClick={
-            serviceName
-              ? () =>
-                  onClick(
-                    service_identity_attribute_value
-                      ? service_identity_attribute_value
-                      : id,
-                    serviceName,
-                  )
-              : () =>
-                  onClick(
-                    service_identity_attribute_value
-                      ? service_identity_attribute_value
-                      : id,
-                  )
+            serviceName ? () => onClick(id, serviceName) : () => onClick(id)
           }
         >
           {service_identity_attribute_value


### PR DESCRIPTION
# Description

closes #5561 

Repair the forwarding to a filtered vue on the service inventory table
Repair the displayName for the create Instance form for Single Selects. (the problem didn't occur in the multi-select)


https://github.com/inmanta/web-console/assets/44098050/eab2b64b-8e14-44cd-b673-3d6e8f9e94fb


https://github.com/inmanta/web-console/assets/44098050/a7d7aaf7-2d52-4fc3-b821-0ed14c5d80cd

