### PR TITLE
Add user details to Keycloak login form to E2E and update deploy state filter test

### DIFF
--- a/changelogs/unreleased/5649-resolve-flake.yml
+++ b/changelogs/unreleased/5649-resolve-flake.yml
@@ -1,0 +1,4 @@
+description: Resolve flakey test in DeployStateFilter test and update keycloak e2e tests for new keycloak version
+issue-nr: 5649
+change-type: patch
+destination-branches: [master, iso7]

--- a/cypress/e2e/scenario-7.1-keycloak.cy.js
+++ b/cypress/e2e/scenario-7.1-keycloak.cy.js
@@ -5,6 +5,10 @@ if (Cypress.env("keycloak")) {
     cy.origin("http://127.0.0.1:8080", () => {
       cy.get("[id=username]").type("admin");
       cy.get("[id=password]").type("admin{enter}");
+
+      cy.get("[id=email]").type("admin@admin.com");
+      cy.get("[id=firstName]").type("Admin");
+      cy.get("[id=lastName]").type("Administrator{enter}");
     });
 
     cy.get("h1").contains("Home").should("be.visible");

--- a/src/Slices/Resource/UI/ResourcesPage/Components/DeployStateFilter.test.tsx
+++ b/src/Slices/Resource/UI/ResourcesPage/Components/DeployStateFilter.test.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from "react";
 import { Toolbar, ToolbarContent, ToolbarItem } from "@patternfly/react-core";
-import { act, render, screen } from "@testing-library/react";
-import { userEvent } from "@testing-library/user-event";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { Resource } from "@/Core";
 import { DeployStateFilter } from "./DeployStateFilter";
 
@@ -24,7 +23,7 @@ test("Given the deploy state filter When changing the include/exclude options Th
     name: "Deploy State-toggle",
   });
   await act(async () => {
-    await userEvent.click(menuToggle);
+    fireEvent.click(menuToggle);
   });
 
   // Skipped state, check if no filter is applied by default on that option.
@@ -37,12 +36,12 @@ test("Given the deploy state filter When changing the include/exclude options Th
 
   // Select include for skipped state
   await act(async () => {
-    await userEvent.click(
+    fireEvent.click(
       await screen.findByRole("generic", { name: "skipped-include-toggle" }),
     );
   });
   await act(async () => {
-    await userEvent.click(menuToggle);
+    fireEvent.click(menuToggle);
   });
 
   // Check if the include active icon is shown
@@ -59,14 +58,14 @@ test("Given the deploy state filter When changing the include/exclude options Th
   ).not.toBeInTheDocument();
 
   await act(async () => {
-    await userEvent.click(
+    fireEvent.click(
       await screen.findByRole("generic", { name: "skipped-exclude-toggle" }),
     );
   });
 
   // The include icon inactive one again and the exclude is active
   await act(async () => {
-    await userEvent.click(menuToggle);
+    fireEvent.click(menuToggle);
   });
 
   expect(
@@ -78,12 +77,12 @@ test("Given the deploy state filter When changing the include/exclude options Th
 
   // Include and exclude filters for different options can be combined
   await act(async () => {
-    await userEvent.click(
+    fireEvent.click(
       await screen.findByRole("generic", { name: "deployed-include-toggle" }),
     );
   });
   await act(async () => {
-    await userEvent.click(menuToggle);
+    fireEvent.click(menuToggle);
   });
 
   expect(
@@ -95,12 +94,12 @@ test("Given the deploy state filter When changing the include/exclude options Th
 
   // Clicking a toggle again removes that filter
   await act(async () => {
-    await userEvent.click(
+    fireEvent.click(
       await screen.findByRole("generic", { name: "deployed-include-toggle" }),
     );
   });
   await act(async () => {
-    await userEvent.click(menuToggle);
+    fireEvent.click(menuToggle);
   });
 
   expect(

--- a/src/Slices/Resource/UI/ResourcesPage/Components/DeployStateFilter.test.tsx
+++ b/src/Slices/Resource/UI/ResourcesPage/Components/DeployStateFilter.test.tsx
@@ -41,6 +41,9 @@ test("Given the deploy state filter When changing the include/exclude options Th
       await screen.findByRole("generic", { name: "skipped-include-toggle" }),
     );
   });
+  await act(async () => {
+    await userEvent.click(menuToggle);
+  });
 
   // Check if the include active icon is shown
   expect(
@@ -78,6 +81,9 @@ test("Given the deploy state filter When changing the include/exclude options Th
     await userEvent.click(
       await screen.findByRole("generic", { name: "deployed-include-toggle" }),
     );
+  });
+  await act(async () => {
+    await userEvent.click(menuToggle);
   });
 
   expect(

--- a/src/Slices/Resource/UI/ResourcesPage/Components/DeployStateFilter.test.tsx
+++ b/src/Slices/Resource/UI/ResourcesPage/Components/DeployStateFilter.test.tsx
@@ -81,7 +81,7 @@ test("Given the deploy state filter When changing the include/exclude options Th
   });
 
   expect(
-    screen.getByRole("generic", { name: "deployed-include-active" }),
+    await screen.findByRole("generic", { name: "deployed-include-active" }),
   ).toBeVisible();
   expect(
     await screen.findByRole("generic", { name: "skipped-exclude-active" }),


### PR DESCRIPTION
# Description

Add user details to Keycloak login form to E2E and update deploy state filter test.

> To update your keycloak version locally, you should clear all old keycloak images/volumes saved in your docker (I cleared everything to be sure to have a clean slate)

closes #5649 

![image](https://github.com/inmanta/web-console/assets/44098050/ba25fdf6-4614-407e-90a9-f01cbd4e300b)
