### PR TITLE
Bugfix for copy id/identifier being grayed out

### DIFF
--- a/changelogs/unreleased/5827-copy-id-display-bug.yml
+++ b/changelogs/unreleased/5827-copy-id-display-bug.yml
@@ -1,0 +1,6 @@
+description: Update copy id/service_identifier icon to not be grayed out.
+issue-nr: 5827
+change-type: patch
+destination-branches: [master, iso7]
+sections:
+  bugfix: "{{description}}"

--- a/src/Slices/ServiceInventory/UI/InstanceRow.tsx
+++ b/src/Slices/ServiceInventory/UI/InstanceRow.tsx
@@ -68,9 +68,9 @@ export const InstanceRow: React.FC<Props> = ({
             dataLabel={idDataLabel}
             aria-label={`IdentityCell-${row.serviceIdentityValue}`}
           >
+            {row.serviceIdentityValue}
             <CopyMultiOptions
               options={[row.serviceIdentityValue, row.id.full]}
-              text={row.serviceIdentityValue}
             />
           </Td>
         ) : (

--- a/src/UI/Components/CopyMultiOptions/CopyMultiOptions.tsx
+++ b/src/UI/Components/CopyMultiOptions/CopyMultiOptions.tsx
@@ -13,7 +13,7 @@ import styled from "styled-components";
 import { words } from "@/UI";
 
 interface Props {
-  text: string;
+  text?: string;
   options: string[];
   tooltipContent?: string;
   isDisabled?: boolean;
@@ -34,7 +34,7 @@ export const CopyMultiOptions: React.FC<Props> = ({
   options,
   tooltipContent,
   isDisabled,
-  text,
+  text = "",
 }) => {
   const [isOpen, setIsOpen] = useState(false);
   const [copied, setCopied] = useState(false);
@@ -79,7 +79,7 @@ export const CopyMultiOptions: React.FC<Props> = ({
       aria-label="Copy to clipboard"
     >
       {text}
-      <SpacedCopyIcon />
+      <CopyIcon />
     </MenuToggle>
   );
 
@@ -108,8 +108,4 @@ export const CopyMultiOptions: React.FC<Props> = ({
 
 const WidthLimitedTooltip = styled(Tooltip)`
   width: 150px;
-`;
-
-const SpacedCopyIcon = styled(CopyIcon)`
-  margin-left: 5px;
 `;


### PR DESCRIPTION
# Description

Separated the text from the copy button but kept the possibility to add text to the component if needed elsewhere.

closes #5827 

# Self Check:

https://github.com/inmanta/web-console/assets/44098050/47f20fff-c90a-491b-962c-312335cf8a8f


