### PR TITLE
Add flag for coordinates metadata, add test for composerActions

### DIFF
--- a/changelogs/unreleased/5989-actions-composer-flag-tests.yml
+++ b/changelogs/unreleased/5989-actions-composer-flag-tests.yml
@@ -1,0 +1,4 @@
+description: Add v2 flag for coordinates metadata saved in Instance and tests for composer Actions
+issue-nr: 5989
+change-type: patch
+destination-branches: [master]

--- a/src/UI/Components/Diagram/Context/EventWrapper.test.tsx
+++ b/src/UI/Components/Diagram/Context/EventWrapper.test.tsx
@@ -437,7 +437,7 @@ describe("addInterServiceRelationToTracker - eventHandler that adds to the Map i
           detail: {
             id: "1",
             name: "test",
-            relations: [{ current: 0, min: 1, name: "test2" }],
+            relations: [{ currentAmount: 0, min: 1, name: "test2" }],
           },
         }),
       );
@@ -446,7 +446,7 @@ describe("addInterServiceRelationToTracker - eventHandler that adds to the Map i
     expect(result.current).toStrictEqual(
       new Map().set("1", {
         name: "test",
-        relations: [{ current: 0, min: 1, name: "test2" }],
+        relations: [{ currentAmount: 0, min: 1, name: "test2" }],
       }),
     );
   });
@@ -465,7 +465,7 @@ describe("removeInterServiceRelationFromTracker - event handler that removes int
           setInterServiceRelationsOnCanvas(
             new Map().set("1", {
               name: "test",
-              relations: [{ current: 0, min: 1, name: "test2" }],
+              relations: [{ currentAmount: 0, min: 1, name: "test2" }],
             }),
           );
         }, [setInterServiceRelationsOnCanvas]);
@@ -484,7 +484,7 @@ describe("removeInterServiceRelationFromTracker - event handler that removes int
     expect(result.current).toStrictEqual(
       new Map().set("1", {
         name: "test",
-        relations: [{ current: 0, min: 1, name: "test2" }],
+        relations: [{ currentAmount: 0, min: 1, name: "test2" }],
       }),
     );
 
@@ -514,7 +514,7 @@ describe("updateInterServiceRelations", () => {
           setInterServiceRelationsOnCanvas(
             new Map().set("1", {
               name: "test",
-              relations: [{ current: 0, min: 1, name: "test2" }],
+              relations: [{ currentAmount: 0, min: 1, name: "test2" }],
             }),
           );
         }, [setInterServiceRelationsOnCanvas]);
@@ -545,7 +545,7 @@ describe("updateInterServiceRelations", () => {
     expect(result.current).toStrictEqual(
       new Map().set("1", {
         name: "test",
-        relations: [{ current: 1, min: 1, name: "test2" }],
+        relations: [{ currentAmount: 1, min: 1, name: "test2" }],
       }),
     );
 
@@ -564,7 +564,7 @@ describe("updateInterServiceRelations", () => {
     expect(result.current).toStrictEqual(
       new Map().set("1", {
         name: "test",
-        relations: [{ current: 0, min: 1, name: "test2" }],
+        relations: [{ currentAmount: 0, min: 1, name: "test2" }],
       }),
     );
   });

--- a/src/UI/Components/Diagram/Context/EventWrapper.tsx
+++ b/src/UI/Components/Diagram/Context/EventWrapper.tsx
@@ -226,9 +226,9 @@ export const EventWrapper: React.FC<React.PropsWithChildren> = ({
           const relationToUpdate =
             cellsRelations.relations[indexOfRelationToUpdate];
 
-          let current = relationToUpdate.current;
+          let current = relationToUpdate.currentAmount;
 
-          relationToUpdate.current =
+          relationToUpdate.currentAmount =
             action === EventActionEnum.ADD ? ++current : --current;
 
           cellsRelations.relations.splice(

--- a/src/UI/Components/Diagram/actions.test.ts
+++ b/src/UI/Components/Diagram/actions.test.ts
@@ -273,7 +273,7 @@ describe("addDefaultEntities", () => {
     ).toMatchObject({
       name: "child_container",
       id: expect.any(String),
-      relations: [{ current: 0, min: 1, name: "parent-service" }],
+      relations: [{ currentAmount: 0, min: 1, name: "parent-service" }],
     }); //add relations to Tracker
 
     //assert the arguments of the second call - calls is array of the arguments of each call
@@ -521,7 +521,7 @@ describe("appendEmbeddedEntity", () => {
       ).toMatchObject({
         name: "child_container",
         id: expect.any(String),
-        relations: [{ current: 0, min: 1, name: "parent-service" }],
+        relations: [{ currentAmount: 0, min: 1, name: "parent-service" }],
       }); //add relations to Tracker
 
       //assert the arguments of the second call - calls is array of the arguments of each call

--- a/src/UI/Components/Diagram/actions.ts
+++ b/src/UI/Components/Diagram/actions.ts
@@ -92,7 +92,7 @@ export function createComposerEntity({
         relations.push({
           name: relation.entity_type,
           min: relation.lower_limit,
-          current: 0,
+          currentAmount: 0,
         });
       }
     });

--- a/src/UI/Components/Diagram/components/ComposerActions.test.tsx
+++ b/src/UI/Components/Diagram/components/ComposerActions.test.tsx
@@ -1,0 +1,267 @@
+import React, { act } from "react";
+import { MemoryRouter, useLocation } from "react-router-dom";
+import {
+  QueryClient,
+  QueryClientProvider,
+  UseQueryResult,
+} from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { StoreProvider } from "easy-peasy";
+import { delay, http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import { RemoteData } from "@/Core";
+import { getStoreInstance } from "@/Data";
+import { InstanceWithRelations } from "@/Data/Managers/V2/GETTERS/GetInstanceWithRelations";
+import { Inventories } from "@/Data/Managers/V2/GETTERS/GetInventoryList";
+import { dependencies } from "@/Test";
+import { DependencyProvider, EnvironmentHandlerImpl } from "@/UI/Dependency";
+import { PrimaryRouteManager } from "@/UI/Routing";
+import {
+  CanvasContext,
+  defaultCanvasContext,
+  InstanceComposerContext,
+} from "../Context";
+import { childModel } from "../Mocks";
+import { RelationCounterForCell } from "../interfaces";
+import { ComposerActions } from "./ComposerActions";
+const mockedNavigate = jest.fn();
+
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useNavigate: () => mockedNavigate,
+}));
+
+describe("ComposerActions.", () => {
+  const setup = (
+    instanceWithRelations: InstanceWithRelations | null,
+    canvasContext: typeof defaultCanvasContext,
+    editable: boolean = true,
+  ) => {
+    const client = new QueryClient();
+    const environmentHandler = EnvironmentHandlerImpl(
+      useLocation,
+      PrimaryRouteManager(""),
+    );
+    const store = getStoreInstance();
+
+    store.dispatch.environment.setEnvironments(
+      RemoteData.success([
+        {
+          id: "aaa",
+          name: "env-a",
+          project_id: "ppp",
+          repo_branch: "branch",
+          repo_url: "repo",
+          projectName: "project",
+        },
+      ]),
+    );
+
+    return (
+      <QueryClientProvider client={client}>
+        <MemoryRouter initialEntries={[{ search: "?env=aaa" }]}>
+          <StoreProvider store={store}>
+            <DependencyProvider
+              dependencies={{ ...dependencies, environmentHandler }}
+            >
+              <InstanceComposerContext.Provider
+                value={{
+                  serviceModels: [childModel],
+                  instance: instanceWithRelations,
+                  mainService: childModel,
+                  relatedInventoriesQuery: {} as UseQueryResult<
+                    Inventories,
+                    Error
+                  >,
+                }}
+              >
+                <CanvasContext.Provider value={canvasContext}>
+                  <ComposerActions
+                    serviceName="child-service"
+                    editable={editable}
+                  />
+                </CanvasContext.Provider>
+              </InstanceComposerContext.Provider>
+            </DependencyProvider>
+          </StoreProvider>
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+  };
+
+  const validContextForEnabledDeploy = {
+    ...defaultCanvasContext,
+    serviceOrderItems: new Map().set("13920268-cce0-4491-93b5-11316aa2fc37", {
+      instance_id: "13920268-cce0-4491-93b5-11316aa2fc37",
+      service_entity: "child-service",
+      config: {},
+      action: "create",
+      attributes: {
+        name: "test123456789",
+        service_id: "123test",
+        should_deploy_fail: false,
+        parent_entity: "6af44f75-ba4b-4fba-9186-cc61c3c9463c",
+      },
+    }),
+    diagramHandlers: {
+      getCoordinates: jest.fn(),
+      saveAndClearCanvas: jest.fn(),
+      loadState: jest.fn(),
+      addInstance: jest.fn(),
+      editEntity: jest.fn(),
+    } as typeof defaultCanvasContext.diagramHandlers,
+    isDirty: true,
+    looseElement: new Set<string>(),
+    interServiceRelationsOnCanvas: new Map<string, RelationCounterForCell>(),
+  };
+
+  const server = setupServer(
+    http.post(
+      "/lsm/v1/service_inventory/child-service}/*/metadata/coordinates",
+      async () => {
+        return HttpResponse.json({
+          data: [],
+        });
+      },
+    ),
+    http.post("/lsm/v2/order", async () => {
+      return HttpResponse.json({
+        data: [],
+      });
+    }),
+  );
+
+  beforeAll(() => {
+    server.listen();
+  });
+  afterEach(() => {
+    server.resetHandlers();
+  });
+
+  afterAll(() => {
+    server.close();
+  });
+
+  it("should render the ComposerActions component", () => {
+    render(setup(null, defaultCanvasContext));
+
+    expect(screen.getByText("Cancel")).toBeVisible();
+    expect(screen.getByText("Cancel")).toBeEnabled();
+
+    expect(screen.getByText("Deploy")).toBeVisible();
+    expect(screen.getByText("Deploy")).toBeDisabled(); //for default canvas context deploy should be disabled by default
+  });
+
+  it.each`
+    serviceOrderItems | isDirty  | looseElement             | editable | interServiceRelationsOnCanvas
+    ${new Map()}      | ${true}  | ${null}                  | ${true}  | ${null}
+    ${null}           | ${false} | ${null}                  | ${true}  | ${null}
+    ${null}           | ${true}  | ${new Set().add("test")} | ${true}  | ${null}
+    ${null}           | ${true}  | ${null}                  | ${false} | ${null}
+    ${null} | ${true} | ${null} | ${true} | ${new Map().set("test_id", {
+  name: "test",
+  relations: [{ name: "relation-test", currentAmount: 0, min: 1 }],
+})}
+  `(
+    "should have deploy button disabled when at least one of conditions are not met",
+    ({
+      serviceOrderItems,
+      isDirty,
+      looseElement,
+      editable,
+      interServiceRelationsOnCanvas,
+    }) => {
+      const canvasContext = {
+        ...defaultCanvasContext,
+        serviceOrderItems: serviceOrderItems || new Map().set("test", "test"),
+        isDirty: isDirty,
+        looseElement: looseElement || new Set<string>(),
+        interServiceRelationsOnCanvas:
+          interServiceRelationsOnCanvas ||
+          new Map<string, RelationCounterForCell>(),
+      };
+
+      render(setup(null, canvasContext, editable));
+      expect(screen.getByText("Deploy")).toBeDisabled();
+    },
+  );
+
+  it("should have deploy button enabled when all conditions are met", () => {
+    render(setup(null, validContextForEnabledDeploy));
+    expect(screen.getByText("Deploy")).toBeEnabled();
+  });
+
+  it("shows success message and redirects when deploy button is clicked", async () => {
+    server.use(
+      http.post("/lsm/v2/order", async () => {
+        return HttpResponse.json();
+      }),
+    );
+
+    render(setup(null, validContextForEnabledDeploy));
+    expect(screen.getByText("Deploy")).toBeEnabled();
+    await act(async () => {
+      await userEvent.click(screen.getByText("Deploy"));
+    });
+
+    expect(
+      await screen.findByText("The request got sent successfully"),
+    ).toBeVisible();
+
+    await waitFor(
+      () =>
+        expect(mockedNavigate).toHaveBeenCalledWith(
+          "/lsm/catalog/child-service/inventory?env=aaa",
+        ),
+      { timeout: 1500 },
+    );
+  });
+
+  it("shows error message about coordinates when there is no diagramHandlers", async () => {
+    server.use(
+      http.post("/lsm/v2/order", async () => {
+        await delay();
+
+        return HttpResponse.json();
+      }),
+    );
+    const canvasContext = {
+      ...validContextForEnabledDeploy,
+      diagramHandlers: null,
+    };
+
+    render(setup(null, canvasContext));
+    expect(screen.getByText("Deploy")).toBeEnabled();
+    await act(async () => {
+      await userEvent.click(screen.getByText("Deploy"));
+    });
+
+    expect(
+      screen.getByText("Failed to save instance coordinates on deploy."),
+    ).toBeVisible();
+  });
+
+  it("shows error message when deploy button is clicked and request fails", async () => {
+    server.use(
+      http.post("/lsm/v2/order", async () => {
+        return HttpResponse.json(
+          {
+            message: "Failed to deploy instance.",
+          },
+          {
+            status: 401,
+          },
+        );
+      }),
+    );
+
+    render(setup(null, validContextForEnabledDeploy));
+    expect(screen.getByText("Deploy")).toBeEnabled();
+    await act(async () => {
+      await userEvent.click(screen.getByText("Deploy"));
+    });
+
+    expect(await screen.findByText("Failed to deploy instance.")).toBeVisible();
+  });
+});

--- a/src/UI/Components/Diagram/components/ComposerActions.tsx
+++ b/src/UI/Components/Diagram/components/ComposerActions.tsx
@@ -75,7 +75,9 @@ export const ComposerActions: React.FC<Props> = ({ serviceName, editable }) => {
 
     if (!diagramHandlers) {
       setAlertType(AlertVariant.danger);
-      setAlertMessage("failed to save instance coordinates on deploy");
+      setAlertMessage(
+        words("instanceComposer.errorMessage.coordinatesRequest"),
+      );
     } else {
       coordinates = diagramHandlers.getCoordinates();
     }
@@ -85,7 +87,10 @@ export const ComposerActions: React.FC<Props> = ({ serviceName, editable }) => {
       .map((instance) => ({
         ...instance,
         metadata: {
-          coordinates: JSON.stringify(coordinates),
+          coordinates: JSON.stringify({
+            version: "v2",
+            data: coordinates,
+          }),
         },
       }));
 
@@ -98,7 +103,10 @@ export const ComposerActions: React.FC<Props> = ({ serviceName, editable }) => {
         key: "coordinates",
         body: {
           current_version: instance.instance.version,
-          value: JSON.stringify(coordinates),
+          value: JSON.stringify({
+            version: "v2",
+            data: coordinates,
+          }),
         },
       });
     }
@@ -109,8 +117,9 @@ export const ComposerActions: React.FC<Props> = ({ serviceName, editable }) => {
     interServiceRelationsOnCanvas,
   ).filter(
     ([_key, value]) =>
-      value.relations.filter((relation) => relation.current < relation.min)
-        .length > 0,
+      value.relations.filter(
+        (relation) => relation.currentAmount < relation.min,
+      ).length > 0,
   );
 
   useEffect(() => {

--- a/src/UI/Components/Diagram/components/Validation.test.tsx
+++ b/src/UI/Components/Diagram/components/Validation.test.tsx
@@ -26,9 +26,9 @@ describe("Given a Validation component", () => {
     isDirty  | interServiceRelationsOnCanvas
     ${false} | ${new Map()}
     ${true}  | ${new Map()}
-    ${false} | ${new Map().set("1", { name: "test", relations: [{ name: "relation-test", current: 0, min: 1 }] })}
-    ${false} | ${new Map().set("1", { name: "test", relations: [{ name: "relation-test", current: 1, min: 1 }] })}
-    ${true}  | ${new Map().set("1", { name: "test", relations: [{ name: "relation-test", current: 1, min: 1 }] })}
+    ${false} | ${new Map().set("1", { name: "test", relations: [{ name: "relation-test", currentAmount: 0, min: 1 }] })}
+    ${false} | ${new Map().set("1", { name: "test", relations: [{ name: "relation-test", currentAmount: 1, min: 1 }] })}
+    ${true}  | ${new Map().set("1", { name: "test", relations: [{ name: "relation-test", currentAmount: 1, min: 1 }] })}
   `(
     "when requirements for render are not met should not render",
     ({ isDirty, interServiceRelationsOnCanvas }) => {
@@ -41,7 +41,7 @@ describe("Given a Validation component", () => {
     const isDirty = true;
     const interServiceRelationsOnCanvas = new Map().set("1", {
       name: "test",
-      relations: [{ name: "relation-test", current: 0, min: 1 }],
+      relations: [{ name: "relation-test", currentAmount: 0, min: 1 }],
     });
 
     render(setup(isDirty, interServiceRelationsOnCanvas));

--- a/src/UI/Components/Diagram/components/Validation.tsx
+++ b/src/UI/Components/Diagram/components/Validation.tsx
@@ -21,8 +21,9 @@ export const Validation: React.FC = () => {
     interServiceRelationsOnCanvas,
   ).filter(
     ([_key, value]) =>
-      value.relations.filter((relation) => relation.current < relation.min)
-        .length > 0,
+      value.relations.filter(
+        (relation) => relation.currentAmount < relation.min,
+      ).length > 0,
   );
 
   //dirty flag is set to false on initial load for edited instances, that solves issue of flickering as we are starting canvas from empty state and populate it from ground up

--- a/src/UI/Components/Diagram/init.ts
+++ b/src/UI/Components/Diagram/init.ts
@@ -174,7 +174,9 @@ export function diagramInit(
             instance.instance.metadata.coordinates,
           );
 
-          applyCoordinatesToCells(graph, parsedCoordinates);
+          if (parsedCoordinates.version === "v2") {
+            applyCoordinatesToCells(graph, parsedCoordinates.data);
+          }
         }
       }
 

--- a/src/UI/Components/Diagram/interfaces.ts
+++ b/src/UI/Components/Diagram/interfaces.ts
@@ -165,7 +165,7 @@ interface StencilState {
 interface InterServiceRelationOnCanvasWithMin {
   name: string;
   min: ParsedNumber;
-  current: number;
+  currentAmount: number;
 }
 
 /**

--- a/src/UI/words.tsx
+++ b/src/UI/words.tsx
@@ -218,6 +218,8 @@ const dict = {
   "instanceComposer.orderDescription": "Requested with Instance Composer",
   "instanceComposer.errorMessage.missingModel":
     "The instance attribute model is missing",
+  "instanceComposer.errorMessage.coordinatesRequest":
+    "Failed to save instance coordinates on deploy.",
   "instanceComposer.editButton": "Edit in Composer",
   "instanceComposer.showButton": "Show in Composer",
   "instanceComposer.formModal.placeholder": "Choose a Service",


### PR DESCRIPTION
# Description

Adds a v2 flag for metadata for coordinates, canvas fallback to default auto-layout if no flag or no coordinates, adds test for composerActions

closes #5989

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Code is clear and sufficiently documented
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
