### PR TITLE
Fix overflowing of the text in the button in the composer

### DIFF
--- a/changelogs/unreleased/5689-add-instance-button-bug.yml
+++ b/changelogs/unreleased/5689-add-instance-button-bug.yml
@@ -1,0 +1,6 @@
+description: "Resolve a bug of invalid presentation of the add instance button in the instance composer when using Firefox"
+issue-nr: 5689
+change-type: patch
+destination-branches: [master, iso7]
+sections:
+  bugfix: "{{description}}"

--- a/src/UI/Components/Diagram/components/Toolbar.tsx
+++ b/src/UI/Components/Diagram/components/Toolbar.tsx
@@ -54,12 +54,19 @@ const Toolbar = ({
                 aria-label="new-entity-button"
                 isDisabled={!editable}
               >
-                <img
-                  src={entityIcon}
-                  alt="Create new entity icon"
-                  aria-label="new-entity-icon"
-                />{" "}
-                {words("inventory.addInstance.button")}
+                <Flex alignItems={{ default: "alignItemsCenter" }}>
+                  <FlexItem
+                    spacer={{ default: "spacerXs" }}
+                    style={{ width: "16px", height: "20px" }}
+                  >
+                    <img
+                      src={entityIcon}
+                      alt="Create new entity icon"
+                      aria-label="new-entity-icon"
+                    />
+                  </FlexItem>
+                  <FlexItem>{words("inventory.addInstance.button")}</FlexItem>
+                </Flex>
               </IconButton>
             </Tooltip>
           </FlexItem>


### PR DESCRIPTION
# Description

Beside make it the same between browsers I also aligned image to the text, as it was a little of centre which was striking me lately

closes #5689 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Code is clear and sufficiently documented
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
<img width="1436" alt="Screenshot 2024-04-23 at 12 28 55" src="https://github.com/inmanta/web-console/assets/113331659/c8ebb45b-1221-4f65-a6f3-073a72a0d9b4">
