### PR TITLE
Build(deps): Bump markdown-it from 14.0.0 to 14.1.0 (#5661)

### DIFF
--- a/changelogs/unreleased/5661-dependabot.yml
+++ b/changelogs/unreleased/5661-dependabot.yml
@@ -1,0 +1,6 @@
+change-type: patch
+description: 'Build(deps): Bump markdown-it from 14.0.0 to 14.1.0'
+destination-branches:
+- master
+- iso7
+sections: {}

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "keycloak-js": "^23.0.1",
     "lodash": "^4.17.21",
     "lodash-es": "^4.17.21",
-    "markdown-it": "^14.0.0",
+    "markdown-it": "^14.1.0",
     "mermaid": "^9.0.0",
     "moment": "^2.30.1",
     "moment-timezone": "^0.5.45",

--- a/yarn.lock
+++ b/yarn.lock
@@ -984,7 +984,7 @@ __metadata:
     lodash: "npm:^4.17.21"
     lodash-es: "npm:^4.17.21"
     madge: "npm:^6.1.0"
-    markdown-it: "npm:^14.0.0"
+    markdown-it: "npm:^14.1.0"
     mermaid: "npm:^9.0.0"
     mini-css-extract-plugin: "npm:^2.7.6"
     mocha: "npm:^10.2.0"
@@ -10647,19 +10647,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"markdown-it@npm:^14.0.0":
-  version: 14.0.0
-  resolution: "markdown-it@npm:14.0.0"
+"markdown-it@npm:^14.1.0":
+  version: 14.1.0
+  resolution: "markdown-it@npm:14.1.0"
   dependencies:
     argparse: "npm:^2.0.1"
     entities: "npm:^4.4.0"
     linkify-it: "npm:^5.0.0"
     mdurl: "npm:^2.0.0"
     punycode.js: "npm:^2.3.1"
-    uc.micro: "npm:^2.0.0"
+    uc.micro: "npm:^2.1.0"
   bin:
     markdown-it: bin/markdown-it.mjs
-  checksum: 10/ae319aa4dd02b79d305fa0ff55020f8a3f728793938de5c8849c265a62a558f3968a3c023709d3a25aa0ce3287dc5a1faf33201f41efaf578dcf5d75b20462e8
+  checksum: 10/f34f921be178ed0607ba9e3e27c733642be445e9bb6b1dba88da7aafe8ba1bc5d2f1c3aa8f3fc33b49a902da4e4c08c2feadfafb290b8c7dda766208bb6483a9
   languageName: node
   linkType: hard
 
@@ -15198,7 +15198,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uc.micro@npm:^2.0.0":
+"uc.micro@npm:^2.0.0, uc.micro@npm:^2.1.0":
   version: 2.1.0
   resolution: "uc.micro@npm:2.1.0"
   checksum: 10/37197358242eb9afe367502d4638ac8c5838b78792ab218eafe48287b0ed28aaca268ec0392cc5729f6c90266744de32c06ae938549aee041fc93b0f9672d6b2


### PR DESCRIPTION
Pull request opened by the merge tool on behalf of #5661