### PR TITLE
update 2E2 tests based on upgrade DELETE project endpoint

### DIFF
--- a/changelogs/unreleased/buildmaster-update-e2e.yml
+++ b/changelogs/unreleased/buildmaster-update-e2e.yml
@@ -1,0 +1,3 @@
+description: Updated the first scenario based on changes on the delete project endpoint.
+change-type: patch
+destination-branches: [master, iso7]

--- a/cypress/e2e/scenario-1-environment.cy.js
+++ b/cypress/e2e/scenario-1-environment.cy.js
@@ -135,9 +135,7 @@ describe("Environment", () => {
     //go back to home and check if env is visible
     cy.get(".pf-v5-c-breadcrumb__item").eq(0).click();
 
-    cy.get('[aria-label="Environment card"]')
-    .contains(testName(2))
-    .click();
+    cy.get('[aria-label="Environment card"]').contains(testName(2)).click();
 
     openSettings(testName(2));
     deleteEnv(testName(2), testProjectName(2));

--- a/cypress/e2e/scenario-1-environment.cy.js
+++ b/cypress/e2e/scenario-1-environment.cy.js
@@ -134,40 +134,21 @@ describe("Environment", () => {
 
     //go back to home and check if env is visible
     cy.get(".pf-v5-c-breadcrumb__item").eq(0).click();
-    cy.get('[aria-label="Environment card"]').should(
-      "any.contain",
-      testName(2),
-    );
-  });
 
-  it("1.3 delete an environment", function () {
-    //Fill The form and submit
-    cy.visit("/console/environment/create");
-    fillCreateEnvForm({
-      envName: testName(3),
-      projectName: testProjectName(3),
-      shouldPassEnvName: true,
-      fillOptionalInputs: true,
-    });
+    cy.get('[aria-label="Environment card"]')
+    .contains(testName(2))
+    .click();
 
-    cy.get("button").contains("Submit").click();
-
-    if (Cypress.env("edition") === "iso") {
-      cy.url().should("contain", "/console/lsm/catalog?env=", {
-        timeout: 10000,
-      });
-    }
-
-    openSettings(testName(3));
-    deleteEnv(testName(3), testProjectName(3));
+    openSettings(testName(2));
+    deleteEnv(testName(2), testProjectName(2));
   });
 
   it("1.4 Edit created environment", function () {
     //Fill The form and submit
     cy.visit("/console/environment/create");
     fillCreateEnvForm({
-      envName: testName(4),
-      projectName: testProjectName(4),
+      envName: testName(3),
+      projectName: testProjectName(3),
       shouldPassEnvName: true,
       fillOptionalInputs: true,
     });
@@ -181,7 +162,7 @@ describe("Environment", () => {
       });
     }
 
-    openSettings(testName(4));
+    openSettings(testName(3));
 
     //change Name value
     cy.get('[aria-label="Name-toggle-edit"]').click();
@@ -237,6 +218,9 @@ describe("Environment", () => {
 
     cy.get("button").contains('Create "New Value Project Name"').click();
     cy.get('[aria-label="Project Name-submit-edit"]').click();
+
+    openSettings("New Value Name");
+    deleteEnv("New Value Name", testProjectName(3));
   });
 
   // specific to ISO


### PR DESCRIPTION
# Description

The endpoint to delete projects now requires all environments to be deleted within. I added a delete to each section, and thus removed the case specific to deleting an environment. 

Ran the oss tests to make sure they were also working. 

<img width="542" alt="image" src="https://github.com/user-attachments/assets/42324593-448e-4c7f-a88d-65875b4c40a0">
