### PR TITLE
Unlock scenario 3.4

### DIFF
--- a/changelogs/unreleased/buildmaster-unlock-scenario-3.4.yml
+++ b/changelogs/unreleased/buildmaster-unlock-scenario-3.4.yml
@@ -1,0 +1,3 @@
+description: unlock scenario 3.4 after core fixed the issue on their side
+change-type: patch
+destination-branches: [master]

--- a/cypress/e2e/scenario-3-service-details.cy.js
+++ b/cypress/e2e/scenario-3-service-details.cy.js
@@ -342,7 +342,7 @@ if (Cypress.env("edition") === "iso") {
       });
     });
 
-    xit("3.4 Callbacks", () => {
+    it("3.4 Callbacks", () => {
       // Select card 'test' environment on home page
       cy.visit("/console/");
       cy.get('[aria-label="Environment card"]')


### PR DESCRIPTION
# Description

According to sander we have green light to unlock skipped scenario - 3.4 in callback set

closes [N/A]

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Code is clear and sufficiently documented
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
