### PR TITLE
Issue/5987 sidebar visual changes

### DIFF
--- a/changelogs/unreleased/5987-sidebar-visual-changes.yml
+++ b/changelogs/unreleased/5987-sidebar-visual-changes.yml
@@ -1,0 +1,4 @@
+description: Adjusted the stencil/left sidebar elements to match design, fix issues with shadows on both sidebars
+issue-nr: 5987
+change-type: patch
+destination-branches: [master]

--- a/cypress/e2e/scenario-2.4-expert-mode.cy.js
+++ b/cypress/e2e/scenario-2.4-expert-mode.cy.js
@@ -157,13 +157,11 @@ if (Cypress.env("edition") === "iso") {
       cy.get("#operation-select").select("clear candidate");
       cy.get("button").contains("Yes").click();
 
-      // expect to find in the history the creating state as last
-      cy.get('[aria-label="History-Row"]', { timeout: 30000 }).should(
-        ($rows) => {
-          expect($rows[1]).to.contain("creating");
-          expect($rows[1]).to.contain(4);
-          expect($rows).to.have.length(5);
-        },
+      // expect to find in the history the creating state after the up state
+      cy.get('[data-testid="version-3-state"]').should("have.text", "up");
+      cy.get('[data-testid="version-4-state"]', { timeout: 30000 }).should(
+        "have.text",
+        "creating",
       );
     });
 

--- a/src/UI/Components/Diagram/Canvas.tsx
+++ b/src/UI/Components/Diagram/Canvas.tsx
@@ -301,4 +301,5 @@ const LeftSidebarContainer = styled.div`
     0.1rem 0.1rem 0.15rem
       var(--pf-v5-global--BackgroundColor--dark-transparent-200)
   );
+  z-index: 1;
 `;

--- a/src/UI/Components/Diagram/stencil/helpers.test.ts
+++ b/src/UI/Components/Diagram/stencil/helpers.test.ts
@@ -17,6 +17,7 @@ describe("createStencilElement", () => {
         attrTwo: "other_test_value",
       },
       true,
+      true,
       "holderName",
     );
 
@@ -52,6 +53,9 @@ describe("createStencilElement", () => {
     expect(embeddedElementWithModel.attributes.attrs?.label?.class).toEqual(
       "text_default",
     );
+    expect(
+      embeddedElementWithModel.attributes.attrs?.borderTop?.height,
+    ).toEqual(1);
 
     //check difference with body fill for non-embedded
     const nonEmbedded = createStencilElement("nonEmbedded", containerModel, {
@@ -65,6 +69,9 @@ describe("createStencilElement", () => {
     expect(nonEmbedded.attributes.attrs?.body?.class).toEqual(
       "body_nonEmbedded",
     );
+    expect(
+      embeddedElementWithModel.attributes.attrs?.borderTop?.height,
+    ).toEqual(0);
   });
 });
 

--- a/src/UI/Components/Diagram/stencil/helpers.test.ts
+++ b/src/UI/Components/Diagram/stencil/helpers.test.ts
@@ -69,9 +69,7 @@ describe("createStencilElement", () => {
     expect(nonEmbedded.attributes.attrs?.body?.class).toEqual(
       "body_nonEmbedded",
     );
-    expect(
-      embeddedElementWithModel.attributes.attrs?.borderTop?.height,
-    ).toEqual(0);
+    expect(nonEmbedded.attributes.attrs?.borderTop?.height).toEqual(0);
   });
 });
 

--- a/src/UI/Components/Diagram/stencil/helpers.ts
+++ b/src/UI/Components/Diagram/stencil/helpers.ts
@@ -1,5 +1,8 @@
 import { shapes } from "@inmanta/rappid";
-import { global_palette_white } from "@patternfly/react-tokens";
+import {
+  global_BackgroundColor_200,
+  global_palette_white,
+} from "@patternfly/react-tokens";
 import { v4 as uuidv4 } from "uuid";
 import { EmbeddedEntity, InstanceAttributeModel, ServiceModel } from "@/Core";
 import { HeaderColor } from "../interfaces";
@@ -17,12 +20,13 @@ export const transformEmbeddedToStencilElements = (
 ): shapes.standard.Path[] => {
   return service.embedded_entities
     .filter((embedded_entity) => embedded_entity.modifier !== "r") // filter out read-only embedded entities from the stencil as they can't be created by the user
-    .flatMap((embedded_entity) => {
+    .flatMap((embedded_entity, index) => {
       const stencilElement = createStencilElement(
         embedded_entity.name,
         embedded_entity,
         {},
         true,
+        index === 0,
         service.name,
       );
       const nestedStencilElements =
@@ -48,6 +52,7 @@ export const createStencilElement = (
   serviceModel: EmbeddedEntity | ServiceModel,
   instanceAttributes: InstanceAttributeModel,
   isEmbedded: boolean = false,
+  showBorderTop: boolean = false,
   holderName?: string,
 ): shapes.standard.Path => {
   let id = uuidv4();
@@ -90,6 +95,22 @@ export const createStencilElement = (
         fontSize: 12,
         text: name,
       },
+      borderBottom: {
+        width: 233,
+        height: 1,
+        x: 0,
+        y: 39,
+        fill: global_BackgroundColor_200.var,
+        stroke: "none",
+      },
+      borderTop: {
+        width: 233,
+        height: showBorderTop ? 1 : 0,
+        x: 0,
+        y: 0,
+        fill: global_BackgroundColor_200.var,
+        stroke: "none",
+      },
     },
     markup: [
       {
@@ -103,6 +124,14 @@ export const createStencilElement = (
       {
         tagName: "text",
         selector: "label",
+      },
+      {
+        tagName: "rect",
+        selector: "borderBottom",
+      },
+      {
+        tagName: "rect",
+        selector: "borderTop",
       },
     ],
   });

--- a/src/UI/Components/Diagram/stencil/instanceStencil.ts
+++ b/src/UI/Components/Diagram/stencil/instanceStencil.ts
@@ -61,7 +61,6 @@ export class InstanceStencilTab {
       layout: {
         columns: 1,
         rowHeight: "compact",
-        rowGap: 10,
         horizontalAlign: "left",
         marginY: 10,
         // reset defaults

--- a/src/UI/Components/Diagram/stencil/inventoryStencil.ts
+++ b/src/UI/Components/Diagram/stencil/inventoryStencil.ts
@@ -41,7 +41,7 @@ export class InventoryStencilTab {
       }
 
       return (groups[serviceName] = serviceInventories[serviceName].map(
-        (instance) => {
+        (instance, index) => {
           const attributes =
             instance.candidate_attributes ||
             instance.active_attributes ||
@@ -52,10 +52,16 @@ export class InventoryStencilTab {
             : instance.id;
 
           //add the instance id to the attributes object, to then pass it to the actual object on canvas
-          return createStencilElement(displayName, serviceModel, {
-            ...attributes,
-            id: instance.id,
-          });
+          return createStencilElement(
+            displayName,
+            serviceModel,
+            {
+              ...attributes,
+              id: instance.id,
+            },
+            false,
+            index === 0,
+          );
         },
       ));
     });
@@ -101,7 +107,6 @@ export class InventoryStencilTab {
       layout: {
         columns: 1,
         rowHeight: "compact",
-        rowGap: 10,
         marginY: 10,
         horizontalAlign: "left",
         // reset defaults

--- a/src/UI/Components/Diagram/styles.ts
+++ b/src/UI/Components/Diagram/styles.ts
@@ -69,13 +69,6 @@ export const CanvasWrapper = styled.div`
     }
   }
 
-  .joint-element {
-    filter: drop-shadow(
-      0.1rem 0.1rem 0.15rem
-        var(--pf-v5-global--BackgroundColor--dark-transparent-200)
-    );
-  }
-
   .joint-stencil.searchable > .content {
     top: 60px;
   }


### PR DESCRIPTION
# Description

remove distance between stencil elements and removes shadows, adds borders to them.
Fix shadow in stencilSidebar not to be overflowed by canvas paper - I think that those shadows that align with the design are visually really good, fix is better that removal of them but can be discussed.

![Screenshot 2024-12-02 at 11 50 52](https://github.com/user-attachments/assets/b98e026c-3ddb-4514-983c-09a8b94653f7)
![Screenshot 2024-12-02 at 11 50 30](https://github.com/user-attachments/assets/338b6dac-b461-4587-8b13-f45611f4ca68)

closes #5987 #6038 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Code is clear and sufficiently documented
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
