### PR TITLE
add column for managed resources in resource discovery page

### DIFF
--- a/changelogs/unreleased/5765-isManaged-resource.yml
+++ b/changelogs/unreleased/5765-isManaged-resource.yml
@@ -1,0 +1,6 @@
+description: Add column for managed resources in the Resource Discovery page.
+issue-nr: 5765
+change-type: patch
+destination-branches: [master, iso7]
+sections:
+  minor-improvement: "{{description}}"

--- a/src/Slices/ResourceDiscovery/Core/Query.ts
+++ b/src/Slices/ResourceDiscovery/Core/Query.ts
@@ -31,6 +31,7 @@ export interface Manifest {
 
 export interface DiscoveredResource {
   discovered_resource_id: string;
+  managed_resource_uri: string | null;
   values: unknown;
 }
 

--- a/src/Slices/ResourceDiscovery/Data/Mock.ts
+++ b/src/Slices/ResourceDiscovery/Data/Mock.ts
@@ -2,6 +2,7 @@ export const response = {
   data: [
     {
       discovered_resource_id: "vcenter::VirtualMachine[lab,name=acisim]",
+      managed_resource_uri: "/api/v2/resource/resource-1",
       values: {
         name: "acisim",
         path: "/bedc/vm/acisim",
@@ -34,6 +35,7 @@ export const response = {
     },
     {
       discovered_resource_id: "vcenter::VirtualMachine[lab,name=acisim-5.2-7f]",
+      managed_resource_uri: null,
       values: {
         name: "acisim-5.2-7f",
         path: "/bedc/vm/acisim-5.2-7f",
@@ -66,6 +68,7 @@ export const response = {
     },
     {
       discovered_resource_id: "vcenter::VirtualMachine[lab,name=acisim-5.7]",
+      managed_resource_uri: "invalid/uri1/",
       values: {
         name: "acisim-5.7",
         path: "/bedc/vm/acisim-5.7",
@@ -99,6 +102,7 @@ export const response = {
     {
       discovered_resource_id:
         "vcenter::VirtualMachine[lab,name=CentOS7Template]",
+      managed_resource_uri: "",
       values: {
         name: "CentOS7Template",
         path: "/bedc/vm/CentOS7Template",
@@ -126,6 +130,7 @@ export const response = {
     {
       discovered_resource_id:
         "vcenter::VirtualMachine[lab,name=CentOS7TestNfvApiTemplate]",
+      managed_resource_uri: null,
       values: {
         name: "CentOS7TestNfvApiTemplate",
         path: "/bedc/vm/CentOS7TestNfvApiTemplate",
@@ -153,6 +158,7 @@ export const response = {
     {
       discovered_resource_id:
         "vcenter::VirtualMachine[lab,name=ma-test-1705069110.4363039_1]",
+      managed_resource_uri: null,
       values: {
         name: "ma-test-1705069110.4363039_1",
         path: "/bedc/vm/test_lab_root_ma/ma-test-1705069110.4363039_1",
@@ -185,6 +191,7 @@ export const response = {
     },
     {
       discovered_resource_id: "vcenter::VirtualMachine[lab,name=rocky-8]",
+      managed_resource_uri: null,
       values: {
         name: "rocky-8",
         path: "/bedc/vm/rocky-8",
@@ -212,6 +219,7 @@ export const response = {
     {
       discovered_resource_id:
         "vcenter::VirtualMachine[lab,name=t160_srv_example]",
+      managed_resource_uri: null,
       values: {
         name: "t160_srv_example",
         path: "/bedc/vm/test_lab_root/t160_srv_example",
@@ -232,6 +240,7 @@ export const response = {
     {
       discovered_resource_id:
         "vcenter::VirtualMachine[lab,name=t160_srv_example_2]",
+      managed_resource_uri: null,
       values: {
         name: "t160_srv_example_2",
         path: "/bedc/vm/test_lab_root/t160_srv_example_2",
@@ -251,6 +260,7 @@ export const response = {
     },
     {
       discovered_resource_id: "vcenter::VirtualMachine[lab,name=test]",
+      managed_resource_uri: null,
       values: {
         name: "test",
         path: "/bedc/vm/test",
@@ -278,6 +288,7 @@ export const response = {
     {
       discovered_resource_id:
         "vcenter::VirtualMachine[lab,name=ubuntu-18.04.6]",
+      managed_resource_uri: null,
       values: {
         name: "ubuntu-18.04.6",
         path: "/bedc/vm/ubuntu-18.04.6",
@@ -310,6 +321,7 @@ export const response = {
     },
     {
       discovered_resource_id: "vcenter::VirtualMachine[lab,name=ubuntu-22.04]",
+      managed_resource_uri: null,
       values: {
         name: "ubuntu-22.04",
         path: "/bedc/vm/ubuntu-22.04",
@@ -337,6 +349,7 @@ export const response = {
     {
       discovered_resource_id:
         "vcenter::VirtualMachine[lab,name=vCLS-8d6212c5-a9be-40a9-a99e-f8b563a6f284]",
+      managed_resource_uri: null,
       values: {
         name: "vCLS-8d6212c5-a9be-40a9-a99e-f8b563a6f284",
         path: "/bedc/vm/vCLS/vCLS-8d6212c5-a9be-40a9-a99e-f8b563a6f284",
@@ -357,6 +370,7 @@ export const response = {
     {
       discovered_resource_id:
         "vcenter::VirtualMachine[lab,name=vCLS-a11c52cf-ce5c-438b-a4dc-40ef661f16c3]",
+      managed_resource_uri: null,
       values: {
         name: "vCLS-a11c52cf-ce5c-438b-a4dc-40ef661f16c3",
         path: "/bedc/vm/vCLS/vCLS-a11c52cf-ce5c-438b-a4dc-40ef661f16c3",
@@ -377,6 +391,7 @@ export const response = {
     {
       discovered_resource_id:
         "vcenter::VirtualMachine[lab,name=VMware_Cloud_Director-10.5.1.10593-22821417_OVF10]",
+      managed_resource_uri: null,
       values: {
         name: "VMware_Cloud_Director-10.5.1.10593-22821417_OVF10",
         path: "/bedc/vm/VMware_Cloud_Director-10.5.1.10593-22821417_OVF10",
@@ -410,6 +425,7 @@ export const response = {
     {
       discovered_resource_id:
         "vcenter::VirtualMachine[lab,name=VMware vCenter Server 8]",
+      managed_resource_uri: null,
       values: {
         name: "VMware vCenter Server 8",
         path: "/bedc/vm/Discovered virtual machine/VMware vCenter Server 8",
@@ -437,6 +453,7 @@ export const response = {
     {
       discovered_resource_id:
         "vcenter::VirtualMachine[lab,name=WindowsServer2016Template]",
+      managed_resource_uri: null,
       values: {
         name: "WindowsServer2016Template",
         path: "/bedc/vm/WindowsServer2016Template",

--- a/src/Slices/ResourceDiscovery/UI/Components/ManagedResourceLink.tsx
+++ b/src/Slices/ResourceDiscovery/UI/Components/ManagedResourceLink.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { ResourceLink } from "@/UI/Components";
+
+interface Props {
+  resourceUri: string | null;
+}
+
+/**
+ * @Component that renders a link to the managed resource
+ * or a "-" if the resourceUri is null or empty.
+ *
+ * managed_resource_uri comes in format : /api/v2/resource/<rid>
+ *
+ * @param resourceUri : API URI of the managed resource
+ *
+ * @returns ManagedResourceLink component
+ */
+export const ManagedResourceLink: React.FC<Props> = ({ resourceUri }) => {
+  if (!resourceUri) {
+    return <>-</>;
+  }
+
+  const rid = resourceUri.split("/").pop();
+
+  if (!rid) {
+    return <>-</>;
+  }
+
+  return <ResourceLink resourceId={rid} />;
+};

--- a/src/Slices/ResourceDiscovery/UI/DiscoveredResourceTablePresenter.test.ts
+++ b/src/Slices/ResourceDiscovery/UI/DiscoveredResourceTablePresenter.test.ts
@@ -1,0 +1,29 @@
+import * as DiscoveredResources from "../Data/Mock";
+import { DiscoveredResourcesTablePresenter } from "./DiscoveredResourcesTablePresenter";
+
+const presenter = new DiscoveredResourcesTablePresenter();
+
+const rows = presenter.createRows(DiscoveredResources.response.data);
+
+test("Rows should have two items", () => {
+  expect(rows).toHaveLength(17);
+});
+
+test("TablePresenter converts column index to name correctly", () => {
+  expect(presenter.getColumnNameForIndex(0)).toEqual("discovered_resource_id");
+  expect(presenter.getColumnNameForIndex(1)).toEqual("managed_resource_id");
+  expect(presenter.getColumnNameForIndex(-1)).toBeUndefined();
+  expect(presenter.getColumnNameForIndex(10)).toBeUndefined();
+});
+
+test("TablePresenter converts column name to index correctly", () => {
+  expect(presenter.getIndexForColumnName("discovered_resource_id")).toEqual(0);
+  expect(presenter.getIndexForColumnName("managed_resource_id")).toEqual(1);
+  expect(presenter.getIndexForColumnName(undefined)).toEqual(-1);
+});
+
+test("TablePresenter returns sortable columns correctly", () => {
+  expect(presenter.getSortableColumnNames()).toEqual([
+    "discovered_resource_id",
+  ]);
+});

--- a/src/Slices/ResourceDiscovery/UI/DiscoveredResourcesRow.tsx
+++ b/src/Slices/ResourceDiscovery/UI/DiscoveredResourcesRow.tsx
@@ -10,9 +10,13 @@ import styled from "styled-components";
 import { CodeHighlighter, Toggle } from "@/UI/Components";
 import { words } from "@/UI/words";
 import { DiscoveredResource } from "../Core/Query";
+import { ManagedResourceLink } from "./Components/ManagedResourceLink";
 
 interface Props {
-  row: Pick<DiscoveredResource, "discovered_resource_id" | "values">;
+  row: Pick<
+    DiscoveredResource,
+    "discovered_resource_id" | "values" | "managed_resource_uri"
+  >;
   isExpanded: boolean;
   onToggle: () => void;
   numberOfColumns: number;
@@ -36,6 +40,9 @@ export const DiscoveredResourceRow: React.FC<Props> = ({
         </Td>
         <Td dataLabel={words("discovered.column.resource_id")}>
           {row.discovered_resource_id}
+        </Td>
+        <Td dataLabel={words("discovered.column.managed_resource")} width={30}>
+          <ManagedResourceLink resourceUri={row.managed_resource_uri} />
         </Td>
       </Tr>
       {isExpanded && (

--- a/src/Slices/ResourceDiscovery/UI/DiscoveredResourcesTable.tsx
+++ b/src/Slices/ResourceDiscovery/UI/DiscoveredResourcesTable.tsx
@@ -28,7 +28,7 @@ export const DiscoveredResourcesTable: React.FC<Props> = ({
   ...props
 }) => {
   const [isExpanded, onExpansion] = useExpansion();
-  const onSort: OnSort = (event, index, order) => {
+  const onSort: OnSort = (_event, index, order) => {
     setSort({
       name: tablePresenter.getColumnNameForIndex(index) as SortKey,
       order,

--- a/src/Slices/ResourceDiscovery/UI/DiscoveredResourcesTablePresenter.ts
+++ b/src/Slices/ResourceDiscovery/UI/DiscoveredResourcesTablePresenter.ts
@@ -14,6 +14,10 @@ export class DiscoveredResourcesTablePresenter
         displayName: words("discovered.column.resource_id"),
         apiName: "discovered_resource_id",
       },
+      {
+        displayName: words("discovered.column.managed_resource"),
+        apiName: "managed_resource_id",
+      },
     ];
     this.numberOfColumns = this.columnHeads.length + 1;
   }

--- a/src/Slices/ResourceDiscovery/UI/Page.test.tsx
+++ b/src/Slices/ResourceDiscovery/UI/Page.test.tsx
@@ -66,6 +66,29 @@ test("GIVEN Discovered Resources page THEN shows table", async () => {
       name: "vcenter::VirtualMachine[lab,name=acisim]",
     }),
   ).toBeVisible();
+  expect(
+    within(rows[0]).getByRole("cell", {
+      name: "resource-1",
+    }),
+  ).toBeVisible();
+  // uri is null
+  expect(
+    within(rows[1]).getByRole("cell", {
+      name: "-",
+    }),
+  ).toBeVisible();
+  // uri doesn't have a rid
+  expect(
+    within(rows[2]).getByRole("cell", {
+      name: "-",
+    }),
+  ).toBeVisible();
+  // uri is an empty string
+  expect(
+    within(rows[3]).getByRole("cell", {
+      name: "-",
+    }),
+  ).toBeVisible();
 
   await act(async () => {
     const results = await axe(document.body);

--- a/src/UI/words.tsx
+++ b/src/UI/words.tsx
@@ -467,6 +467,7 @@ const dict = {
 
   /** Discovered Resources related text */
   "discovered.column.resource_id": "resource_id",
+  "discovered.column.managed_resource": "managed resource",
   "discovered_resources.title": "Discovered Resources",
   "discovered_resources.values": "values",
 


### PR DESCRIPTION
# Description

Added a column to display the link to the managed resource if available. When no link is available, a dash is displayed. 
The screenshot doesn't yet have managed resources. 

 closes #5765 

<img width="1040" alt="image" src="https://github.com/inmanta/web-console/assets/44098050/32741b08-8073-4ba2-86e4-bb94c490a684">


