### PR TITLE
Add support for nested status properties

### DIFF
--- a/changelogs/unreleased/6018-nested-status-properties.yml
+++ b/changelogs/unreleased/6018-nested-status-properties.yml
@@ -1,0 +1,6 @@
+description: Support nested status properties in the Status Page
+issue-nr: 6018
+change-type: patch
+destination-branches: [master]
+sections:
+  minor-improvement: "{{description}}"

--- a/src/Slices/Status/UI/StatusItem.tsx
+++ b/src/Slices/Status/UI/StatusItem.tsx
@@ -10,10 +10,11 @@ import {
   FlexItem,
 } from "@patternfly/react-core";
 import styled from "styled-components";
+import { DetailTuple } from "./StatusList";
 
 interface Props {
   name: string;
-  details: [string, Record<string, string> | string][];
+  details: DetailTuple[];
   icon: React.ReactNode;
   category?: string;
 }
@@ -23,9 +24,9 @@ interface Props {
  *
  * @props {Props} props - The properties for the status item component.
  * @prop {string} name - The name of the status item.
- * @prop {Array<[string, unknown]>} details - The details of the status item, which can include nested objects.
+ * @prop {DetailTuple[]} details - The details of the status item, which can include nested objects.
  * @prop {React.ReactNode} icon - The icon to display for the status item.
- * @prop {string} category - The category of the status item.
+ * @prop {string} [category] - The category of the status item.
  * @returns {React.FC<Props>} The rendered status item component.
  */
 export const StatusItem: React.FC<Props> = ({
@@ -70,16 +71,16 @@ const Category = styled.span`
 
 const InlineTitle = styled(Title)`
   display: inline-block;
-  padding-right: 8px;
+  padding-right: var(--pf-v5-global--spacer--sm);
 `;
 
 const CompactDescriptionList = styled(DescriptionList)`
   --pf-v5-c-description-list--m-compact--RowGap: 0;
-  margin-bottom: 16px;
+  margin-bottom: var(--pf-v5-global--spacer--md);
 `;
 
 const IndentedDescriptionListGroup = styled(DescriptionListGroup)`
-  padding-left: 1rem;
+  padding-left: var(--pf-v5-global--spacer--md);
 `;
 
 interface SubListProps {

--- a/src/Slices/Status/UI/StatusItem.tsx
+++ b/src/Slices/Status/UI/StatusItem.tsx
@@ -46,7 +46,9 @@ export const StatusItem: React.FC<Props> = ({
           <CompactDescriptionList isHorizontal isCompact isFluid>
             {details.map(([key, value]) => {
               if (typeof value === "object") {
-                return <SubList key={key} name={key} properties={value} />;
+                return (
+                  <NestedListItem key={key} name={key} properties={value} />
+                );
               } else {
                 return (
                   <DescriptionListGroup key={key}>
@@ -83,7 +85,7 @@ const IndentedDescriptionListGroup = styled(DescriptionListGroup)`
   padding-left: var(--pf-v5-global--spacer--md);
 `;
 
-interface SubListProps {
+interface NestedListItemProps {
   name: string;
   properties: Record<string, string>;
 }
@@ -91,14 +93,17 @@ interface SubListProps {
 /**
  * Renders sub list for Status value that is a Record instead of string.
  *
- * @props {SubListProps} props - The properties for the SubList component.
+ * @props {NestedListItemProps} props - The properties for the NestedListItem component.
  * @prop {string} name - The name of the property.
- * @prop {Record<string, string>} properties - The sub properties to display in the SubList components.
- * @returns {React.FC<SubListProps>} The rendered SubList component.
+ * @prop {Record<string, string>} properties - The sub properties to display in the NestedListItem components.
+ * @returns {React.FC<NestedListItemProps>} The rendered NestedListItem component.
  */
-const SubList: React.FC<SubListProps> = ({ name, properties }) => {
+const NestedListItem: React.FC<NestedListItemProps> = ({
+  name,
+  properties,
+}) => {
   return (
-    <ListItem aria-label={`StatusSubList-${name}`}>
+    <ListItem aria-label={`StatusNestedListItem-${name}`}>
       <DescriptionListGroup>
         <DescriptionListTerm>{name}</DescriptionListTerm>
       </DescriptionListGroup>

--- a/src/Slices/Status/UI/StatusItem.tsx
+++ b/src/Slices/Status/UI/StatusItem.tsx
@@ -13,11 +13,21 @@ import styled from "styled-components";
 
 interface Props {
   name: string;
-  details: [string, string][];
+  details: [string, Record<string, string> | string][];
   icon: React.ReactNode;
   category?: string;
 }
 
+/**
+ * Renders a status item
+ *
+ * @props {Props} props - The properties for the status item component.
+ * @prop {string} name - The name of the status item.
+ * @prop {Array<[string, unknown]>} details - The details of the status item, which can include nested objects.
+ * @prop {React.ReactNode} icon - The icon to display for the status item.
+ * @prop {string} category - The category of the status item.
+ * @returns {React.FC<Props>} The rendered status item component.
+ */
 export const StatusItem: React.FC<Props> = ({
   name,
   details,
@@ -33,12 +43,20 @@ export const StatusItem: React.FC<Props> = ({
       {details.length > 0 && (
         <FlexItem>
           <CompactDescriptionList isHorizontal isCompact isFluid>
-            {details.map(([key, value]) => (
-              <DescriptionListGroup key={key}>
-                <DescriptionListTerm>{key}</DescriptionListTerm>
-                <DescriptionListDescription>{value}</DescriptionListDescription>
-              </DescriptionListGroup>
-            ))}
+            {details.map(([key, value]) => {
+              if (typeof value === "object") {
+                return <SubList key={key} name={key} properties={value} />;
+              } else {
+                return (
+                  <DescriptionListGroup key={key}>
+                    <DescriptionListTerm>{key}</DescriptionListTerm>
+                    <DescriptionListDescription>
+                      {value}
+                    </DescriptionListDescription>
+                  </DescriptionListGroup>
+                );
+              }
+            })}
           </CompactDescriptionList>
         </FlexItem>
       )}
@@ -59,3 +77,36 @@ const CompactDescriptionList = styled(DescriptionList)`
   --pf-v5-c-description-list--m-compact--RowGap: 0;
   margin-bottom: 16px;
 `;
+
+const IndentedDescriptionListGroup = styled(DescriptionListGroup)`
+  padding-left: 1rem;
+`;
+
+interface SubListProps {
+  name: string;
+  properties: Record<string, string>;
+}
+
+/**
+ * Renders sub list for Status value that is a Record instead of string.
+ *
+ * @props {SubListProps} props - The properties for the SubList component.
+ * @prop {string} name - The name of the property.
+ * @prop {Record<string, string>} properties - The sub properties to display in the SubList components.
+ * @returns {React.FC<SubListProps>} The rendered SubList component.
+ */
+const SubList: React.FC<SubListProps> = ({ name, properties }) => {
+  return (
+    <ListItem aria-label={`StatusSubList-${name}`}>
+      <DescriptionListGroup>
+        <DescriptionListTerm>{name}</DescriptionListTerm>
+      </DescriptionListGroup>
+      {Object.entries(properties).map(([subKey, subValue]) => (
+        <IndentedDescriptionListGroup key={name + "_" + subKey}>
+          <DescriptionListTerm>{subKey}</DescriptionListTerm>
+          <DescriptionListDescription>{subValue}</DescriptionListDescription>
+        </IndentedDescriptionListGroup>
+      ))}
+    </ListItem>
+  );
+};

--- a/src/Slices/Status/UI/StatusList.test.tsx
+++ b/src/Slices/Status/UI/StatusList.test.tsx
@@ -163,48 +163,60 @@ describe("Given StatusList", () => {
 
     expect(within(coreSchedulerManagerItem).getByText("total")).toBeVisible();
 
-    const totalSubList = screen.getByLabelText("StatusSubList-total");
+    const totalNestedListItem = screen.getByLabelText(
+      "StatusNestedListItem-total",
+    );
 
-    expect(totalSubList).toBeVisible();
-    expect(within(totalSubList).getByText("total")).toBeVisible();
+    expect(totalNestedListItem).toBeVisible();
+    expect(within(totalNestedListItem).getByText("total")).toBeVisible();
 
-    expect(within(totalSubList).getByText("connected")).toBeVisible();
-    expect(within(totalSubList).getByText("true")).toBeVisible();
+    expect(within(totalNestedListItem).getByText("connected")).toBeVisible();
+    expect(within(totalNestedListItem).getByText("true")).toBeVisible();
 
-    expect(within(totalSubList).getByText("max_pool")).toBeVisible();
-    expect(within(totalSubList).getByText("9")).toBeVisible();
-
-    expect(within(totalSubList).getByText("open_connections")).toBeVisible();
-    expect(within(totalSubList).getByText("3")).toBeVisible();
-
-    expect(within(totalSubList).getByText("free_connections")).toBeVisible();
-    expect(within(totalSubList).getByText("4")).toBeVisible();
+    expect(within(totalNestedListItem).getByText("max_pool")).toBeVisible();
+    expect(within(totalNestedListItem).getByText("9")).toBeVisible();
 
     expect(
-      within(totalSubList).getByText("pool_exhaustion_count"),
+      within(totalNestedListItem).getByText("open_connections"),
     ).toBeVisible();
-    expect(within(totalSubList).getByText("209")).toBeVisible();
-
-    const prodSubList = screen.getByLabelText("StatusSubList-prod");
-
-    expect(prodSubList).toBeVisible();
-    expect(within(prodSubList).getByText("prod")).toBeVisible();
-
-    expect(within(prodSubList).getByText("connected")).toBeVisible();
-    expect(within(prodSubList).getByText("true")).toBeVisible();
-
-    expect(within(prodSubList).getByText("max_pool")).toBeVisible();
-    expect(within(prodSubList).getByText("3")).toBeVisible();
-
-    expect(within(prodSubList).getByText("open_connections")).toBeVisible();
-    expect(within(prodSubList).getByText("1")).toBeVisible();
-
-    expect(within(prodSubList).getByText("free_connections")).toBeVisible();
-    expect(within(prodSubList).getByText("2")).toBeVisible();
+    expect(within(totalNestedListItem).getByText("3")).toBeVisible();
 
     expect(
-      within(prodSubList).getByText("pool_exhaustion_count"),
+      within(totalNestedListItem).getByText("free_connections"),
     ).toBeVisible();
-    expect(within(prodSubList).getByText("209")).toBeVisible();
+    expect(within(totalNestedListItem).getByText("4")).toBeVisible();
+
+    expect(
+      within(totalNestedListItem).getByText("pool_exhaustion_count"),
+    ).toBeVisible();
+    expect(within(totalNestedListItem).getByText("209")).toBeVisible();
+
+    const prodNestedListItem = screen.getByLabelText(
+      "StatusNestedListItem-prod",
+    );
+
+    expect(prodNestedListItem).toBeVisible();
+    expect(within(prodNestedListItem).getByText("prod")).toBeVisible();
+
+    expect(within(prodNestedListItem).getByText("connected")).toBeVisible();
+    expect(within(prodNestedListItem).getByText("true")).toBeVisible();
+
+    expect(within(prodNestedListItem).getByText("max_pool")).toBeVisible();
+    expect(within(prodNestedListItem).getByText("3")).toBeVisible();
+
+    expect(
+      within(prodNestedListItem).getByText("open_connections"),
+    ).toBeVisible();
+    expect(within(prodNestedListItem).getByText("1")).toBeVisible();
+
+    expect(
+      within(prodNestedListItem).getByText("free_connections"),
+    ).toBeVisible();
+    expect(within(prodNestedListItem).getByText("2")).toBeVisible();
+
+    expect(
+      within(prodNestedListItem).getByText("pool_exhaustion_count"),
+    ).toBeVisible();
+    expect(within(prodNestedListItem).getByText("209")).toBeVisible();
   });
 });

--- a/src/Slices/Status/UI/StatusList.test.tsx
+++ b/src/Slices/Status/UI/StatusList.test.tsx
@@ -1,0 +1,210 @@
+import React from "react";
+import { render, screen, within } from "@testing-library/react";
+import { ServerStatus } from "@/Core";
+import { dependencies } from "@/Test";
+import { DependencyProvider } from "@/UI";
+import { StatusList } from "./StatusList";
+
+const status: ServerStatus = {
+  product: "Inmanta Service Orchestrator",
+  edition: "Standard",
+  version: "1.0.0",
+  license: "Inmanta EULA",
+  extensions: [
+    {
+      name: "core",
+      version: "1.1.1",
+      package: "core",
+    },
+  ],
+  slices: [
+    {
+      name: "lsm.order",
+      status: {},
+    },
+    {
+      name: "core.transport",
+      status: {
+        inflight: 2,
+        running: true,
+        sockets: ["0.0.0.0:8888"],
+      },
+    },
+    {
+      name: "core.scheduler_manager",
+      status: {
+        resource_facts: 28,
+        sessions: 7,
+        database: "inmanta",
+        host: "localhost",
+        total: {
+          connected: true,
+          max_pool: 9,
+          open_connections: 3,
+          free_connections: 4,
+          pool_exhaustion_count: 209,
+        },
+        prod: {
+          connected: true,
+          max_pool: 3,
+          open_connections: 1,
+          free_connections: 2,
+          pool_exhaustion_count: 209,
+        },
+      },
+    },
+  ],
+  features: [],
+};
+
+describe("Given StatusList", () => {
+  it("WHEN receiving status object THEN should render correctly list", () => {
+    render(
+      <DependencyProvider dependencies={dependencies}>
+        <StatusList status={status} apiUrl="test" />
+      </DependencyProvider>,
+    );
+
+    expect(screen.getByRole("list", { name: "StatusList" })).toBeVisible();
+
+    const orchestratorItem = screen.getByRole("listitem", {
+      name: "StatusItem-Inmanta Service Orchestrator",
+    });
+
+    expect(orchestratorItem).toBeVisible();
+    expect(screen.getByText("Inmanta Service Orchestrator")).toBeVisible();
+
+    expect(screen.getByText("edition")).toBeVisible();
+    expect(screen.getByText("Standard")).toBeVisible();
+
+    expect(within(orchestratorItem).getByText("version")).toBeVisible();
+    expect(screen.getByText("1.0.0")).toBeVisible();
+
+    expect(screen.getByText("license")).toBeVisible();
+    expect(screen.getByText("Inmanta EULA")).toBeVisible();
+
+    const coreItem = screen.getByRole("listitem", {
+      name: "StatusItem-core",
+    });
+
+    expect(coreItem).toBeVisible();
+
+    expect(
+      within(coreItem).getByRole("heading", { name: "core" }),
+    ).toBeVisible();
+    expect(within(coreItem).getByText("extension")).toBeVisible();
+
+    expect(within(coreItem).getByText("version")).toBeVisible();
+    expect(within(coreItem).getByText("1.1.1")).toBeVisible();
+
+    expect(within(coreItem).getByText("package")).toBeVisible();
+    expect(within(coreItem).getAllByText("core")[1]).toBeVisible(); //the first core component is heading
+
+    const lsmOrderItem = screen.getByRole("listitem", {
+      name: "StatusItem-lsm.order",
+    });
+
+    expect(lsmOrderItem).toBeVisible();
+
+    expect(within(lsmOrderItem).getByText("lsm.order")).toBeVisible();
+    expect(within(lsmOrderItem).getByText("component")).toBeVisible();
+
+    const coreTransportItem = screen.getByRole("listitem", {
+      name: "StatusItem-core.transport",
+    });
+
+    expect(coreTransportItem).toBeVisible();
+
+    within(coreTransportItem);
+    expect(within(coreTransportItem).getByText("core.transport")).toBeVisible();
+    expect(within(coreTransportItem).getByText("component")).toBeVisible();
+
+    expect(within(coreTransportItem).getByText("inflight")).toBeVisible();
+    expect(within(coreTransportItem).getByText("2")).toBeVisible();
+
+    expect(within(coreTransportItem).getByText("running")).toBeVisible();
+    expect(within(coreTransportItem).getByText("true")).toBeVisible();
+
+    expect(within(coreTransportItem).getByText("sockets")).toBeVisible();
+    expect(within(coreTransportItem).getByText("0.0.0.0:8888")).toBeVisible();
+
+    const coreSchedulerManagerItem = screen.getByRole("listitem", {
+      name: "StatusItem-core.scheduler_manager",
+    });
+
+    expect(coreSchedulerManagerItem).toBeVisible();
+
+    expect(
+      within(coreSchedulerManagerItem).getByText("core.scheduler_manager"),
+    ).toBeVisible();
+    expect(
+      within(coreSchedulerManagerItem).getByText("component"),
+    ).toBeVisible();
+
+    expect(
+      within(coreSchedulerManagerItem).getByText("resource_facts"),
+    ).toBeVisible();
+    expect(within(coreSchedulerManagerItem).getByText("28")).toBeVisible();
+
+    expect(
+      within(coreSchedulerManagerItem).getByText("sessions"),
+    ).toBeVisible();
+    expect(within(coreSchedulerManagerItem).getByText("7")).toBeVisible();
+
+    expect(
+      within(coreSchedulerManagerItem).getByText("database"),
+    ).toBeVisible();
+    expect(within(coreSchedulerManagerItem).getByText("inmanta")).toBeVisible();
+
+    expect(within(coreSchedulerManagerItem).getByText("host")).toBeVisible();
+    expect(
+      within(coreSchedulerManagerItem).getByText("localhost"),
+    ).toBeVisible();
+
+    expect(within(coreSchedulerManagerItem).getByText("total")).toBeVisible();
+
+    const totalSubList = screen.getByLabelText("StatusSubList-total");
+
+    expect(totalSubList).toBeVisible();
+    expect(within(totalSubList).getByText("total")).toBeVisible();
+
+    expect(within(totalSubList).getByText("connected")).toBeVisible();
+    expect(within(totalSubList).getByText("true")).toBeVisible();
+
+    expect(within(totalSubList).getByText("max_pool")).toBeVisible();
+    expect(within(totalSubList).getByText("9")).toBeVisible();
+
+    expect(within(totalSubList).getByText("open_connections")).toBeVisible();
+    expect(within(totalSubList).getByText("3")).toBeVisible();
+
+    expect(within(totalSubList).getByText("free_connections")).toBeVisible();
+    expect(within(totalSubList).getByText("4")).toBeVisible();
+
+    expect(
+      within(totalSubList).getByText("pool_exhaustion_count"),
+    ).toBeVisible();
+    expect(within(totalSubList).getByText("209")).toBeVisible();
+
+    const prodSubList = screen.getByLabelText("StatusSubList-prod");
+
+    expect(prodSubList).toBeVisible();
+    expect(within(prodSubList).getByText("prod")).toBeVisible();
+
+    expect(within(prodSubList).getByText("connected")).toBeVisible();
+    expect(within(prodSubList).getByText("true")).toBeVisible();
+
+    expect(within(prodSubList).getByText("max_pool")).toBeVisible();
+    expect(within(prodSubList).getByText("3")).toBeVisible();
+
+    expect(within(prodSubList).getByText("open_connections")).toBeVisible();
+    expect(within(prodSubList).getByText("1")).toBeVisible();
+
+    expect(within(prodSubList).getByText("free_connections")).toBeVisible();
+    expect(within(prodSubList).getByText("2")).toBeVisible();
+
+    expect(
+      within(prodSubList).getByText("pool_exhaustion_count"),
+    ).toBeVisible();
+    expect(within(prodSubList).getByText("209")).toBeVisible();
+  });
+});

--- a/src/Slices/Status/UI/StatusList.tsx
+++ b/src/Slices/Status/UI/StatusList.tsx
@@ -105,6 +105,11 @@ export const StatusList: React.FC<Props> = ({
   );
 };
 
+type DetailKey = string;
+
+type DetailValue = Record<string, string> | string;
+export type DetailTuple = [DetailKey, DetailValue];
+
 /**
  * Converts a Record<string, unknown> to an array of key-value pairs where values are either strings or nested records with string values.
  *
@@ -112,11 +117,9 @@ export const StatusList: React.FC<Props> = ({
  * We know from the core team that we can safely assume that we don't need to handle nested records more than one level deep.
  *
  * @param {Record<string, unknown>} obj - The record to convert.
- * @returns {[string, Record<string, string> | string][]} An array of key-value pairs where values are either strings or nested records with string values.
+ * @returns {DetailTuple[]} An array of key-value pairs where values are either strings or nested records with string values.
  */
-const toDetails = (
-  obj: Record<string, unknown>,
-): [string, Record<string, string> | string][] =>
+const toDetails = (obj: Record<string, unknown>): DetailTuple[] =>
   Object.entries(obj).map(([key, value]) => {
     return [
       key,

--- a/src/Slices/Status/UI/StatusList.tsx
+++ b/src/Slices/Status/UI/StatusList.tsx
@@ -18,6 +18,15 @@ interface Props {
   className?: string;
 }
 
+/**
+ * Renders a list of status items, including product status, API status, web console status, extensions, and slices.
+ *
+ * @props {Props} props - The properties for the status list component.
+ * @prop {ServerStatus} status - The server status object
+ * @prop {string} apiUrl - The API URL to display in the status list.
+ * @prop {string} [className] - Optional additional class name for the list.
+ * @returns {React.FC<Props>} The rendered status list component.
+ */
 export const StatusList: React.FC<Props> = ({
   status,
   apiUrl,
@@ -96,5 +105,49 @@ export const StatusList: React.FC<Props> = ({
   );
 };
 
-const toDetails = (obj: Record<string, unknown>): [string, string][] =>
-  Object.entries(obj).map(([key, value]) => [key, `${value}`]);
+/**
+ * Converts a Record<string, unknown> to an array of key-value pairs where values are either strings or nested records with string values.
+ *
+ * This function iterates over the entries of the provided record and converts each value to a string. If a value is a nested record, it recursively converts all nested values to strings.
+ * We know from the core team that we can safely assume that we don't need to handle nested records more than one level deep.
+ *
+ * @param {Record<string, unknown>} obj - The record to convert.
+ * @returns {[string, Record<string, string> | string][]} An array of key-value pairs where values are either strings or nested records with string values.
+ */
+const toDetails = (
+  obj: Record<string, unknown>,
+): [string, Record<string, string> | string][] =>
+  Object.entries(obj).map(([key, value]) => {
+    return [
+      key,
+      isRecord(value) ? stringifyRecordAttributes(value) : `${value}`,
+    ];
+  });
+
+/**
+ * Converts all attributes of a Record<string, unknown> to strings.
+ *
+ * This function iterates over the entries of the provided record and converts each value to a string.
+ *
+ * @param {Record<string, unknown>} obj - The record whose attributes are to be converted to strings.
+ * @returns {Record<string, string>} A new record with all values converted to strings.
+ */
+const stringifyRecordAttributes = (
+  obj: Record<string, unknown>,
+): Record<string, string> => {
+  return Object.fromEntries(
+    Object.entries(obj).map(([key, value]) => [key, String(value)]),
+  );
+};
+
+/**
+ * Type guard to check if a value is a Record<string, unknown>.
+ *
+ * This function checks if the provided value is an object, is not null, and is not an array.
+ *
+ * @param {unknown} value - The value to check.
+ * @returns {value is Record<string, unknown>} True if the value is a Record<string, unknown>, otherwise false.
+ */
+const isRecord = (value: unknown): value is Record<string, unknown> => {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+};


### PR DESCRIPTION
# Description

Fix the issue that nested properties in status list crash the Page.

![Screenshot 2024-11-06 at 12 06 15](https://github.com/user-attachments/assets/3b5af4ca-92b5-4619-815c-22578e7d7496)

closes #6018 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Code is clear and sufficiently documented
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
