### PR TITLE
Build(deps): Bump keycloak-js from 23.0.1 to 24.0.3 (#5741)

### DIFF
--- a/changelogs/unreleased/5741-dependabot.yml
+++ b/changelogs/unreleased/5741-dependabot.yml
@@ -1,0 +1,6 @@
+change-type: patch
+description: 'Build(deps): Bump keycloak-js from 23.0.1 to 24.0.3'
+destination-branches:
+- master
+- iso7
+sections: {}

--- a/package.json
+++ b/package.json
@@ -154,7 +154,7 @@
     "file-saver": "^2.0.5",
     "history": "^5.3.0",
     "json-bigint": "https://github.com/sidorares/json-bigint.git#3391780b2a3f613bb51536c47e6cddbca31013eb",
-    "keycloak-js": "^23.0.1",
+    "keycloak-js": "^24.0.3",
     "lodash": "^4.17.21",
     "lodash-es": "^4.17.21",
     "markdown-it": "^14.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1102,7 +1102,7 @@ __metadata:
     jest-fetch-mock: "npm:^3.0.3"
     jest-junit: "npm:^16.0.0"
     json-bigint: "https://github.com/sidorares/json-bigint.git#3391780b2a3f613bb51536c47e6cddbca31013eb"
-    keycloak-js: "npm:^23.0.1"
+    keycloak-js: "npm:^24.0.3"
     lint-staged: "npm:^15.2.0"
     lodash: "npm:^4.17.21"
     lodash-es: "npm:^4.17.21"
@@ -4160,7 +4160,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"base64-js@npm:^1.3.1, base64-js@npm:^1.5.1":
+"base64-js@npm:^1.3.1":
   version: 1.5.1
   resolution: "base64-js@npm:1.5.1"
   checksum: 10/669632eb3745404c2f822a18fc3a0122d2f9a7a13f7fb8b5823ee19d1d2ff9ee5b52c53367176ea4ad093c332fd5ab4bd0ebae5a8e27917a4105a4cfc86b1005
@@ -10230,10 +10230,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-sha256@npm:^0.10.1":
-  version: 0.10.1
-  resolution: "js-sha256@npm:0.10.1"
-  checksum: 10/6bae235dd458744e573876cc0875e21ea18a84e3aec4ba82d0efdb28537366e225304d93072789883500ca995fcc7c4500528c66d02da88cc5d6ab4554ce2b8c
+"js-sha256@npm:^0.11.0":
+  version: 0.11.0
+  resolution: "js-sha256@npm:0.11.0"
+  checksum: 10/3adc208452302838136f1464ea331bae3b4d4c95afa9314fa6446d755059ff37114cb209fe9ed166c460ffe720d4875aa955e4f4c7aacab2d99858dd3e008b93
   languageName: node
   linkType: hard
 
@@ -10431,14 +10431,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"keycloak-js@npm:^23.0.1":
-  version: 23.0.1
-  resolution: "keycloak-js@npm:23.0.1"
+"keycloak-js@npm:^24.0.3":
+  version: 24.0.3
+  resolution: "keycloak-js@npm:24.0.3"
   dependencies:
-    base64-js: "npm:^1.5.1"
-    js-sha256: "npm:^0.10.1"
+    js-sha256: "npm:^0.11.0"
     jwt-decode: "npm:^4.0.0"
-  checksum: 10/0b32e8c58c7eee256e19f76ef055b3e26fcbaf401fcf3328c8c0df8b1fc5d319a08c3a944411fc00bcb96cfceeed7c44e0b503fea9fc66fdea7d18289faafc11
+  checksum: 10/e93d49194eac407b6bf89a977f280c0aacf438cde40a96a8f8c49d8349fd96f0373988548951ca58e8ae23f3edf2539b6497021e8dbc801c3fba0c087f4be9f5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Pull request opened by the merge tool on behalf of #5741