### PR TITLE
fix inconsistent casing

### DIFF
--- a/changelogs/unreleased/align-casing-discovered-resources.yml
+++ b/changelogs/unreleased/align-casing-discovered-resources.yml
@@ -1,0 +1,5 @@
+description: Align the casing of the table headings in the discovered resource page.
+change-type: patch
+destination-branches: [master, iso7]
+sections:
+  minor-improvement: "{{description}}"

--- a/cypress/e2e/scenario-2.1-basic-service.cy.js
+++ b/cypress/e2e/scenario-2.1-basic-service.cy.js
@@ -283,6 +283,9 @@ if (Cypress.env("edition") === "iso") {
       // expect the value for address_r1 to be empty
       cy.get(".view-line").contains("address_r1").should("contain", '""');
       cy.get(".view-line > :nth-child(1) > .mtk5").first().type("1.2.3.2/32");
+      cy.get(".view-line > :nth-child(1) > .mtk5")
+        .first()
+        .type("{uparrow}{uparrow}"); // force editor to scroll up
 
       // change the service id to make instance unique
       cy.get(".mtk5").contains("0001").type("{backspace}9");

--- a/src/Slices/ResourceDiscovery/UI/DiscoveredResourcesRow.tsx
+++ b/src/Slices/ResourceDiscovery/UI/DiscoveredResourcesRow.tsx
@@ -40,7 +40,7 @@ export const DiscoveredResourceRow: React.FC<Props> = ({
         </Td>
         <Td
           dataLabel={words("discovered.column.resource_id")}
-          style={{ width: "40vw" }}
+          style={{ width: "50vw" }}
           data-testid={words("discovered.column.resource_id")}
         >
           {row.discovered_resource_id}

--- a/src/Slices/ResourceDiscovery/UI/Page.test.tsx
+++ b/src/Slices/ResourceDiscovery/UI/Page.test.tsx
@@ -80,13 +80,13 @@ test("GIVEN Discovered Resources page THEN shows table", async () => {
   );
 
   // uri is null
-  expect(within(rows[1]).getByTestId("managed resource")).toHaveTextContent("");
+  expect(within(rows[1]).getByTestId("Managed resource")).toHaveTextContent("");
 
   // uri doesn't have a rid
-  expect(within(rows[2]).getByTestId("managed resource")).toHaveTextContent("");
+  expect(within(rows[2]).getByTestId("Managed resource")).toHaveTextContent("");
 
   // uri is an empty string
-  expect(within(rows[3]).getByTestId("managed resource")).toHaveTextContent("");
+  expect(within(rows[3]).getByTestId("Managed resource")).toHaveTextContent("");
 
   await act(async () => {
     const results = await axe(document.body);

--- a/src/UI/words.tsx
+++ b/src/UI/words.tsx
@@ -468,8 +468,8 @@ const dict = {
     "Request the agents to check the current state of each resource and make the current state in-line with the desired state.",
 
   /** Discovered Resources related text */
-  "discovered.column.resource_id": "resource id",
-  "discovered.column.managed_resource": "managed resource",
+  "discovered.column.resource_id": "Resource Id",
+  "discovered.column.managed_resource": "Managed resource",
   "discovered_resources.title": "Discovered Resources",
   "discovered_resources.values": "values",
   "discovered_resources.show_resource": "Show managed resource",


### PR DESCRIPTION
# Description

Aligned the casing of the headings of the table to be consistent with the rest of the app. Also ensured the column with the ID got more spacing. 


https://github.com/inmanta/web-console/assets/44098050/500047f2-4dd6-4d87-bb17-ab6c85c87350

