### PR TITLE
Build(deps): Bump @patternfly/react-icons from 5.2.1 to 5.3.1 (#5715)

### DIFF
--- a/changelogs/unreleased/5715-dependabot.yml
+++ b/changelogs/unreleased/5715-dependabot.yml
@@ -1,0 +1,6 @@
+change-type: patch
+description: 'Build(deps): Bump @patternfly/react-icons from 5.2.1 to 5.3.1'
+destination-branches:
+- master
+- iso7
+sections: {}

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "@loadable/component": "^5.16.3",
     "@patternfly/react-charts": "^7.1.2",
     "@patternfly/react-core": "^5.2.2",
-    "@patternfly/react-icons": "^5.2.1",
+    "@patternfly/react-icons": "^5.3.1",
     "@patternfly/react-styles": "^5.2.0",
     "@patternfly/react-table": "^5.2.1",
     "@patternfly/react-tokens": "^5.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1038,7 +1038,7 @@ __metadata:
     "@loadable/component": "npm:^5.16.3"
     "@patternfly/react-charts": "npm:^7.1.2"
     "@patternfly/react-core": "npm:^5.2.2"
-    "@patternfly/react-icons": "npm:^5.2.1"
+    "@patternfly/react-icons": "npm:^5.3.1"
     "@patternfly/react-styles": "npm:^5.2.0"
     "@patternfly/react-table": "npm:^5.2.1"
     "@patternfly/react-tokens": "npm:^5.1.2"
@@ -1740,6 +1740,16 @@ __metadata:
     react: ^17 || ^18
     react-dom: ^17 || ^18
   checksum: 10/aecdd3f5c9399cb60aec63a6ab8ef2e9519e48d8eaf954abac65b91ddc0d82112439ac026437336cf0d3b89f186a42827b1d068528c1d502e6d6b779cb17f7e0
+  languageName: node
+  linkType: hard
+
+"@patternfly/react-icons@npm:^5.3.1":
+  version: 5.3.1
+  resolution: "@patternfly/react-icons@npm:5.3.1"
+  peerDependencies:
+    react: ^17 || ^18
+    react-dom: ^17 || ^18
+  checksum: 10/7884518ea4562e08f04d3f35bbaa93ba2483df78c3f6a5a1322a30732b24424ca5c7c87262d8093813b35953fe9f29d6f1fb20fbb9be1d2abe318af66be7add6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Pull request opened by the merge tool on behalf of #5715