### PR TITLE
Hide left sidebar from Composer Viewer

### DIFF
--- a/changelogs/unreleased/5988-view-mode-composer.yml
+++ b/changelogs/unreleased/5988-view-mode-composer.yml
@@ -1,0 +1,6 @@
+description: Hide Left sidebar from the Instance Composer when in the view mode
+issue-nr: 5988
+change-type: patch
+destination-branches: [master]
+sections:
+  minor-improvement: "{{description}}"

--- a/src/UI/Components/Diagram/Canvas.test.tsx
+++ b/src/UI/Components/Diagram/Canvas.test.tsx
@@ -191,7 +191,7 @@ describe("Canvas.tsx", () => {
     expect(modal).not.toBeVisible();
   });
 
-  it("renders right sidebar without buttons when not editable", async () => {
+  it("renders right sidebar without buttons and left sidebar when not editable", async () => {
     const component = setup(
       mockedInstanceTwoServiceModel,
       mockedInstanceTwo,
@@ -208,6 +208,8 @@ describe("Canvas.tsx", () => {
 
     expect(screen.queryByText("Remove")).toBeNull();
     expect(screen.queryByText("Cancel")).toBeNull();
+
+    expect(screen.getByTestId("left_sidebar")).not.toBeVisible(); // Left sidebar is set to display:none when not editable
   });
 
   it("renders right sidebar with buttons when editable", async () => {
@@ -227,5 +229,7 @@ describe("Canvas.tsx", () => {
 
     expect(screen.getByText("Remove")).toBeVisible();
     expect(screen.getByText("Cancel")).toBeVisible();
+
+    expect(screen.getByTestId("left_sidebar")).toBeVisible();
   });
 });

--- a/src/UI/Components/Diagram/Canvas.tsx
+++ b/src/UI/Components/Diagram/Canvas.tsx
@@ -156,11 +156,15 @@ export const Canvas: React.FC<Props> = ({ editable }) => {
       <DictModal />
       <CanvasWrapper id="canvas-wrapper" data-testid="Composer-Container">
         <LeftSidebarContainer
-          className="left_sidebar"
+          className={`left_sidebar ${!editable && "view_mode"}`}
           data-testid="left_sidebar"
           ref={LeftSidebar}
         />
-        <CanvasContainer className="canvas" data-testid="canvas" ref={Canvas} />
+        <CanvasContainer
+          className={`canvas ${!editable && "view_mode"}`}
+          data-testid="canvas"
+          ref={Canvas}
+        />
         <RightSidebar editable={editable} />
         <ZoomHandlerContainer className="zoom-handler" ref={ZoomHandler} />
       </CanvasWrapper>
@@ -276,6 +280,10 @@ const CanvasContainer = styled.div`
   height: 100%;
   background: var(--pf-v5-global--BackgroundColor--light-300);
 
+  &.view_mode {
+    width: calc(100% - 300px);
+  }
+
   * {
     font-family: var(--pf-v5-global--FontFamily--monospace);
   }
@@ -301,4 +309,8 @@ const LeftSidebarContainer = styled.div`
     0.1rem 0.1rem 0.15rem
       var(--pf-v5-global--BackgroundColor--dark-transparent-200)
   );
+
+  &.view_mode {
+    display: none;
+  }
 `;


### PR DESCRIPTION
# Description

Hides Left sidebar from the instance composer viewer. it was done by hiding element, as conditional rendering was stopping lifecycle due to missing ref for sidebar that is required in further steps. It could be resolved but that would equal to some additional conditions, and display: none is straightforward, clean and simplest solution in my opinion

closes #5988 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Code is clear and sufficiently documented
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
