### PR TITLE
Build(deps): Bump @patternfly/react-tokens from 5.2.1 to 5.3.1 (#5837)

### DIFF
--- a/changelogs/unreleased/5837-dependabot.yml
+++ b/changelogs/unreleased/5837-dependabot.yml
@@ -1,0 +1,6 @@
+change-type: patch
+description: 'Build(deps): Bump @patternfly/react-tokens from 5.2.1 to 5.3.1'
+destination-branches:
+- master
+- iso7
+sections: {}

--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
     "@patternfly/react-icons": "^5.3.2",
     "@patternfly/react-styles": "^5.2.0",
     "@patternfly/react-table": "^5.2.1",
-    "@patternfly/react-tokens": "^5.1.2",
+    "@patternfly/react-tokens": "^5.3.1",
     "@react-keycloak/web": "^3.4.0",
     "@tanstack/react-query": "^5.37.1",
     "@tanstack/react-query-devtools": "^5.31.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1144,7 +1144,7 @@ __metadata:
     "@patternfly/react-icons": "npm:^5.3.2"
     "@patternfly/react-styles": "npm:^5.2.0"
     "@patternfly/react-table": "npm:^5.2.1"
-    "@patternfly/react-tokens": "npm:^5.1.2"
+    "@patternfly/react-tokens": "npm:^5.3.1"
     "@react-keycloak/web": "npm:^3.4.0"
     "@tanstack/react-query": "npm:^5.37.1"
     "@tanstack/react-query-devtools": "npm:^5.31.0"
@@ -1867,6 +1867,13 @@ __metadata:
   version: 5.2.1
   resolution: "@patternfly/react-tokens@npm:5.2.1"
   checksum: 10/6dc162ad30c3b480e15e4aef90c41b923c70fd4e11c7f6e54f3341d4675800d3248e9b28ebe64b7860d790aa2751dd25fd838622fa7ed0ac172731a42f806a6a
+  languageName: node
+  linkType: hard
+
+"@patternfly/react-tokens@npm:^5.3.1":
+  version: 5.3.1
+  resolution: "@patternfly/react-tokens@npm:5.3.1"
+  checksum: 10/bdc63babf07969f6c959ee6f8368239fe00090ac39b265961130638dad613b3680ba7f660805c73d1a7a83baf84d74293f3f071bbc6d8f5b4fc43dcbd6e6dd11
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Pull request opened by the merge tool on behalf of #5837