### PR TITLE
remove E2E from pipeline for iso6

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -46,24 +46,6 @@ pipeline {
                         }
                     }
                 }
-                stage('Testing with cypress') {
-                    steps {
-                        timeout(time: 20, unit: 'MINUTES') {
-                            dir('web-console') {
-                                sh '''yarn run build;
-                                yarn run install:orchestrator:ci;
-                                yarn run cypress-test:iso;'''
-                            }
-                        }
-                    }
-                    post {
-                        always {
-                            dir('web-console') {
-                                sh'yarn run kill-server'
-                            }
-                        }
-                    }
-                }
             }
             post {
                 always {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,12 +49,7 @@ pipeline {
             }
             post {
                 always {
-                    dir('web-console') {
-                        sh '''npx junit-merge -d cypress/reports/junit -o cypress/reports/cypress-report.xml'''
-                    }
-                    junit 'web-console/junit.xml'
                     cobertura coberturaReportFile: 'web-console/coverage/cobertura-coverage.xml', failNoReports: false, failUnhealthy: false
-                    archiveArtifacts artifacts: 'web-console/cypress/reports/cypress-report.xml, web-console/cypress/screenshots/**, web-console/cypress/videos/**', allowEmptyArchive: true, onlyIfSuccessful: false
                     deleteDir()
                 }
             }

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [Docs](./docs/index.md)
 
+**THIS VERSION IS NOT SUPPORTED ANY LONGER. PLEASE USE A MORE RECENT VERSION.**
+
 ## Intro
 
 This project is the current frontend of for the inmanta service orchestrator.  
@@ -34,7 +36,7 @@ The frontend uses the (patternfly v4 framework)[https://www.patternfly.org/v4/] 
 
     yarn setup-server:lsm # Will setup and install an orchestrator running on port 8888 with lsm modules.
 
-    yarn cypress-test # Run tests with Cypress (Requires the previous command to run succesfully)
+    yarn cypress-test # **THESE ARE NO LONGER IN LINE WITH THE CURRENT MODEL PROVIDED BY THE local-setup.**
 
     yarn kill-server:lsm # This will remove the temporary folder containing the local-setup repo and destroy the docker containers that were setup previously with the setup-server:lsm command.
 

--- a/changelogs/unreleased/end-support-iso6.yml
+++ b/changelogs/unreleased/end-support-iso6.yml
@@ -1,0 +1,5 @@
+description: End of support for ISO6
+change-type: patch
+destination-branches: [iso6]
+sections:
+  deprecation-note: "{{description}}"


### PR DESCRIPTION
# Description

REMOVING SUPPORT FOR ISO6

The e2e tests are no longer expected to be maintained for this version. I removed them from the pipeline.
