### PR TITLE
Build(deps-dev): Bump @types/react-syntax-highlighter from 15.5.10 to 15.5.13 (#5813)

### DIFF
--- a/changelogs/unreleased/5813-dependabot.yml
+++ b/changelogs/unreleased/5813-dependabot.yml
@@ -1,0 +1,7 @@
+change-type: patch
+description: 'Build(deps-dev): Bump @types/react-syntax-highlighter from 15.5.10 to
+    15.5.13'
+destination-branches:
+- master
+- iso7
+sections: {}

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@types/qs": "^6.9.15",
     "@types/react-dom": "^18.3.0",
     "@types/react-router-dom": "^5.3.3",
-    "@types/react-syntax-highlighter": "^15.5.10",
+    "@types/react-syntax-highlighter": "^15.5.13",
     "@types/react-test-renderer": "^18.3.0",
     "@types/styled-components": "^5.1.26",
     "@types/uuid": "^9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1157,7 +1157,7 @@ __metadata:
     "@types/qs": "npm:^6.9.15"
     "@types/react-dom": "npm:^18.3.0"
     "@types/react-router-dom": "npm:^5.3.3"
-    "@types/react-syntax-highlighter": "npm:^15.5.10"
+    "@types/react-syntax-highlighter": "npm:^15.5.13"
     "@types/react-test-renderer": "npm:^18.3.0"
     "@types/styled-components": "npm:^5.1.26"
     "@types/uuid": "npm:^9"
@@ -2609,12 +2609,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react-syntax-highlighter@npm:^15.5.10":
-  version: 15.5.10
-  resolution: "@types/react-syntax-highlighter@npm:15.5.10"
+"@types/react-syntax-highlighter@npm:^15.5.13":
+  version: 15.5.13
+  resolution: "@types/react-syntax-highlighter@npm:15.5.13"
   dependencies:
     "@types/react": "npm:*"
-  checksum: 10/46a2b39784f6b2a52f089d459949dd1a642630beba64660bb89fcaed1f827535b6027618da2600c0f0e2bd585b2e51c93b2758cd2fcecc159184bbb024441eda
+  checksum: 10/0cc47785326aea5effac9ee68c263abc6448c63b6a084eec3084fd13c08da93addfdc3102ff919cbe420aa71fbded9bf041cc2c51fe625c6ee0751e8a131bd38
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Pull request opened by the merge tool on behalf of #5813