### PR TITLE
Emphasize terminated instances

### DIFF
--- a/changelogs/unreleased/5951-emphasize-terminated-instances.yml
+++ b/changelogs/unreleased/5951-emphasize-terminated-instances.yml
@@ -1,0 +1,6 @@
+description: Emphasize terminated instances in the instance details view
+issue-nr: 5951
+change-type: patch
+destination-branches: [master]
+sections:
+  minor-improvement: "{{description}}"

--- a/cypress/e2e/scenario-8-instance-composer.cy.js
+++ b/cypress/e2e/scenario-8-instance-composer.cy.js
@@ -817,6 +817,7 @@ if (Cypress.env("edition") === "iso") {
           expect(text).to.match(uuidRegex);
           oldUuid = text;
         });
+      cy.wait(1000); // wait for the async assertion
 
       // click on edit instance with composer
       cy.get('[aria-label="Actions-Toggle"]').click();

--- a/src/Data/Managers/ServiceInstances/getUrl.ts
+++ b/src/Data/Managers/ServiceInstances/getUrl.ts
@@ -22,7 +22,7 @@ export function getUrl(
   const includeDeletedParam =
     filter?.deleted === "Include" ? "&include_deleted=true" : "";
 
-  return `/lsm/v1/service_inventory/${name}?&include_deployment_progress=${capitalize(
+  return `/lsm/v1/service_inventory/${name}?include_deployment_progress=${capitalize(
     includeDeploymentProgress.toString(),
   )}&limit=${pageSize.value}${filterParam}${sortParam}${includeDeletedParam}${
     currentPage.value ? `&${currentPage.value}` : ""

--- a/src/Data/Managers/ServiceInstances/getUrl.ts
+++ b/src/Data/Managers/ServiceInstances/getUrl.ts
@@ -22,7 +22,7 @@ export function getUrl(
   const includeDeletedParam =
     filter?.deleted === "Include" ? "&include_deleted=true" : "";
 
-  return `/lsm/v1/service_inventory/${name}?include_deleted=true&include_deployment_progress=${capitalize(
+  return `/lsm/v1/service_inventory/${name}?&include_deployment_progress=${capitalize(
     includeDeploymentProgress.toString(),
   )}&limit=${pageSize.value}${filterParam}${sortParam}${includeDeletedParam}${
     currentPage.value ? `&${currentPage.value}` : ""

--- a/src/Data/Managers/ServiceInstances/getUrl.ts
+++ b/src/Data/Managers/ServiceInstances/getUrl.ts
@@ -22,7 +22,7 @@ export function getUrl(
   const includeDeletedParam =
     filter?.deleted === "Include" ? "&include_deleted=true" : "";
 
-  return `/lsm/v1/service_inventory/${name}?include_deployment_progress=${capitalize(
+  return `/lsm/v1/service_inventory/${name}?include_deleted=true&include_deployment_progress=${capitalize(
     includeDeploymentProgress.toString(),
   )}&limit=${pageSize.value}${filterParam}${sortParam}${includeDeletedParam}${
     currentPage.value ? `&${currentPage.value}` : ""

--- a/src/Slices/ServiceInstanceDetails/UI/Components/Sections/HistorySection.tsx
+++ b/src/Slices/ServiceInstanceDetails/UI/Components/Sections/HistorySection.tsx
@@ -8,6 +8,7 @@ import {
   Title,
 } from "@patternfly/react-core";
 import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
+import styled from "styled-components";
 import { ServiceModel } from "@/Core";
 import { useUrlStateWithString } from "@/Data";
 import { InstanceLog } from "@/Slices/ServiceInstanceHistory/Core/Domain";
@@ -78,16 +79,17 @@ export const HistorySection: React.FC = () => {
               </Thead>
               <Tbody>
                 {logsQuery.data.map((log: InstanceLog) => (
-                  <Tr
+                  <StyledRow
                     key={String(log.version)}
                     isSelectable
                     isClickable
                     onRowClick={() => setSelectedVersion(String(log.version))}
                     isRowSelected={String(log.version) === selectedVersion}
                     aria-label="History-Row"
+                    className={log.deleted ? "-terminated" : ""}
                   >
                     <HistoryRowContent log={log} />
-                  </Tr>
+                  </StyledRow>
                 ))}
               </Tbody>
             </Table>
@@ -97,6 +99,20 @@ export const HistorySection: React.FC = () => {
     </Panel>
   );
 };
+
+const StyledRow = styled(Tr)`
+  &.-terminated {
+    &:hover {
+      background-color: var(--pf-t--global--color--nonstatus--red--clicked);
+    }
+    &.pf-m-clickable {
+      background-color: var(--pf-t--global--color--nonstatus--red--default);
+    }
+    &.pf-m-selected {
+      background-color: var(--pf-t--global--color--nonstatus--red--clicked);
+    }
+  }
+`;
 
 interface HistoryRowProps {
   log: InstanceLog;

--- a/src/Slices/ServiceInstanceDetails/UI/Components/Sections/VersionedPageTitleWithActions.tsx
+++ b/src/Slices/ServiceInstanceDetails/UI/Components/Sections/VersionedPageTitleWithActions.tsx
@@ -49,6 +49,11 @@ export const VersionedPageTitleWithActions: React.FC<Props> = ({ title }) => {
             {words("instanceDetails.title.latest")}
           </Label>
         )}
+        {instance.deleted && (
+          <Label color="red" icon={<InfoAltIcon />}>
+            {instance.state}
+          </Label>
+        )}
       </LabelContainer>
       {isLatest && <InstanceActions />}
     </>

--- a/src/Slices/ServiceInventory/UI/InstanceRow.tsx
+++ b/src/Slices/ServiceInventory/UI/InstanceRow.tsx
@@ -123,5 +123,7 @@ const ActionWrapper = styled.span`
 
 const StyledRow = styled(Tr)<{ $deleted: boolean }>`
   ${(p) =>
-    p.$deleted ? "var(--pf-t--global--color--nonstatus--red--default)" : ""}
+    p.$deleted
+      ? "background-color: var(--pf-t--global--color--nonstatus--red--default)"
+      : ""}
 `;

--- a/src/UI/Components/LegendBar/LoneItem.tsx
+++ b/src/UI/Components/LegendBar/LoneItem.tsx
@@ -1,8 +1,5 @@
 import React from "react";
-import {
-  t_global_background_color_100,
-  t_global_text_color_brand_default,
-} from "@patternfly/react-tokens";
+import { t_global_text_color_brand_default } from "@patternfly/react-tokens";
 import { Container } from "./Item";
 
 export interface Props {
@@ -12,7 +9,7 @@ export interface Props {
 export const LoneItem: React.FC<Props> = ({ label }) => (
   <Container
     value={1}
-    backgroundColor={t_global_background_color_100.var}
+    backgroundColor="transparent"
     color={t_global_text_color_brand_default.var}
   >
     {label}


### PR DESCRIPTION
# Description

Emphasize terminated instances, fix terminated instances not being highlighted in the service inventory, change progress bar bg to be transparent, as white was looking weird on highlighted rows

https://github.com/user-attachments/assets/c196f32c-9448-4d32-9b4e-e43ceb74cc7f


closes #5951 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Code is clear and sufficiently documented
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
