### PR TITLE
simplify documentation tab when only one item

### DIFF
--- a/changelogs/unreleased/5916-simple-docs.yml
+++ b/changelogs/unreleased/5916-simple-docs.yml
@@ -1,0 +1,6 @@
+description: Simplify the documentation tab when there's only one item available.
+issue-nr: 5916
+change-type: patch
+destination-branches: [master]
+sections:
+  minor-improvement: "{{description}}"

--- a/src/Slices/ServiceInstanceDetails/Test/Page.test.tsx
+++ b/src/Slices/ServiceInstanceDetails/Test/Page.test.tsx
@@ -396,21 +396,6 @@ describe("ServiceInstanceDetailsPage", () => {
       ),
     ).toBeVisible();
 
-    // Topography should be a collapsible section.
-    await act(async () => {
-      await userEvent.click(
-        screen.getByRole("button", {
-          name: "Topography",
-        }),
-      );
-    });
-
-    expect(
-      screen.getByText(
-        /this version doesn’t contain documentation for topography yet\./i,
-      ),
-    ).not.toBeVisible();
-
     // Events
 
     // Select the Events tab

--- a/src/Slices/ServiceInstanceDetails/UI/Tabs/DocumentationTabContent.tsx
+++ b/src/Slices/ServiceInstanceDetails/UI/Tabs/DocumentationTabContent.tsx
@@ -80,6 +80,17 @@ export const DocumentationTabContent: React.FC<Props> = ({
     }
   };
 
+  if (sections.length === 1) {
+    return (
+      <TabContentWrapper id="documentation">
+        <MarkdownCard
+          attributeValue={sections[0].value}
+          web_title={sections[0].title}
+        />
+      </TabContentWrapper>
+    );
+  }
+
   return (
     <TabContentWrapper id="documentation">
       <Accordion asDefinitionList togglePosition="start">

--- a/src/Slices/ServiceInstanceDetails/UI/Tabs/DocumentationTabContent.tsx
+++ b/src/Slices/ServiceInstanceDetails/UI/Tabs/DocumentationTabContent.tsx
@@ -4,6 +4,8 @@ import {
   AccordionContent,
   AccordionItem,
   AccordionToggle,
+  Flex,
+  Title,
 } from "@patternfly/react-core";
 import { InstanceAttributeModel } from "@/Core";
 import { InstanceLog } from "@/Slices/ServiceInstanceHistory/Core/Domain";
@@ -83,6 +85,13 @@ export const DocumentationTabContent: React.FC<Props> = ({
   if (sections.length === 1) {
     return (
       <TabContentWrapper id="documentation">
+        <Flex
+          alignItems={{ default: "alignItemsCenter" }}
+          gap={{ default: "gapSm" }}
+        >
+          <DynamicFAIcon icon={sections[0].iconName} />
+          <Title headingLevel="h2">{sections[0].title}</Title>
+        </Flex>
         <MarkdownCard
           attributeValue={sections[0].value}
           web_title={sections[0].title}


### PR DESCRIPTION
# Description

simplify documentation tab when only one item
![Screenshot 2024-12-13 at 15 21 54](https://github.com/user-attachments/assets/b1804580-1735-461a-a5cb-066ea364d826)

closes #5916 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Code is clear and sufficiently documented
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
