### PR TITLE
Hide form actions in composer viewer

### DIFF
--- a/changelogs/unreleased/6036-actions-composer-viewer.yml
+++ b/changelogs/unreleased/6036-actions-composer-viewer.yml
@@ -1,0 +1,4 @@
+description: Hide Form Actions buttons in the Composer Viewer
+issue-nr: 6036
+change-type: patch
+destination-branches: [master]

--- a/src/UI/Components/Diagram/Canvas.test.tsx
+++ b/src/UI/Components/Diagram/Canvas.test.tsx
@@ -190,4 +190,26 @@ describe("Canvas.tsx", () => {
 
     expect(modal).not.toBeVisible();
   });
+
+  it("renders right sidebar with disabled buttons when not editable", async () => {
+    const component = setup(
+      mockedInstanceTwoServiceModel,
+      mockedInstanceTwo,
+      [mockedInstanceTwoServiceModel],
+      false,
+    );
+
+    render(component);
+    const headerLabel = await screen.findByJointSelector("headerLabel");
+
+    await act(async () => {
+      await user.click(headerLabel);
+    });
+
+    const removeButton = await screen.queryByText("Remove");
+    const editButton = await screen.queryByText("Edit");
+
+    expect(removeButton).toBeNull();
+    expect(editButton).toBeNull();
+  });
 });

--- a/src/UI/Components/Diagram/Canvas.test.tsx
+++ b/src/UI/Components/Diagram/Canvas.test.tsx
@@ -191,7 +191,7 @@ describe("Canvas.tsx", () => {
     expect(modal).not.toBeVisible();
   });
 
-  it("renders right sidebar with disabled buttons when not editable", async () => {
+  it("renders right sidebar without buttons when not editable", async () => {
     const component = setup(
       mockedInstanceTwoServiceModel,
       mockedInstanceTwo,

--- a/src/UI/Components/Diagram/Canvas.tsx
+++ b/src/UI/Components/Diagram/Canvas.tsx
@@ -171,7 +171,7 @@ export const Canvas: React.FC<Props> = ({ editable }) => {
           ref={LeftSidebar}
         />
         <CanvasContainer className="canvas" data-testid="canvas" ref={Canvas} />
-        <RightSidebar />
+        <RightSidebar editable={editable} />
         <ZoomHandlerContainer className="zoom-handler" ref={ZoomHandler} />
       </CanvasWrapper>
     </EventWrapper>

--- a/src/UI/Components/Diagram/Context/ComposerEditorProvider.test.tsx
+++ b/src/UI/Components/Diagram/Context/ComposerEditorProvider.test.tsx
@@ -242,7 +242,8 @@ describe("ComposerEditorProvider", () => {
 
     expect(title).toBeInTheDocument();
   });
-  it("if provider is editable show Instance Composer Editor title ", async () => {
+
+  it("if provider is not editable show Instance Composer Viewer title ", async () => {
     render(setup("13920268-cce0-4491-93b5-11316aa2fc37", false));
 
     const title = await screen.findByText("Instance Composer Viewer");

--- a/src/UI/Components/Diagram/components/RightSidebar.tsx
+++ b/src/UI/Components/Diagram/components/RightSidebar.tsx
@@ -31,6 +31,9 @@ interface Props {
  * - Embedded entities are removed from the canvas(if service model allows it), and will be erased from the service instance.
  * - Inter-service relation entities are removed from the canvas(if service model allows it), but won't be deleted from the environment.
  *
+ * @props {Props} props - The properties passed to the component
+ * @prop {boolean} editable - A flag indication if the composer is editable
+ *
  * @returns {React.FC} The RightSidebar component.
  */
 export const RightSidebar: React.FC<Props> = ({ editable }) => {

--- a/src/UI/Components/Diagram/components/RightSidebar.tsx
+++ b/src/UI/Components/Diagram/components/RightSidebar.tsx
@@ -15,6 +15,10 @@ import { updateServiceOrderItems } from "../helpers";
 import { ActionEnum, EmbeddedEventEnum } from "../interfaces";
 import { EntityForm } from "./EntityForm";
 
+interface Props {
+  editable: boolean;
+}
+
 /**
  * `RightSidebar` is a React functional component that renders a sidebar for editing and removing entities.
  * The sidebar displays the details of the selected entity and provides options to edit or remove the entity.
@@ -29,7 +33,7 @@ import { EntityForm } from "./EntityForm";
  *
  * @returns {React.FC} The RightSidebar component.
  */
-export const RightSidebar: React.FC = () => {
+export const RightSidebar: React.FC<Props> = ({ editable }) => {
   const { cellToEdit, diagramHandlers, setServiceOrderItems, stencilState } =
     useContext(CanvasContext);
   const { mainService } = useContext(InstanceComposerContext);
@@ -227,7 +231,7 @@ export const RightSidebar: React.FC = () => {
           />
         )}
 
-        {!isFormOpen && (
+        {!(isFormOpen || !editable) && (
           <Flex justifyContent={{ default: "justifyContentCenter" }}>
             <FlexItem>
               <StyledButton


### PR DESCRIPTION
# Description

Hide form actions buttons in the instance composer viewer.

![Screenshot 2024-11-12 at 09 37 28](https://github.com/user-attachments/assets/a67acddc-0ccb-41a5-9321-ad6984837486)

closes #6036 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [x] Changelog entry
- [x] Code is clear and sufficiently documented
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
