### PR TITLE
Fix enum field issue

### DIFF
--- a/changelogs/unreleased/5676-bug-duplicate-form.yml
+++ b/changelogs/unreleased/5676-bug-duplicate-form.yml
@@ -1,0 +1,6 @@
+description: " resolve bug in duplicate form for preselected values in dropdowns."
+issue-nr: 5588
+change-type: patch
+destination-branches: [master, iso7]
+sections:
+  bugfix: "{{description}}"

--- a/src/Data/Common/AttributeConverter/sanitizeAttributes.ts
+++ b/src/Data/Common/AttributeConverter/sanitizeAttributes.ts
@@ -17,16 +17,7 @@ export function sanitizeAttributes(
 
   fields.forEach((field) => {
     switch (field.kind) {
-      case "Enum": {
-        const key = formState[field.name];
-        const value =
-          typeof key === "string" && key.length > 0 ? field.options[key] : "";
-        sanitized[field.name] = converter.ensureAttributeType(
-          value,
-          field.type,
-        );
-        return;
-      }
+      case "Enum":
       case "Boolean":
       case "Text": {
         sanitized[field.name] = converter.ensureAttributeType(

--- a/src/Slices/CreateInstance/UI/CreateInstance.test.tsx
+++ b/src/Slices/CreateInstance/UI/CreateInstance.test.tsx
@@ -337,19 +337,19 @@ test("Given the CreateInstance View When creating entity with default values The
     screen.queryByLabelText("TextFieldInput-editableString[]?"),
   ).toHaveTextContent("8.8.8.8");
 
-  expect(
-    screen.getByRole("combobox", { name: "enum-selectFilterInput" }),
-  ).toHaveValue("OPTION_ONE");
-  expect(
-    screen.getByRole("combobox", { name: "editableEnum?-selectFilterInput" }),
-  ).toHaveValue("OPTION_ONE");
+  expect(screen.getByTestId("enum-select-toggle")).toHaveTextContent(
+    "OPTION_ONE",
+  );
+  expect(screen.getByTestId("editableEnum?-select-toggle")).toHaveTextContent(
+    "OPTION_ONE",
+  );
 
-  expect(
-    screen.getByRole("combobox", { name: "editableEnum-selectFilterInput" }),
-  ).toHaveValue("OPTION_ONE");
-  expect(
-    screen.getByRole("combobox", { name: "enum?-selectFilterInput" }),
-  ).toHaveValue("OPTION_ONE");
+  expect(screen.getByTestId("editableEnum-select-toggle")).toHaveTextContent(
+    "OPTION_ONE",
+  );
+  expect(screen.getByTestId("enum?-select-toggle")).toHaveTextContent(
+    "OPTION_ONE",
+  );
 
   expect(screen.queryByLabelText("TextInput-dict")).toHaveValue(
     '{"default":"value"}',
@@ -430,25 +430,17 @@ test("Given the CreateInstance View When creating entity with default values The
   ).toHaveTextContent("8.8.8.8");
 
   expect(
-    within(embedded_base).getByRole("combobox", {
-      name: "enum-selectFilterInput",
-    }),
-  ).toHaveValue("OPTION_ONE");
+    within(embedded_base).getByTestId("enum-select-toggle"),
+  ).toHaveTextContent("OPTION_ONE");
   expect(
-    within(embedded_base).getByRole("combobox", {
-      name: "editableEnum-selectFilterInput",
-    }),
-  ).toHaveValue("OPTION_ONE");
+    within(embedded_base).getByTestId("editableEnum-select-toggle"),
+  ).toHaveTextContent("OPTION_ONE");
   expect(
-    within(embedded_base).getByRole("combobox", {
-      name: "enum?-selectFilterInput",
-    }),
-  ).toHaveValue("OPTION_ONE");
+    within(embedded_base).getByTestId("enum?-select-toggle"),
+  ).toHaveTextContent("OPTION_ONE");
   expect(
-    within(embedded_base).getByRole("combobox", {
-      name: "editableEnum?-selectFilterInput",
-    }),
-  ).toHaveValue("OPTION_ONE");
+    within(embedded_base).getByTestId("editableEnum?-select-toggle"),
+  ).toHaveTextContent("OPTION_ONE");
 
   expect(within(embedded_base).queryByLabelText("TextInput-dict")).toHaveValue(
     '{"default":"value"}',

--- a/src/Slices/DuplicateInstance/UI/DuplicateForm.tsx
+++ b/src/Slices/DuplicateInstance/UI/DuplicateForm.tsx
@@ -51,6 +51,7 @@ export const DuplicateForm: React.FC<Props> = ({ serviceEntity, instance }) => {
   ) => {
     //as setState used in setIsDirty doesn't change immediately we cannot use it only before handleRedirect() as it would trigger prompt from ServiceInstanceForm
     setIsDirty(false);
+
     const result = await trigger(fields, attributes);
     if (result.kind === "Left") {
       setIsDirty(true);

--- a/src/UI/Components/ServiceInstanceForm/Components/SelectFormInput.tsx
+++ b/src/UI/Components/ServiceInstanceForm/Components/SelectFormInput.tsx
@@ -22,6 +22,21 @@ interface Props {
   shouldBeDisabled?: boolean;
   handleInputChange: (value) => void;
 }
+/**
+ * A form input component for managing a select input.
+ * @component
+ *
+ * @param {Props} props - The props for the SelectFormInput component.
+ *  @prop {Record<string, string | ParsedNumber>} options - The options for the select input.
+ *  @prop {string} attributeName - The name of the attribute.
+ *  @prop {string} attributeValue - The value of the attribute.
+ *  @prop {string} description - The description of the attribute.
+ *  @prop {boolean} isOptional - Whether the attribute is optional.
+ *  @prop {boolean} shouldBeDisabled - Whether the attribute should be disabled. Default is false.
+ *  @prop {function} handleInputChange - The callback for handling input changes.
+ *
+ * @returns {JSX.Element} The SelectFormInput component.
+ */
 export const SelectFormInput: React.FC<Props> = ({
   options,
   attributeName,
@@ -44,10 +59,21 @@ export const SelectFormInput: React.FC<Props> = ({
     };
   });
 
+  /**
+   * Handles the toggle click event.
+   */
   const onToggleClick = () => {
     setIsOpen(!isOpen);
   };
 
+  /**
+   * Handles the select event.
+   *
+   * @param {React.MouseEvent<Element, MouseEvent> | undefined} _event - The event.
+   * @param {string | number | undefined} value - The value.
+   *
+   * @returns {void}
+   */
   const onSelect = (
     _event: React.MouseEvent<Element, MouseEvent> | undefined,
     value: string | number | undefined,
@@ -56,6 +82,13 @@ export const SelectFormInput: React.FC<Props> = ({
     setIsOpen(false);
   };
 
+  /**
+   * Creates the toggle element.
+   *
+   * @param {React.Ref<MenuToggleElement>} toggleRef - The toggle reference.
+   *
+   * @returns {JSX.Element} The toggle element.
+   */
   const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
     <MenuToggle
       data-testid={`${attributeName}-select-toggle`}

--- a/src/UI/Components/ServiceInstanceForm/Components/SelectFormInput.tsx
+++ b/src/UI/Components/ServiceInstanceForm/Components/SelectFormInput.tsx
@@ -112,16 +112,6 @@ export const SelectFormInput: React.FC<Props> = ({
           ))}
         </SelectList>
       </Select>
-      {/* <SingleTextSelect
-        options={formattedOptions}
-        toggleAriaLabel={`${attributeName}-select`}
-        setSelected={handleInputChange}
-        selected={
-          selectOptions.length === 1 ? selectOptions[0] : attributeValue
-        }
-        isDisabled={shouldBeDisabled}
-        placeholderText={words("common.serviceInstance.select")(attributeName)}
-      /> */}
     </FormGroup>
   );
 };

--- a/src/UI/Components/ServiceInstanceForm/Components/SelectFormInput.tsx
+++ b/src/UI/Components/ServiceInstanceForm/Components/SelectFormInput.tsx
@@ -1,13 +1,17 @@
-import React from "react";
+import React, { useState } from "react";
 import {
   FormGroup,
   FormHelperText,
   HelperText,
   HelperTextItem,
+  MenuToggle,
+  MenuToggleElement,
+  Select,
+  SelectList,
+  SelectOption,
 } from "@patternfly/react-core";
 import { ParsedNumber } from "@/Core";
-import { words } from "@/UI/words";
-import { SingleTextSelect } from "../../SingleTextSelect";
+import { words } from "@/UI";
 
 interface Props {
   options: Record<string, string | ParsedNumber>;
@@ -28,14 +32,49 @@ export const SelectFormInput: React.FC<Props> = ({
   handleInputChange,
   ...props
 }) => {
+  const [isOpen, setIsOpen] = useState(false);
+
   const selectOptions = Object.keys(options).sort();
   const formattedOptions = selectOptions.map((option) => {
     return {
-      value: option,
+      value: options[option],
       children: option,
-      isSelected: selectOptions.length === 1 || option === attributeValue,
+      isSelected:
+        selectOptions.length === 1 || options[option] === attributeValue,
     };
   });
+
+  const onToggleClick = () => {
+    setIsOpen(!isOpen);
+  };
+
+  const onSelect = (
+    _event: React.MouseEvent<Element, MouseEvent> | undefined,
+    value: string | number | undefined,
+  ) => {
+    handleInputChange(value);
+    setIsOpen(false);
+  };
+
+  const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
+    <MenuToggle
+      data-testid={`${attributeName}-select-toggle`}
+      ref={toggleRef}
+      onClick={onToggleClick}
+      isExpanded={isOpen}
+      isDisabled={shouldBeDisabled}
+      style={
+        {
+          width: "100%",
+        } as React.CSSProperties
+      }
+    >
+      {selectOptions.length === 1
+        ? selectOptions[0]
+        : attributeValue ||
+          words("common.serviceInstance.select")(attributeName)}
+    </MenuToggle>
+  );
 
   return (
     <FormGroup
@@ -49,7 +88,31 @@ export const SelectFormInput: React.FC<Props> = ({
           <HelperTextItem>{description}</HelperTextItem>
         </HelperText>
       </FormHelperText>
-      <SingleTextSelect
+      <Select
+        id={`${attributeName}-select`}
+        isOpen={isOpen}
+        selected={
+          selectOptions.length === 1 ? selectOptions[0] : attributeValue
+        }
+        onSelect={onSelect}
+        onOpenChange={(isOpen) => setIsOpen(isOpen)}
+        toggle={toggle}
+        shouldFocusToggleOnSelect
+        aria-label={`${attributeName}-select`}
+      >
+        <SelectList>
+          {formattedOptions.map((option, index) => (
+            <SelectOption
+              key={index}
+              value={option.value}
+              isSelected={option.isSelected}
+            >
+              {option.children}
+            </SelectOption>
+          ))}
+        </SelectList>
+      </Select>
+      {/* <SingleTextSelect
         options={formattedOptions}
         toggleAriaLabel={`${attributeName}-select`}
         setSelected={handleInputChange}
@@ -58,7 +121,7 @@ export const SelectFormInput: React.FC<Props> = ({
         }
         isDisabled={shouldBeDisabled}
         placeholderText={words("common.serviceInstance.select")(attributeName)}
-      />
+      /> */}
     </FormGroup>
   );
 };

--- a/src/UI/Components/ServiceInstanceForm/ServiceInstanceForm.test.tsx
+++ b/src/UI/Components/ServiceInstanceForm/ServiceInstanceForm.test.tsx
@@ -238,10 +238,11 @@ test("GIVEN ServiceInstanceForm WHEN passed an EnumField THEN shows that field",
     }),
   ).toBeVisible();
 
-  const select = screen.getByRole("combobox", {
-    name: "enum_field-selectFilterInput",
-  });
-  expect(select).toHaveValue("local");
+  const select = screen.getByTestId(
+    `${Test.Field.enumField.name}-select-toggle`,
+  );
+
+  expect(select).toHaveTextContent("local");
 
   await act(async () => {
     await userEvent.click(select);
@@ -254,7 +255,7 @@ test("GIVEN ServiceInstanceForm WHEN passed an EnumField THEN shows that field",
     await userEvent.click(options[0]);
   });
 
-  expect(select).toHaveValue("ci");
+  expect(select).toHaveTextContent("ci");
 });
 
 test("GIVEN ServiceInstanceForm WHEN passed an EnumField with more than one value THEN shows that field with default prompt", async () => {
@@ -266,14 +267,14 @@ test("GIVEN ServiceInstanceForm WHEN passed an EnumField with more than one valu
   });
   expect(field).toBeVisible();
 
-  const placeholder = screen.getByPlaceholderText(
+  const placeholder = screen.getByText(
     `Select value for ${Test.Field.enumFieldTwoOptions.name}`,
   );
   expect(placeholder).toBeVisible();
 
-  const select = screen.getByRole("combobox", {
-    name: `${Test.Field.enumFieldTwoOptions.name}-selectFilterInput`,
-  });
+  const select = screen.getByTestId(
+    `${Test.Field.enumFieldTwoOptions.name}-select-toggle`,
+  );
 
   await act(async () => {
     await userEvent.click(select);
@@ -292,11 +293,11 @@ test("GIVEN ServiceInstanceForm WHEN passed an EnumField with only one value THE
   });
   expect(field).toBeVisible();
 
-  const select = screen.getByRole("combobox", {
-    name: `${Test.Field.enumFieldSingleOption.name}-selectFilterInput`,
-  });
+  const select = screen.getByTestId(
+    `${Test.Field.enumFieldSingleOption.name}-select-toggle`,
+  );
 
-  expect(select).toHaveValue("local");
+  expect(select).toHaveTextContent("local");
 
   await act(async () => {
     await userEvent.click(select);


### PR DESCRIPTION
# Description

I replaced the select as it was before, whilst keeping the original type of the options. Previously the values were stringified in the Object.keys mapping. Now that the values keep their typing, we can safely remove the logic in the mapping prepping the body to send to the api that was previously assuming the value would always be a string in case of enums. The issue wasn't specific to the duplicate form.

close #5676 