### PR TITLE
Buildmaster update env settings e2e test

### DIFF
--- a/changelogs/unreleased/buildmaster-update-e2e-env-settings.yml
+++ b/changelogs/unreleased/buildmaster-update-e2e-env-settings.yml
@@ -1,0 +1,3 @@
+description: Update the Environment scenario. Some environment settings have been removed in the Orchestrator, and shouldn't be asserted anymore in the E2E test.
+change-type: patch
+destination-branches: [master]

--- a/cypress/e2e/scenario-1-environment.cy.js
+++ b/cypress/e2e/scenario-1-environment.cy.js
@@ -340,22 +340,6 @@ describe("Environment", () => {
       .find(".pf-v5-c-form-control input")
       .should("have.value", "20");
 
-    //Change autostart_agent_map
-    cy.get('[aria-label="Row-autostart_agent_map"]')
-      .find('[aria-label="editEntryValue"]')
-      .filter((key, $el) => {
-        return $el.value === "local:";
-      })
-      .type("{selectAll}{backspace}new value");
-    cy.get('[data-testid="Warning"]').should("exist");
-    cy.get('[aria-label="Row-autostart_agent_map"]')
-      .find('[aria-label="SaveAction"]')
-      .click();
-    cy.get('[data-testid="Warning"]').should("not.exist");
-    cy.get('[aria-label="Row-autostart_agent_map"]')
-      .find('[aria-label="editEntryValue"]')
-      .should("have.value", "new value");
-
     //Change autostart_agent_repair_interval
     cy.get('[aria-label="Row-autostart_agent_repair_interval"]')
       .find(".pf-v5-c-form-control")
@@ -405,20 +389,6 @@ describe("Environment", () => {
       .find(".pf-v5-c-form-control input")
       .should("have.value", "110");
 
-    //Change environment_agent_trigger_method
-    cy.get(
-      '[aria-label="EnumInput-environment_agent_trigger_methodFilterInput"]',
-    ).click();
-    cy.get('[role="option"]').contains("push_full_deploy").click();
-    cy.get('[data-testid="Warning"]').should("exist");
-    cy.get('[aria-label="Row-environment_agent_trigger_method"]')
-      .find('[aria-label="SaveAction"]')
-      .click();
-    cy.get('[data-testid="Warning"]').should("not.exist");
-    cy.get(
-      '[aria-label="EnumInput-environment_agent_trigger_methodFilterInput"]',
-    ).should("have.value", "push_full_deploy");
-
     // specific to ISO
     if (Cypress.env("edition") === "iso") {
       // Change lsm_partial_compile
@@ -452,16 +422,6 @@ describe("Environment", () => {
       .click();
     cy.get('[data-testid="Warning"]').should("exist");
     cy.get('[aria-label="Row-protected_environment"]')
-      .find('[aria-label="SaveAction"]')
-      .click();
-    cy.get('[data-testid="Warning"]').should("not.exist");
-
-    //Change push_on_auto_deploy
-    cy.get('[aria-label="Row-push_on_auto_deploy"]')
-      .find(".pf-v5-c-switch")
-      .click();
-    cy.get('[data-testid="Warning"]').should("exist");
-    cy.get('[aria-label="Row-push_on_auto_deploy"]')
       .find('[aria-label="SaveAction"]')
       .click();
     cy.get('[data-testid="Warning"]').should("not.exist");

--- a/cypress/e2e/scenario-1-environment.cy.js
+++ b/cypress/e2e/scenario-1-environment.cy.js
@@ -294,20 +294,6 @@ describe("Environment", () => {
     openSettings(testName(6), testProjectName(6));
     cy.get("button").contains("Configuration").click();
 
-    //Change agent_trigger_method_on_auto_deploy
-    cy.get(
-      '[aria-label="EnumInput-agent_trigger_method_on_auto_deployFilterInput"]',
-    ).click();
-    cy.get('[role="option"]').contains("push_full_deploy").click();
-    cy.get('[data-testid="Warning"]').should("exist");
-    cy.get('[aria-label="Row-agent_trigger_method_on_auto_deploy"]')
-      .find('[aria-label="SaveAction"]')
-      .click();
-    cy.get('[data-testid="Warning"]').should("not.exist");
-    cy.get(
-      '[aria-label="EnumInput-agent_trigger_method_on_auto_deployFilterInput"]',
-    ).should("have.value", "push_full_deploy");
-
     //Change auto_deploy
     cy.get('[aria-label="Row-auto_deploy"]').find(".pf-v5-c-switch").click();
     cy.get('[data-testid="Warning"]').should("exist");

--- a/cypress/e2e/scenario-3-service-details.cy.js
+++ b/cypress/e2e/scenario-3-service-details.cy.js
@@ -342,7 +342,7 @@ if (Cypress.env("edition") === "iso") {
       });
     });
 
-    it("3.4 Callbacks", () => {
+    xit("3.4 Callbacks", () => {
       // Select card 'test' environment on home page
       cy.visit("/console/");
       cy.get('[aria-label="Environment card"]')


### PR DESCRIPTION
# Description

It was agreed as a temporary work around to skip the test about callbacks in the 3rd scenario.
I removed the assertions in the environment settings that were removed by the Core team on the orchestrator. 