### PR TITLE
Enable expert mode on empty values

### DIFF
--- a/changelogs/unreleased/5588-enable-expert-mode-on-empty-values.yml
+++ b/changelogs/unreleased/5588-enable-expert-mode-on-empty-values.yml
@@ -1,0 +1,6 @@
+description: "Enable expert mode on empty values."
+issue-nr: 5588
+change-type: patch
+destination-branches: [master, iso7]
+sections:
+  minor-improvement: "{{description}}"

--- a/src/UI/Components/TreeTable/TreeRow/CellWithCopyExpert.tsx
+++ b/src/UI/Components/TreeTable/TreeRow/CellWithCopyExpert.tsx
@@ -139,7 +139,7 @@ export const CellWithCopyExpert: React.FC<Props> = ({
           setMessage={setStateErrorMessage}
         />
       )}
-      {environmentModifier.useIsExpertModeEnabled() && value !== "" && (
+      {environmentModifier.useIsExpertModeEnabled() && (
         <Button
           variant="link"
           isDanger


### PR DESCRIPTION
# Description

Enable expert mode on empty values. This means it also allows to edit the attributeSets that are still empty.

Closes #5588 

<img width="632" alt="image" src="https://github.com/inmanta/web-console/assets/44098050/39137f30-daf9-401d-accb-fad8318cecf4">
