### PR TITLE
Build(deps): Bump @tanstack/react-query-devtools from 5.25.0 to 5.31.0 (#5695)

### DIFF
--- a/changelogs/unreleased/5695-dependabot.yml
+++ b/changelogs/unreleased/5695-dependabot.yml
@@ -1,0 +1,6 @@
+change-type: patch
+description: 'Build(deps): Bump @tanstack/react-query-devtools from 5.25.0 to 5.31.0'
+destination-branches:
+- master
+- iso7
+sections: {}

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "@patternfly/react-tokens": "^5.1.2",
     "@react-keycloak/web": "^3.4.0",
     "@tanstack/react-query": "^5.28.14",
-    "@tanstack/react-query-devtools": "^5.24.0",
+    "@tanstack/react-query-devtools": "^5.31.0",
     "copy-to-clipboard": "^3.3.3",
     "easy-peasy": "^6.0.4",
     "file-saver": "^2.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -927,7 +927,7 @@ __metadata:
     "@patternfly/react-tokens": "npm:^5.1.2"
     "@react-keycloak/web": "npm:^3.4.0"
     "@tanstack/react-query": "npm:^5.28.14"
-    "@tanstack/react-query-devtools": "npm:^5.24.0"
+    "@tanstack/react-query-devtools": "npm:^5.31.0"
     "@testing-library/dom": "npm:^9.3.4"
     "@testing-library/jest-dom": "npm:^6.4.2"
     "@testing-library/react": "npm:^13.4.0"
@@ -1750,22 +1750,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tanstack/query-devtools@npm:5.24.0":
-  version: 5.24.0
-  resolution: "@tanstack/query-devtools@npm:5.24.0"
-  checksum: 10/92a4faed16ca86bb2e65fec5c47295f537322c6fb16e5e694c66c99a1e6fcb4e0a757b2cd27d73c8315798503299d6959923cdfd17013b038f18772784bf7aec
+"@tanstack/query-devtools@npm:5.28.10":
+  version: 5.28.10
+  resolution: "@tanstack/query-devtools@npm:5.28.10"
+  checksum: 10/3caa49e83507abc1fb5d44283738d6c5d88fd4b7d6f6ec2c26aa77d938157679fc99da51e1f832295e76940d9d90f793549ae927d11bfba67fcc2dfeaf0d5a43
   languageName: node
   linkType: hard
 
-"@tanstack/react-query-devtools@npm:^5.24.0":
-  version: 5.25.0
-  resolution: "@tanstack/react-query-devtools@npm:5.25.0"
+"@tanstack/react-query-devtools@npm:^5.31.0":
+  version: 5.31.0
+  resolution: "@tanstack/react-query-devtools@npm:5.31.0"
   dependencies:
-    "@tanstack/query-devtools": "npm:5.24.0"
+    "@tanstack/query-devtools": "npm:5.28.10"
   peerDependencies:
-    "@tanstack/react-query": ^5.25.0
+    "@tanstack/react-query": ^5.31.0
     react: ^18.0.0
-  checksum: 10/797ab89ff1a83a899a591529f53788f76741e74167f9360f2e21af987be5de0bf285c9caa5bbcd9bc8840c4edef3c1c112a1241b8eb5e11da21339c5003b8f26
+  checksum: 10/be6bf77f17d24d9fc9dd6ac04a649a17347b6aa5b6a7c3b2cf0787a8edd2a0aac9d8deb45968bc404a5e6f5492c66ea9e15f8f341fc0bed57360fa505ed50fa7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Pull request opened by the merge tool on behalf of #5695