### PR TITLE
Fix missing inter-service relations on the canvas

### DIFF
--- a/changelogs/unreleased/6030-composer-relations-fix.yml
+++ b/changelogs/unreleased/6030-composer-relations-fix.yml
@@ -1,0 +1,6 @@
+description: Fix issue with missing inter-service relations on the canvas
+issue-nr: 6030
+change-type: patch
+destination-branches: [master]
+sections:
+  bugfix: "{{description}}"

--- a/src/Data/Managers/V2/GETTERS/GetInstanceWithRelations/useGetInstanceWithRelations.test.tsx
+++ b/src/Data/Managers/V2/GETTERS/GetInstanceWithRelations/useGetInstanceWithRelations.test.tsx
@@ -120,6 +120,71 @@ test("if the fetched instance has inter-service relation(s) in the model, then q
   ).toEqual("test_mpn_id");
 });
 
+test("if the fetched instance has inter-service relation(s) in the model, and they are stored in the array in the instance, then query will return the given instance with that related instance(s)", async () => {
+  server.use(
+    http.get("/lsm/v1/service_inventory", async (params) => {
+      if (params.request.url.match(/test_id/)) {
+        return HttpResponse.json({
+          data: {
+            ...testInstance,
+            id: "test_id",
+            referenced_by: ["test_mpn_id"],
+          },
+        });
+      }
+
+      if (params.request.url.match(/child_id/)) {
+        return HttpResponse.json({
+          data: {
+            id: "child_id",
+            environment: "env",
+            service_entity: "child-service",
+            version: 4,
+            config: {},
+            state: "up",
+            candidate_attributes: null,
+            active_attributes: {
+              name: "child-test",
+              service_id: "123523534623",
+              parent_entity: ["test_mpn_id"],
+              should_deploy_fail: false,
+            },
+            rollback_attributes: null,
+            created_at: "2023-09-19T14:40:08.999123",
+            last_updated: "2023-09-19T14:40:36.178723",
+            callback: [],
+            deleted: false,
+            deployment_progress: null,
+            service_identity_attribute_value: "child-test",
+            referenced_by: [],
+          },
+        });
+      }
+
+      return HttpResponse.json({
+        data: { ...testInstance, id: "test_mpn_id" },
+      });
+    }),
+  );
+  const { result } = renderHook(
+    () =>
+      useGetInstanceWithRelations("child_id", "env", childModel).useOneTime(),
+    {
+      wrapper: createWrapper(),
+    },
+  );
+
+  await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+  expect(result.current.data).toBeDefined();
+  expect(result.current.data?.instance.id).toEqual("child_id");
+  expect(result.current.data?.interServiceRelations).toHaveLength(1);
+  expect(
+    (result.current.data?.interServiceRelations as ServiceInstanceModel[])[0]
+      .id,
+  ).toEqual("test_mpn_id");
+});
+
 test("when instance returned has not referenced instance(s), then the query will return the given instance without interServiceRelations", async () => {
   const { result } = renderHook(
     () =>

--- a/src/Data/Managers/V2/GETTERS/GetInstanceWithRelations/useGetInstanceWithRelations.ts
+++ b/src/Data/Managers/V2/GETTERS/GetInstanceWithRelations/useGetInstanceWithRelations.ts
@@ -127,7 +127,7 @@ export const useGetInstanceWithRelations = (
   ): string[] => {
     // Map relation names to corresponding IDs from attributes
     const relationIds = relationNames
-      .map((relationName) => attributes[relationName])
+      .flatMap((relationName) => attributes[relationName]) //relations can be in the array of strings so we need to flatten it just in case
       .filter((id): id is string => typeof id === "string"); // Filter to ensure only you only keep strings
 
     // Extract IDs from embedded relations recursively


### PR DESCRIPTION
# Description

useGetInstanceWith relations was omitting inter-service relations in an array, that PR resolves that

closes #6030 


![Screenshot 2024-11-07 at 11 51 56](https://github.com/user-attachments/assets/afb458eb-8c21-4fe7-ae24-18a74948a22d)
