### PR TITLE
fix bug onchange JSON-editor

### DIFF
--- a/changelogs/unreleased/5892-JSON-editor-bug.yml
+++ b/changelogs/unreleased/5892-JSON-editor-bug.yml
@@ -1,0 +1,6 @@
+description: "Resolve bug when JSON-editor is invalid on initial render."
+issue-nr: 5892
+change-type: patch
+destination-branches: [master, iso7]
+sections:
+  bugfix: "{{description}}"

--- a/cypress/e2e/scenario-2.1-basic-service.cy.js
+++ b/cypress/e2e/scenario-2.1-basic-service.cy.js
@@ -338,7 +338,43 @@ if (Cypress.env("edition") === "iso") {
       cy.get('[aria-label="InstanceRow-Intro"]').should("have.length", 2);
     });
 
-    it("2.1.5 Delete previously created instance", () => {
+    it("2.1.5 JSON editor invalid should disable buttons", () => {
+      // Go from Home page to Service Inventory of Basic-service
+      cy.visit("/console/");
+
+      cy.intercept(
+        "GET",
+        "/lsm/v1/service_inventory/basic-service?include_deployment_progress=True&limit=20&&sort=created_at.desc",
+      ).as("GetServiceInventory");
+
+      cy.get('[aria-label="Environment card"]')
+        .contains("lsm-frontend")
+        .click();
+      cy.get(".pf-v5-c-nav__item").contains("Service Catalog").click();
+      cy.get("#basic-service").contains("Show inventory").click();
+
+      // make sure the call to get inventory has been executed
+      cy.wait("@GetServiceInventory");
+
+      // Add an instance and fill form
+      cy.get("#add-instance-button").click();
+      cy.get("#editorButton").click();
+
+      // expect Form and submit buttons to be disabled
+      cy.get("#formButton").should("be.disabled");
+      cy.get("button").contains("Confirm").should("be.disabled");
+
+      // Cancel form should still be possible.
+      cy.get("button").contains("Cancel").click();
+
+      // make sure the call to get inventory has been executed
+      cy.wait("@GetServiceInventory");
+
+      // expect two rows to be in the inventory still
+      cy.get('[aria-label="InstanceRow-Intro"]').should("have.length", 2);
+    });
+
+    it("2.1.6 Delete previously created instance", () => {
       cy.visit("/console/");
 
       // Add interceptions for the delete and get call to be able to catch responses later on.

--- a/src/UI/Components/JSONEditor/JSONEditor.tsx
+++ b/src/UI/Components/JSONEditor/JSONEditor.tsx
@@ -9,7 +9,7 @@ import { DependencyContext } from "@/UI";
 interface Props {
   service_entity: string;
   data: string;
-  onChange: (value: string) => void;
+  onChange: (value: string, valid: boolean) => void;
 }
 
 /**
@@ -66,9 +66,9 @@ export const JSONEditor: React.FC<Props> = ({
   // Whenever the editorState has changed and no errors are found, call the onChange callback.
   // This prevents the string to be invalid based on the provided schema.
   useEffect(() => {
-    if (errors?.length === 0) {
-      onChange(editorState);
-    }
+    const isValid = errors.length < 1;
+
+    onChange(editorState, isValid);
   }, [editorState, errors, onChange]);
 
   // see https://microsoft.github.io/monaco-editor/typedoc/interfaces/languages.json.ModeConfiguration.html
@@ -107,7 +107,7 @@ export const JSONEditor: React.FC<Props> = ({
   ) : (
     <EditorWrapper data-testid="JSON-Editor-Wrapper">
       <Editor
-        height={"calc(100vh - 500px)"}
+        height={"calc(100vh - 550px)"}
         width={"100%"}
         defaultLanguage="json"
         defaultValue={data}

--- a/src/UI/Components/ServiceInstanceForm/ServiceInstanceForm.tsx
+++ b/src/UI/Components/ServiceInstanceForm/ServiceInstanceForm.tsx
@@ -148,11 +148,11 @@ export const ServiceInstanceForm: React.FC<Props> = ({
 
   // The try catch is there to make certain the provided string is parsable to JSON before setting the formstate.
   const onEditorChange = useCallback(
-    (value: string) => {
+    (value: string, isValid: boolean) => {
       try {
         const parsed = JSON.parse(value);
         setFormState(parsed);
-        setIsEditorValid(true);
+        setIsEditorValid(isValid);
       } catch (error) {
         setIsEditorValid(false);
       }


### PR DESCRIPTION
# Description

The onchange wasn't called correctly when the initial render contained errors, causing two distinctive bugs. 
- The buttons weren't disabled correctly 
- The formstate wasn't updated correctly when going back to the form, or submitting since the onchange wasn't triggering the update.

closes #5892


Uploading onchange-bug-json-editor.mp4…

