### PR TITLE
autocomplete bugfix for iso7

### DIFF
--- a/changelogs/unreleased/5993-autocomplete-null-bug.yml
+++ b/changelogs/unreleased/5993-autocomplete-null-bug.yml
@@ -1,0 +1,6 @@
+description: Resolve issue when inter-service relation attribute value is set to null AutoCompleteInput crashes.
+issue-nr: 5993
+change-type: patch
+destination-branches: [master, iso7]
+sections:
+  bugfix: "{{description}}"

--- a/changelogs/unreleased/5993-autocomplete-null-bug.yml
+++ b/changelogs/unreleased/5993-autocomplete-null-bug.yml
@@ -1,6 +1,6 @@
 description: Resolve issue when inter-service relation attribute value is set to null AutoCompleteInput crashes.
 issue-nr: 5993
 change-type: patch
-destination-branches: [master, iso7]
+destination-branches: [iso7]
 sections:
   bugfix: "{{description}}"

--- a/src/UI/Components/ServiceInstanceForm/Components/AutoCompleteInputProvider.tsx
+++ b/src/UI/Components/ServiceInstanceForm/Components/AutoCompleteInputProvider.tsx
@@ -7,7 +7,7 @@ import { AutoCompleteInput } from "./AutoCompleteInput";
 interface Props {
   serviceName: string;
   attributeName: string;
-  attributeValue: string | string[];
+  attributeValue: string | string[] | null;
   description?: string;
   isOptional: boolean;
   isDisabled?: boolean;
@@ -16,6 +16,22 @@ interface Props {
   multi?: boolean;
 }
 
+/**
+ * A React component that provides an autocomplete input field for inter service relations.
+ *
+ * @props {object} props - The properties passed to the component.
+ * @prop {string} serviceName - The name of the service.
+ * @prop {string} attributeName - The name of the attribute.
+ * @prop {string | string[] | null} attributeValue - The value of the attribute.
+ * @prop {string} description - The description of the attribute.
+ * @prop {boolean} isOptional - Whether the attribute is optional.
+ * @prop {boolean} isDisabled - Whether the input field should be disabled.
+ * @prop {(value): void;} handleInputChange - The function to handle input changes.
+ * @prop {string[]} alreadySelected - The already selected options.
+ * @prop {boolean} multi - Whether multiple options can be selected.
+ *
+ * @returns {React.FC<Props> | null} The rendered autocomplete input field or null if the data is not yet available or fetching failed.
+ */
 export const AutoCompleteInputProvider: React.FC<Props> = ({
   serviceName,
   attributeName,
@@ -66,10 +82,14 @@ export const AutoCompleteInputProvider: React.FC<Props> = ({
             const displayName = service_identity_attribute_value
               ? service_identity_attribute_value
               : id;
+
+            const isSelected =
+              alreadySelected !== null && alreadySelected.includes(id); //it can be that the value for inter-service relation is set to null
+
             return {
               displayName,
               value: id,
-              isSelected: alreadySelected.includes(id),
+              isSelected,
             };
           },
         );

--- a/src/UI/Components/ServiceInstanceForm/Components/RelatedServiceProvider.tsx
+++ b/src/UI/Components/ServiceInstanceForm/Components/RelatedServiceProvider.tsx
@@ -8,7 +8,7 @@ import { AutoCompleteInputProvider } from "./AutoCompleteInputProvider";
 interface Props {
   serviceName: string;
   attributeName: string;
-  attributeValue: string | string[];
+  attributeValue: string | string[] | null;
   description?: string;
   isOptional: boolean;
   handleInputChange: (value) => void;
@@ -16,6 +16,21 @@ interface Props {
   multi?: boolean;
 }
 
+/**
+ * A React component that provides related services for the inter-service relation input.
+ *
+ * @props {object} props - The properties passed to the component.
+ * @prop {string} serviceName - The name of the service.
+ * @prop {string} attributeName - The name of the attribute.
+ * @prop {string | string[] | null} attributeValue - The value of the attribute.
+ * @prop {string} description - The description of the attribute.
+ * @prop {boolean} isOptional - Whether the attribute is optional.
+ * @prop {(value): void} handleInputChange - The function to handle input changes.
+ * @prop {string[]} alreadySelected - The already selected options.
+ * @prop {boolean} multi - Whether multiple options can be selected.
+ *
+ * @returns {React.FC<Props>| null} The rendered input with fetched related services, null if the data is not yet available or Alert if the fetching failed.
+ */
 export const RelatedServiceProvider: React.FC<Props> = ({
   serviceName,
   attributeName,


### PR DESCRIPTION
Resolve issue when inter-service relation attribute value is set to null AutoCompleteInput crashes. (Issue #5993, PR #5995)

Previously opening the interfaces would crash the app as Autocomplete didn't handle null values

closes #5993

https://github.com/user-attachments/assets/571530ee-1ed5-4eb0-9bce-ccb433fdeaed


# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Code is clear and sufficiently documented
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
