### PR TITLE
cleanup

### DIFF
--- a/changelogs/unreleased/pf-6-cleanup.yml
+++ b/changelogs/unreleased/pf-6-cleanup.yml
@@ -1,0 +1,3 @@
+description: Last cleanup phase for PF6 migration.
+change-type: patch
+destination-branches: [master]

--- a/src/Slices/Agents/UI/Components/ActionButton.tsx
+++ b/src/Slices/Agents/UI/Components/ActionButton.tsx
@@ -44,6 +44,7 @@ export const ActionButton: React.FC<Props> = ({ name, paused }) => {
       <Button
         variant="secondary"
         isDisabled={isHalted}
+        aria-disabled={isHalted}
         size="sm"
         onClick={onSubmit}
       >

--- a/src/Slices/CompileReports/UI/CompileReportsTableRow.tsx
+++ b/src/Slices/CompileReports/UI/CompileReportsTableRow.tsx
@@ -2,7 +2,6 @@ import React, { useContext } from "react";
 import { Link } from "react-router-dom";
 import { Button } from "@patternfly/react-core";
 import { Tbody, Td, Tr } from "@patternfly/react-table";
-import styled from "styled-components";
 import { DateWithTooltip } from "@/UI/Components";
 import { DependencyContext } from "@/UI/Dependency";
 import { words } from "@/UI/words";
@@ -19,12 +18,15 @@ export const CompileReportsTableRow: React.FC<Props> = ({ row }) => {
   return (
     <Tbody isExpanded={false}>
       <Tr aria-label="Compile Reports Table Row">
-        <Td width={15} dataLabel={words("compileReports.columns.requested")}>
+        <Td width={10} dataLabel={words("compileReports.columns.requested")}>
           <DateWithTooltip timestamp={row.requested} />
         </Td>
-        <StyledCell dataLabel={words("compileReports.columns.status")}>
+        <Td
+          modifier="fitContent"
+          dataLabel={words("compileReports.columns.status")}
+        >
           <CompileStatusLabel status={row.status} />
-        </StyledCell>
+        </Td>
         <Td dataLabel={words("compileReports.columns.message")}>
           {row.message}
         </Td>
@@ -52,9 +54,3 @@ export const CompileReportsTableRow: React.FC<Props> = ({ row }) => {
     </Tbody>
   );
 };
-
-const StyledCell = styled(Td)`
-  && {
-    width: 120px;
-  }
-`;

--- a/src/Slices/CreateEnvironment/UI/CreateEnvironmentForm.tsx
+++ b/src/Slices/CreateEnvironment/UI/CreateEnvironmentForm.tsx
@@ -1,6 +1,5 @@
 import React, { useContext, useState } from "react";
 import { Button, Flex, FlexItem, Form } from "@patternfly/react-core";
-import styled from "styled-components";
 import { Either, ProjectModel } from "@/Core";
 import { CreatableSelectInput, InlinePlainAlert } from "@/UI/Components";
 import { DependencyContext } from "@/UI/Dependency";
@@ -146,7 +145,7 @@ const FormControls: React.FC<{
   onSubmit: () => void;
   onCancel: () => void;
 }> = ({ isSubmitDisabled, onSubmit, onCancel }) => (
-  <PaddedControls direction={{ default: "row" }}>
+  <Flex direction={{ default: "row" }} rowGap={{ default: "rowGap2xl" }}>
     <FlexItem>
       <Button
         aria-label="submit"
@@ -161,9 +160,5 @@ const FormControls: React.FC<{
         {words("cancel")}
       </Button>
     </FlexItem>
-  </PaddedControls>
+  </Flex>
 );
-
-const PaddedControls = styled(Flex)`
-  padding-top: 1em;
-`;

--- a/src/Slices/Dashboard/UI/Dashboard.tsx
+++ b/src/Slices/Dashboard/UI/Dashboard.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useState } from "react";
-import { Button } from "@patternfly/react-core";
+import { Button, Flex } from "@patternfly/react-core";
 import moment from "moment";
 import styled from "styled-components";
 import { RemoteData } from "@/Core";
@@ -46,23 +46,28 @@ export const Dashboard: React.FC = () => {
                   {words("dashboard.refresh")}
                 </Button>
               </RefreshWrapper>
-              {featureManager.isLsmEnabled() && (
+              <Flex
+                direction={{ default: "column" }}
+                gap={{ default: "gapLg" }}
+              >
+                {featureManager.isLsmEnabled() && (
+                  <Section
+                    title={words("navigation.lifecycleServiceManager")}
+                    metricType="lsm"
+                    metrics={metrics}
+                  />
+                )}
                 <Section
-                  title={words("navigation.lifecycleServiceManager")}
-                  metricType="lsm"
+                  title={words("navigation.orchestrationEngine")}
+                  metricType="orchestrator"
                   metrics={metrics}
                 />
-              )}
-              <Section
-                title={words("navigation.orchestrationEngine")}
-                metricType="orchestrator"
-                metrics={metrics}
-              />
-              <Section
-                title={words("navigation.resourceManager")}
-                metricType="resource"
-                metrics={metrics}
-              />
+                <Section
+                  title={words("navigation.resourceManager")}
+                  metricType="resource"
+                  metrics={metrics}
+                />
+              </Flex>
             </Wrapper>
           ),
         },

--- a/src/Slices/Dashboard/UI/Section.tsx
+++ b/src/Slices/Dashboard/UI/Section.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { Flex, FlexItem, Title } from "@patternfly/react-core";
-import styled from "styled-components";
 import { BackendMetricData } from "../Core/Domain";
 import { GraphCard } from "./GraphCard";
 import { NumericCard } from "./NumericCard";
@@ -17,7 +16,7 @@ export const Section: React.FC<Props> = ({ title, metricType, metrics }) => {
   );
 
   return (
-    <Wrapper>
+    <FlexItem>
       <Title
         headingLevel="h2"
         style={{ paddingBottom: "20px", fontWeight: 700 }}
@@ -60,10 +59,6 @@ export const Section: React.FC<Props> = ({ title, metricType, metrics }) => {
           ),
         )}
       </Flex>
-    </Wrapper>
+    </FlexItem>
   );
 };
-
-const Wrapper = styled.div`
-  padding-bottom: 40px;
-`;

--- a/src/Slices/DesiredStateDetails/UI/VersionResourceTable.tsx
+++ b/src/Slices/DesiredStateDetails/UI/VersionResourceTable.tsx
@@ -7,7 +7,6 @@ import {
   Thead,
   Tr,
 } from "@patternfly/react-table";
-import styled from "styled-components";
 import { Resource, Sort } from "@/Core";
 import { Row } from "./Row";
 import { VersionResourceTablePresenter } from "./VersionResourceTablePresenter";
@@ -55,14 +54,9 @@ export const VersionResourceTable: React.FC<Props> = ({
         : {};
 
       return (
-        <StyledTh
-          key={displayName}
-          {...sortParams}
-          $characters={displayName.length}
-          $hasSort={hasSort}
-        >
+        <Th key={displayName} {...sortParams} modifier="fitContent">
           {displayName}
-        </StyledTh>
+        </Th>
       );
     });
 
@@ -77,21 +71,3 @@ export const VersionResourceTable: React.FC<Props> = ({
     </Table>
   );
 };
-
-interface HeaderProps {
-  $characters: number;
-  $hasSort: boolean;
-}
-
-const getWidth = ({ $characters, $hasSort }: HeaderProps) => {
-  const base = `${$characters}ch`;
-  const extra = $hasSort ? "60px" : "16px";
-
-  return `calc(${base} + ${extra})`;
-};
-
-const StyledTh = styled(Th)<HeaderProps>`
-  &&& {
-    min-width: ${getWidth};
-  }
-`;

--- a/src/Slices/DesiredStateResourceDetails/UI/Page.tsx
+++ b/src/Slices/DesiredStateResourceDetails/UI/Page.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import styled from "styled-components";
 import { Description, PageContainer } from "@/UI/Components";
 import { useRouteParams } from "@/UI/Routing";
 import { words } from "@/UI/words";
@@ -11,12 +10,8 @@ export const Page: React.FC = () => {
 
   return (
     <PageContainer pageTitle={words("desiredState.resourceDetails.title")}>
-      <StyledDescription>{resourceId}</StyledDescription>
+      <Description>{resourceId}</Description>
       <DetailsProvider version={version} resourceId={resourceId} />
     </PageContainer>
   );
 };
-
-const StyledDescription = styled(Description)`
-  margin-bottom: 16px;
-`;

--- a/src/Slices/Facts/UI/FactsTable.tsx
+++ b/src/Slices/Facts/UI/FactsTable.tsx
@@ -7,7 +7,6 @@ import {
   Thead,
   Tr,
 } from "@patternfly/react-table";
-import styled from "styled-components";
 import { Sort } from "@/Core";
 import { Fact } from "@S/Facts/Core/Domain";
 import { SortKey } from "@S/Facts/Core/Query";
@@ -52,14 +51,9 @@ export const FactsTable: React.FC<Props> = ({
         : {};
 
       return (
-        <StyledTh
-          key={displayName}
-          {...sortParams}
-          $characters={displayName.length}
-          $hasSort={hasSort}
-        >
+        <Th key={displayName} {...sortParams} modifier="fitContent">
           {displayName}
-        </StyledTh>
+        </Th>
       );
     });
 
@@ -74,21 +68,3 @@ export const FactsTable: React.FC<Props> = ({
     </Table>
   );
 };
-
-interface HeaderProps {
-  $characters: number;
-  $hasSort: boolean;
-}
-
-const getWidth = ({ $characters, $hasSort }: HeaderProps) => {
-  const base = `${$characters}ch`;
-  const extra = $hasSort ? "60px" : "16px";
-
-  return `calc(${base} + ${extra})`;
-};
-
-const StyledTh = styled(Th)<HeaderProps>`
-  &&& {
-    min-width: ${getWidth};
-  }
-`;

--- a/src/Slices/Resource/UI/ResourcesPage/Page.test.tsx
+++ b/src/Slices/Resource/UI/ResourcesPage/Page.test.tsx
@@ -173,12 +173,14 @@ test("GIVEN ResourcesView WHEN user clicks on requires toggle THEN list of requi
     name: "Resource Table Row",
   });
 
-  const toggle = within(rows[0]).getByRole("button", {
+  const toggleCell = within(rows[0]).getByRole("cell", {
     name: "Toggle-" + Resource.response.data[0].resource_id,
   });
 
+  const toggleButton = within(toggleCell).getByRole("button");
+
   await act(async () => {
-    await userEvent.click(toggle);
+    await userEvent.click(toggleButton);
   });
 
   await act(async () => {

--- a/src/Slices/Resource/UI/ResourcesPage/Page.tsx
+++ b/src/Slices/Resource/UI/ResourcesPage/Page.tsx
@@ -1,6 +1,5 @@
 import React, { useContext, useEffect, useState } from "react";
 import { Flex, FlexItem } from "@patternfly/react-core";
-import styled from "styled-components";
 import { RemoteData, Resource } from "@/Core";
 import {
   useUrlStateWithFilter,
@@ -110,7 +109,7 @@ export const Page: React.FC = () => {
                 resources={resources.data}
                 aria-label="ResourcesView-Success"
               />
-              <StyledFlex justifyContent={{ default: "justifyContentFlexEnd" }}>
+              <Flex justifyContent={{ default: "justifyContentFlexEnd" }}>
                 <FlexItem>
                   <PaginationWidget
                     data={staleData}
@@ -120,7 +119,7 @@ export const Page: React.FC = () => {
                     variant="bottom"
                   />
                 </FlexItem>
-              </StyledFlex>
+              </Flex>
             </>
           )
         }
@@ -128,7 +127,3 @@ export const Page: React.FC = () => {
     </Wrapper>
   );
 };
-
-const StyledFlex = styled(Flex)`
-  padding-right: 16px;
-`;

--- a/src/Slices/Resource/UI/ResourcesPage/ResourceTableRow.tsx
+++ b/src/Slices/Resource/UI/ResourcesPage/ResourceTableRow.tsx
@@ -58,7 +58,7 @@ export const ResourceTableRow: React.FC<Props> = ({
         />
       </Td>
     </Tr>
-    {row.numberOfDependencies > 0 && (
+    {isExpanded && (
       <Tr isExpanded={isExpanded}>
         <Td colSpan={numberOfColumns}>
           <ExpandableRowContent>

--- a/src/Slices/Resource/UI/ResourcesPage/ResourceTableRow.tsx
+++ b/src/Slices/Resource/UI/ResourcesPage/ResourceTableRow.tsx
@@ -1,12 +1,10 @@
 import React from "react";
 import { Tbody, Tr, Td, ExpandableRowContent } from "@patternfly/react-table";
-import styled from "styled-components";
 import { Resource } from "@/Core";
 import {
   labelColorConfig,
   ResourceLink,
   ResourceStatusLabel,
-  Toggle,
 } from "@/UI/Components";
 import { words } from "@/UI/words";
 import { RequiresTableWithData } from "./Components";
@@ -16,6 +14,7 @@ interface Props {
   isExpanded: boolean;
   onToggle: () => void;
   numberOfColumns: number;
+  index: number;
 }
 
 export const ResourceTableRow: React.FC<Props> = ({
@@ -23,75 +22,53 @@ export const ResourceTableRow: React.FC<Props> = ({
   isExpanded,
   onToggle,
   numberOfColumns,
+  index,
 }) => (
   <Tbody>
     <Tr aria-label="Resource Table Row">
-      {row.numberOfDependencies > 0 ? (
-        <Td>
-          <Toggle
-            expanded={isExpanded}
-            onToggle={onToggle}
-            aria-label={`Toggle-${row.id}`}
-          />
-        </Td>
-      ) : (
-        <NoToggle />
-      )}
+      <Td
+        style={{ width: "0%" }} // This is to enforce the same width when there is no expandable content.
+        aria-label={`Toggle-${row.id}${row.numberOfDependencies <= 0 ? "-hidden" : ""}`}
+        expand={
+          row.numberOfDependencies > 0
+            ? {
+                rowIndex: index,
+                isExpanded: isExpanded,
+                onToggle: onToggle,
+              }
+            : undefined
+        }
+      ></Td>
       <Td dataLabel={words("resources.column.type")}>{row.type}</Td>
       <Td dataLabel={words("resources.column.agent")}>{row.agent}</Td>
       <Td dataLabel={words("resources.column.value")}>{row.value}</Td>
-      <CenteredCell dataLabel={words("resources.column.requires")}>
+      <Td dataLabel={words("resources.column.requires")}>
         {row.numberOfDependencies as React.ReactNode}
-      </CenteredCell>
+      </Td>
       <Td dataLabel={words("resources.column.deployState")}>
         <ResourceStatusLabel
           status={labelColorConfig[row.deployState]}
           label={row.deployState}
         />
       </Td>
-      <StyledCell>
+      <Td isActionCell>
         <ResourceLink
           resourceId={row.id}
           linkText={words("resources.link.details")}
         />
-      </StyledCell>
+      </Td>
     </Tr>
-    {isExpanded && (
+    {row.numberOfDependencies > 0 && (
       <Tr isExpanded={isExpanded}>
         <Td colSpan={numberOfColumns}>
           <ExpandableRowContent>
-            <Wrapper deps={row.numberOfDependencies as number}>
-              <RequiresTableWithData
-                id={row.id}
-                deps={row.numberOfDependencies as number}
-              />
-            </Wrapper>
+            <RequiresTableWithData
+              id={row.id}
+              deps={row.numberOfDependencies as number}
+            />
           </ExpandableRowContent>
         </Td>
       </Tr>
     )}
   </Tbody>
 );
-
-const StyledCell = styled(Td)`
-  text-align: right;
-`;
-
-const Wrapper = styled.div<{
-  deps: number;
-}>`
-  min-height: ${(p) => p.deps * 53 + 41.5}px;
-`;
-
-const CenteredCell = styled(Td)`
-  @media (min-width: 768px) {
-    padding-left: 34px !important;
-  }
-`;
-
-const NoToggle = styled(Td)`
-  display: none !important;
-  @media (min-width: 768px) {
-    display: inline-block !important;
-  }
-`;

--- a/src/Slices/Resource/UI/ResourcesPage/ResourcesTable.tsx
+++ b/src/Slices/Resource/UI/ResourcesPage/ResourcesTable.tsx
@@ -7,7 +7,6 @@ import {
   Thead,
   Tr,
 } from "@patternfly/react-table";
-import styled from "styled-components";
 import { Resource, Sort } from "@/Core";
 import { useExpansion } from "@/Data";
 import { words } from "@/UI";
@@ -28,7 +27,7 @@ export const ResourcesTable: React.FC<Props> = ({
   ...props
 }) => {
   const [isExpanded, onExpansion] = useExpansion();
-  const onSort: OnSort = (event, index, order) => {
+  const onSort: OnSort = (_event, index, order) => {
     setSort({
       name: tablePresenter.getColumnNameForIndex(index) as Resource.SortKey,
       order,
@@ -53,14 +52,9 @@ export const ResourcesTable: React.FC<Props> = ({
         : {};
 
       return (
-        <StyledTh
-          key={displayName}
-          {...sortParams}
-          $characters={displayName.length}
-          $hasSort={hasSort}
-        >
+        <Th key={displayName} {...sortParams} modifier="fitContent">
           {displayName}
-        </StyledTh>
+        </Th>
       );
     });
 
@@ -68,17 +62,15 @@ export const ResourcesTable: React.FC<Props> = ({
     <Table {...props} variant={TableVariant.compact}>
       <Thead>
         <Tr>
-          <Th
-            aria-hidden
-            screenReaderText={words("common.emptyColumnHeader")}
-          />
+          <Th screenReaderText={words("common.emptyColumnHeader")} />
           {heads}
         </Tr>
       </Thead>
-      {rows.map((row) => (
+      {rows.map((row, index) => (
         <ResourceTableRow
           row={row}
           key={row.id}
+          index={index}
           isExpanded={isExpanded(row.id)}
           onToggle={onExpansion(row.id)}
           numberOfColumns={tablePresenter.getNumberOfColumns()}
@@ -87,21 +79,3 @@ export const ResourcesTable: React.FC<Props> = ({
     </Table>
   );
 };
-
-interface HeaderProps {
-  $characters: number;
-  $hasSort: boolean;
-}
-
-const getWidth = ({ $characters, $hasSort }: HeaderProps) => {
-  const base = `${$characters}ch`;
-  const extra = $hasSort ? "60px" : "16px";
-
-  return `calc(${base} + ${extra})`;
-};
-
-const StyledTh = styled(Th)<HeaderProps>`
-  &&& {
-    min-width: ${getWidth};
-  }
-`;

--- a/src/Slices/ResourceDetails/UI/Tabs/HistoryTab/ResourceHistoryView.tsx
+++ b/src/Slices/ResourceDetails/UI/Tabs/HistoryTab/ResourceHistoryView.tsx
@@ -1,6 +1,8 @@
 import React, { useContext, useEffect } from "react";
 import {
   Divider,
+  Stack,
+  StackItem,
   Toolbar,
   ToolbarContent,
   ToolbarItem,
@@ -52,50 +54,54 @@ export const ResourceHistoryView: React.FC<Props> = ({
   }, [sort.order]);
 
   return (
-    <>
-      <ResourceTemporalData data={details} />
+    <Stack hasGutter>
+      <StackItem>
+        <ResourceTemporalData data={details} />
+      </StackItem>
       <Divider />
-      <Toolbar>
-        <ToolbarContent>
-          <ToolbarItem variant="pagination">
-            <PaginationWidget
-              data={data}
-              pageSize={pageSize}
-              setPageSize={setPageSize}
-              setCurrentPage={setCurrentPage}
-            />
-          </ToolbarItem>
-        </ToolbarContent>
-      </Toolbar>
-      <RemoteDataView
-        data={data}
-        retry={retry}
-        label="ResourceHistory"
-        SuccessView={(history) => {
-          if (history.data.length <= 0) {
+      <StackItem isFilled>
+        <Toolbar>
+          <ToolbarContent>
+            <ToolbarItem variant="pagination">
+              <PaginationWidget
+                data={data}
+                pageSize={pageSize}
+                setPageSize={setPageSize}
+                setCurrentPage={setCurrentPage}
+              />
+            </ToolbarItem>
+          </ToolbarContent>
+        </Toolbar>
+        <RemoteDataView
+          data={data}
+          retry={retry}
+          label="ResourceHistory"
+          SuccessView={(history) => {
+            if (history.data.length <= 0) {
+              return (
+                <EmptyView
+                  message={words("resources.history.empty.message")}
+                  aria-label="ResourceHistory-Empty"
+                />
+              );
+            }
+            const tablePresenter = new ResourceHistoryTablePresenter(
+              new MomentDatePresenter(),
+            );
+            const rows = tablePresenter.createRows(history.data);
+
             return (
-              <EmptyView
-                message={words("resources.history.empty.message")}
-                aria-label="ResourceHistory-Empty"
+              <ResourceHistoryTable
+                aria-label="ResourceHistory-Success"
+                rows={rows}
+                sort={sort}
+                setSort={setSort}
+                tablePresenter={tablePresenter}
               />
             );
-          }
-          const tablePresenter = new ResourceHistoryTablePresenter(
-            new MomentDatePresenter(),
-          );
-          const rows = tablePresenter.createRows(history.data);
-
-          return (
-            <ResourceHistoryTable
-              aria-label="ResourceHistory-Success"
-              rows={rows}
-              sort={sort}
-              setSort={setSort}
-              tablePresenter={tablePresenter}
-            />
-          );
-        }}
-      />
-    </>
+          }}
+        />
+      </StackItem>
+    </Stack>
   );
 };

--- a/src/Slices/ResourceDetails/UI/Tabs/HistoryTab/ResourceTemporalData.tsx
+++ b/src/Slices/ResourceDetails/UI/Tabs/HistoryTab/ResourceTemporalData.tsx
@@ -5,7 +5,6 @@ import {
   DescriptionListGroup,
   DescriptionListTerm,
 } from "@patternfly/react-core";
-import styled from "styled-components";
 import { Query } from "@/Core";
 import { RemoteDataView } from "@/UI/Components";
 import { MomentDatePresenter } from "@/UI/Utils";
@@ -22,10 +21,7 @@ export const ResourceTemporalData: React.FC<Props> = ({ data }) => (
     data={data}
     label="ResourceTemporalData"
     SuccessView={(resourceDetails) => (
-      <StyledDescriptionList
-        isHorizontal
-        aria-label="ResourceTemporalData-Success"
-      >
+      <DescriptionList isHorizontal aria-label="ResourceTemporalData-Success">
         <DescriptionListGroup>
           <DescriptionListTerm>
             {words("resources.info.lastDeploy")}
@@ -44,11 +40,7 @@ export const ResourceTemporalData: React.FC<Props> = ({ data }) => (
             {datePresenter.getFull(resourceDetails.first_generated_time)}
           </DescriptionListDescription>
         </DescriptionListGroup>
-      </StyledDescriptionList>
+      </DescriptionList>
     )}
   />
 );
-
-const StyledDescriptionList = styled(DescriptionList)`
-  padding: 24px;
-`;

--- a/src/Slices/ResourceDetails/UI/Tabs/LogTab/Details.tsx
+++ b/src/Slices/ResourceDetails/UI/Tabs/LogTab/Details.tsx
@@ -5,7 +5,6 @@ import {
   DescriptionListGroup,
   DescriptionListTerm,
 } from "@patternfly/react-core";
-import styled from "styled-components";
 import { isObjectEmpty, Maybe } from "@/Core";
 import { JsonFormatter, XmlFormatter } from "@/Data";
 import { AttributeClassifier, AttributeList, CodeText } from "@/UI/Components";
@@ -19,14 +18,14 @@ export const Details: React.FC<Props> = ({ log }) => {
   return (
     <DescriptionList>
       <DescriptionListGroup>
-        <StyledTerm>Message</StyledTerm>
+        <DescriptionListTerm>Message</DescriptionListTerm>
         <DescriptionListDescription>
           <CodeText>{log.msg}</CodeText>
         </DescriptionListDescription>
       </DescriptionListGroup>
       {!isObjectEmpty(log.kwargs) && (
         <DescriptionListGroup>
-          <StyledTerm>Kwargs</StyledTerm>
+          <DescriptionListTerm>Kwargs</DescriptionListTerm>
           <DescriptionListDescription>
             <AttributeList
               attributes={classifier.classify(log.kwargs)}
@@ -38,10 +37,6 @@ export const Details: React.FC<Props> = ({ log }) => {
     </DescriptionList>
   );
 };
-
-const StyledTerm = styled(DescriptionListTerm)`
-  font-size: 1rem;
-`;
 
 const classifier = new AttributeClassifier(
   new JsonFormatter(),

--- a/src/Slices/ResourceDetails/UI/Tabs/LogTab/Row.tsx
+++ b/src/Slices/ResourceDetails/UI/Tabs/LogTab/Row.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { Tbody, Td, Tr, ExpandableRowContent } from "@patternfly/react-table";
-import styled, { css } from "styled-components";
 import { CodeText } from "@/UI/Components";
 import { MomentDatePresenter } from "@/UI/Utils";
 import { ResourceLog } from "@S/ResourceDetails/Core/ResourceLog";
@@ -27,12 +26,8 @@ export const Row: React.FC<Props> = ({
   toggleActionType,
 }) => {
   return (
-    <StyledTbody
-      isExpanded={false}
-      $level={log.level}
-      aria-label="ResourceLogRow"
-    >
-      <Tr>
+    <Tbody isExpanded={false} aria-label="ResourceLogRow">
+      <Tr className={getClassForLevel(log.level)}>
         <Td
           expand={{
             rowIndex: index,
@@ -40,10 +35,9 @@ export const Row: React.FC<Props> = ({
             onToggle,
           }}
         />
-        {/* The width values represent percentages */}
-        <Td width={15}>{datePresenter.getFull(log.timestamp)}</Td>
-        <Td width={10}>{log.action}</Td>
-        <Td width={10}>{log.level}</Td>
+        <Td modifier="fitContent">{datePresenter.getFull(log.timestamp)}</Td>
+        <Td modifier="fitContent">{log.action}</Td>
+        <Td modifier="fitContent">{log.level}</Td>
         <Td modifier="truncate">
           <CodeText singleLine>{log.msg}</CodeText>
         </Td>
@@ -52,7 +46,7 @@ export const Row: React.FC<Props> = ({
         </Td>
       </Tr>
       {isExpanded && (
-        <Tr isExpanded={isExpanded}>
+        <Tr isExpanded={isExpanded} className={getClassForLevel(log.level)}>
           <Td colSpan={numberOfColumns}>
             <ExpandableRowContent>
               <Details log={log} />
@@ -60,31 +54,17 @@ export const Row: React.FC<Props> = ({
           </Td>
         </Tr>
       )}
-    </StyledTbody>
+    </Tbody>
   );
 };
 
-const StyledTbody = styled(Tbody)<{ $level: string }>`
-  ${(p) => getStyleForLevel(p.$level)};
-`;
-
-const getStyleForLevel = (level: string) => {
+const getClassForLevel = (level: string): string => {
   switch (level) {
     case "WARNING":
-      return css`
-        background-color: var(--pf-t--global--color--status--warning--default);
-        --pf-v6-c-table--BorderColor: var(
-          --pf-t--global--border--color--status--warning--default
-        );
-      `;
+      return "warning";
     case "ERROR":
     case "CRITICAL":
-      return css`
-        background-color: var(--pf-t--global--color--status--danger--default);
-        --pf-v6-c-table--BorderColor: var(
-          --pf-t--global--border--color--status--danger--default
-        );
-      `;
+      return "danger";
     default:
       return "";
   }

--- a/src/Slices/ResourceDetails/UI/Tabs/LogTab/Row.tsx
+++ b/src/Slices/ResourceDetails/UI/Tabs/LogTab/Row.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Tbody, Td, Tr, ExpandableRowContent } from "@patternfly/react-table";
+import { LogLevelString } from "@/Core";
 import { CodeText } from "@/UI/Components";
 import { MomentDatePresenter } from "@/UI/Utils";
 import { ResourceLog } from "@S/ResourceDetails/Core/ResourceLog";
@@ -60,10 +61,10 @@ export const Row: React.FC<Props> = ({
 
 const getClassForLevel = (level: string): string => {
   switch (level) {
-    case "WARNING":
+    case LogLevelString.WARNING:
       return "warning";
-    case "ERROR":
-    case "CRITICAL":
+    case LogLevelString.ERROR:
+    case LogLevelString.CRITICAL:
       return "danger";
     default:
       return "";

--- a/src/Slices/ResourceDetails/UI/View.tsx
+++ b/src/Slices/ResourceDetails/UI/View.tsx
@@ -1,6 +1,5 @@
 import React, { useContext } from "react";
 import { Flex, FlexItem } from "@patternfly/react-core";
-import styled from "styled-components";
 import { Query, RemoteData } from "@/Core";
 import { useUrlStateWithString } from "@/Data";
 import {
@@ -32,23 +31,19 @@ export const View: React.FC<Props> = ({ id }) => {
 
   return (
     <PageContainer pageTitle={words("resources.details.title")}>
-      <CustomFlex>
+      <Flex>
         <FlexItem>
           <Description>{id}</Description>
         </FlexItem>
         <FlexItem>
           <StatusLabel {...{ data }} />
         </FlexItem>
-      </CustomFlex>
+      </Flex>
 
       <Tabs {...{ id, data, activeTab, setActiveTab }} />
     </PageContainer>
   );
 };
-
-const CustomFlex = styled(Flex)`
-  margin-bottom: 16px;
-`;
 
 const StatusLabel: React.FC<{
   data: Query.UsedApiData<"GetResourceDetails">;

--- a/src/Slices/ServiceDetails/UI/Tabs/CatalogTabs.tsx
+++ b/src/Slices/ServiceDetails/UI/Tabs/CatalogTabs.tsx
@@ -1,6 +1,5 @@
 import React from "react";
-import { Tabs, Tab } from "@patternfly/react-core";
-import styled from "styled-components";
+import { Tabs, Tab, TabContentBody } from "@patternfly/react-core";
 import { ServiceModel } from "@/Core";
 import { useUrlStateWithString } from "@/Data";
 import { AttributeTable } from "./AttributeTable";
@@ -34,14 +33,14 @@ export const CatalogTabs: React.FunctionComponent<Props> = ({ service }) => {
         <Details instanceSummary={service.instance_summary} />
       </Tab>
       <Tab eventKey="attributes" title="Attributes">
-        <OverflowContainer>
+        <TabContentBody hasPadding>
           <AttributeTable service={service} />
-        </OverflowContainer>
+        </TabContentBody>
       </Tab>
       <Tab eventKey="lifecycle_states" title="Lifecycle States">
-        <OverflowContainer>
+        <TabContentBody hasPadding>
           <LifecycleTable lifecycle={service.lifecycle} />
-        </OverflowContainer>
+        </TabContentBody>
       </Tab>
       <Tab eventKey="config" title="Config">
         <Config serviceName={service.name} />
@@ -52,7 +51,3 @@ export const CatalogTabs: React.FunctionComponent<Props> = ({ service }) => {
     </Tabs>
   );
 };
-
-const OverflowContainer = styled.div`
-  overflow-x: auto;
-`;

--- a/src/Slices/ServiceInstanceDetails/UI/Components/Sections/HistorySection.tsx
+++ b/src/Slices/ServiceInstanceDetails/UI/Components/Sections/HistorySection.tsx
@@ -7,8 +7,7 @@ import {
   PanelMainBody,
   Title,
 } from "@patternfly/react-core";
-import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
-import styled from "styled-components";
+import { Table, Tbody, Td, Tr } from "@patternfly/react-table";
 import { ServiceModel } from "@/Core";
 import { useUrlStateWithString } from "@/Data";
 import { InstanceLog } from "@/Slices/ServiceInstanceHistory/Core/Domain";
@@ -65,31 +64,20 @@ export const HistorySection: React.FC = () => {
            * Otherwise, it will still display the stale data under the error messages above.
            */}
           {logsQuery.data && !logsQuery.isLoading && !logsQuery.isError && (
-            <Table aria-label="VersionHistoryTable" isStickyHeader>
-              <Thead>
-                <Tr>
-                  <Th style={{ minWidth: "100px" }}>
-                    {words("instanceDetails.history.table.version")}
-                  </Th>
-                  <Th style={{ minWidth: "100px" }}>
-                    {words("instanceDetails.history.table.timestamp")}
-                  </Th>
-                  <Th>{words("instanceDetails.history.table.status")}</Th>
-                </Tr>
-              </Thead>
+            <Table aria-label="VersionHistoryTable">
               <Tbody>
                 {logsQuery.data.map((log: InstanceLog) => (
-                  <StyledRow
+                  <Tr
                     key={String(log.version)}
                     isSelectable
                     isClickable
                     onRowClick={() => setSelectedVersion(String(log.version))}
                     isRowSelected={String(log.version) === selectedVersion}
                     aria-label="History-Row"
-                    className={log.deleted ? "-terminated" : ""}
+                    className={log.deleted ? "danger" : ""}
                   >
                     <HistoryRowContent log={log} />
-                  </StyledRow>
+                  </Tr>
                 ))}
               </Tbody>
             </Table>
@@ -99,20 +87,6 @@ export const HistorySection: React.FC = () => {
     </Panel>
   );
 };
-
-const StyledRow = styled(Tr)`
-  &.-terminated {
-    &:hover {
-      background-color: var(--pf-t--global--color--nonstatus--red--clicked);
-    }
-    &.pf-m-clickable {
-      background-color: var(--pf-t--global--color--nonstatus--red--default);
-    }
-    &.pf-m-selected {
-      background-color: var(--pf-t--global--color--nonstatus--red--clicked);
-    }
-  }
-`;
 
 interface HistoryRowProps {
   log: InstanceLog;

--- a/src/Slices/ServiceInstanceDetails/UI/Tabs/AttributesTabContent.tsx
+++ b/src/Slices/ServiceInstanceDetails/UI/Tabs/AttributesTabContent.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { ToggleGroup, ToggleGroupItem } from "@patternfly/react-core";
+import { Stack, ToggleGroup, ToggleGroupItem } from "@patternfly/react-core";
 import styled from "styled-components";
 import { AttributeViewToggles } from "../../Utils";
 import { AttributesViewProvider } from "../Components/AttributesComponents";
@@ -24,30 +24,32 @@ export const AttributesTabContent: React.FC = () => {
 
   return (
     <TabContentWrapper id={"Attribute-content"}>
-      <StyledToggleGroup aria-label="toggle-group-attributes" isCompact>
-        <ToggleGroupItem
-          text={AttributeViewToggles.TABLE}
-          buttonId={AttributeViewToggles.TABLE}
-          isSelected={selectedView === AttributeViewToggles.TABLE}
-          onChange={handleToggleClick}
-          isDisabled={false}
-        />
-        <ToggleGroupItem
-          text={AttributeViewToggles.EDITOR}
-          buttonId={AttributeViewToggles.EDITOR}
-          isSelected={selectedView === AttributeViewToggles.EDITOR}
-          onChange={handleToggleClick}
-          isDisabled={false}
-        />
-        <ToggleGroupItem
-          text={AttributeViewToggles.COMPARE}
-          buttonId={AttributeViewToggles.COMPARE}
-          isSelected={selectedView === AttributeViewToggles.COMPARE}
-          onChange={handleToggleClick}
-          isDisabled={false}
-        />
-      </StyledToggleGroup>
-      <AttributesViewProvider selectedView={selectedView} />
+      <Stack hasGutter>
+        <StyledToggleGroup aria-label="toggle-group-attributes" isCompact>
+          <ToggleGroupItem
+            text={AttributeViewToggles.TABLE}
+            buttonId={AttributeViewToggles.TABLE}
+            isSelected={selectedView === AttributeViewToggles.TABLE}
+            onChange={handleToggleClick}
+            isDisabled={false}
+          />
+          <ToggleGroupItem
+            text={AttributeViewToggles.EDITOR}
+            buttonId={AttributeViewToggles.EDITOR}
+            isSelected={selectedView === AttributeViewToggles.EDITOR}
+            onChange={handleToggleClick}
+            isDisabled={false}
+          />
+          <ToggleGroupItem
+            text={AttributeViewToggles.COMPARE}
+            buttonId={AttributeViewToggles.COMPARE}
+            isSelected={selectedView === AttributeViewToggles.COMPARE}
+            onChange={handleToggleClick}
+            isDisabled={false}
+          />
+        </StyledToggleGroup>
+        <AttributesViewProvider selectedView={selectedView} />
+      </Stack>
     </TabContentWrapper>
   );
 };

--- a/src/Slices/ServiceInstanceDetails/UI/Tabs/EventTabContent.tsx
+++ b/src/Slices/ServiceInstanceDetails/UI/Tabs/EventTabContent.tsx
@@ -6,6 +6,7 @@ import {
   DescriptionListTerm,
   Flex,
   FlexItem,
+  Stack,
   TabContent,
 } from "@patternfly/react-core";
 import {
@@ -17,7 +18,6 @@ import {
   Thead,
   Tr,
 } from "@patternfly/react-table";
-import styled from "styled-components";
 import { InstanceEvent } from "@/Core";
 import { InstanceLog } from "@/Slices/ServiceInstanceHistory/Core/Domain";
 import { DependencyContext, words } from "@/UI";
@@ -63,6 +63,10 @@ interface Props {
  *
  * @note We are using the events that are pressent in the history logs for the instance details view.
  * A link button allows the user to navigate the the full events page.
+ *
+ * If the transition is `is_error_transition` then we want the rows in an orange/golden hue.
+ * Unlike on the main event page, the history logs don't contain the `ignored_transition`.
+ * These are grayed out in the main event page.
  *
  * @prop {Props} props - The EventsTabContent Props
  *  @prop {string} selectedVersion - The actively selected version on the page.
@@ -157,149 +161,127 @@ export const EventsTabContent: React.FC<Props> = ({ selectedVersion }) => {
   return (
     <TabContent role="tabpanel" id="events">
       <TabContentWrapper>
-        <Flex>
-          <FlexItem align={{ default: "alignRight" }}>
-            <Link
-              aria-label="See-all-events"
-              pathname={routeManager.getUrl("Events", {
-                service: instance.service_entity,
-                instance: instance.id,
-              })}
-            >
-              {words("instanceDetails.events.seeAll")}
-            </Link>
-          </FlexItem>
-        </Flex>
-        <Table
-          aria-label="Expandable-events-table"
-          variant="compact"
-          isExpandable
-        >
-          <Thead>
-            <Tr>
-              <Th screenReaderText="Row expansion column" />
-              <Th width={15} key="eventType">
-                {words("instanceDetails.events.column.eventType")}
-              </Th>
-              <Th width={20} key="timestamp">
-                {words("instanceDetails.events.column.timestamp")}
-              </Th>
-              <Th width={20} key="source-state">
-                {words("instanceDetails.events.column.sourceState")}
-              </Th>
-              <Th width={20} key="destination-state">
-                {words("instanceDetails.events.column.destinationState")}
-              </Th>
-              <Th width={25} key="report">
-                {words("instanceDetails.events.column.report")}
-              </Th>
-            </Tr>
-          </Thead>
-          {events.map((event: InstanceEvent, index: number) => (
-            <BodyWithHighlightedRows
-              $transition={event}
-              key={`styled-row-${index}`}
-            >
-              <Tr
-                key={index}
-                id={`event-row-${event.id}`}
-                aria-label="Event-table-row"
+        <Stack hasGutter>
+          <Flex>
+            <FlexItem align={{ default: "alignRight" }}>
+              <Link
+                aria-label="See-all-events"
+                pathname={routeManager.getUrl("Events", {
+                  service: instance.service_entity,
+                  instance: instance.id,
+                })}
               >
-                <Td
-                  expand={{
-                    rowIndex: index,
-                    isExpanded: isExpanded(event.id),
-                    onToggle: () =>
-                      updateExpanded(event.id, !isExpanded(event.id)),
-                  }}
-                ></Td>
-                <Td>
-                  <EventIcon eventType={event.event_type} />
-                </Td>
-                <Td aria-label={`Event-date-${index}`}>
-                  <DateWithTimeDiffTooltip
-                    timestamp1={event.timestamp}
-                    timestamp2={getNextTimestamp(index)}
-                  />
-                </Td>
-                <Td aria-label={`Event-source-${index}`}>{event.source}</Td>
-                <Td aria-label={`Event-target-${index}`}>
-                  {event.destination}
-                </Td>
-                <Td aria-label={`Event-compile-${index}`}>
-                  {event.id_compile_report && (
-                    <CompileReportLink
-                      compileId={event.id_compile_report}
-                      isExport={isExportReport(event.message)}
+                {words("instanceDetails.events.seeAll")}
+              </Link>
+            </FlexItem>
+          </Flex>
+          <Table
+            aria-label="Expandable-events-table"
+            variant="compact"
+            isExpandable
+          >
+            <Thead>
+              <Tr>
+                <Th screenReaderText="Row expansion column" />
+                <Th width={15} key="eventType">
+                  {words("instanceDetails.events.column.eventType")}
+                </Th>
+                <Th width={20} key="timestamp">
+                  {words("instanceDetails.events.column.timestamp")}
+                </Th>
+                <Th width={20} key="source-state">
+                  {words("instanceDetails.events.column.sourceState")}
+                </Th>
+                <Th width={20} key="destination-state">
+                  {words("instanceDetails.events.column.destinationState")}
+                </Th>
+                <Th width={25} key="report">
+                  {words("instanceDetails.events.column.report")}
+                </Th>
+              </Tr>
+            </Thead>
+            {events.map((event: InstanceEvent, index: number) => (
+              <Tbody key={`styled-row-${index}`}>
+                <Tr
+                  key={index}
+                  id={`event-row-${event.id}`}
+                  aria-label="Event-table-row"
+                  className={event.is_error_transition ? "warning" : ""}
+                >
+                  <Td
+                    expand={{
+                      rowIndex: index,
+                      isExpanded: isExpanded(event.id),
+                      onToggle: () =>
+                        updateExpanded(event.id, !isExpanded(event.id)),
+                    }}
+                  ></Td>
+                  <Td>
+                    <EventIcon eventType={event.event_type} />
+                  </Td>
+                  <Td aria-label={`Event-date-${index}`}>
+                    <DateWithTimeDiffTooltip
+                      timestamp1={event.timestamp}
+                      timestamp2={getNextTimestamp(index)}
                     />
-                  )}
-                </Td>
-              </Tr>
-              <Tr
-                isExpanded={isExpanded(event.id)}
-                data-testid={`details_${event.id}`}
-              >
-                <Td colSpan={5}>
-                  <ExpandableRowContent>
-                    <DescriptionList>
-                      <DescriptionListGroup>
-                        <DescriptionListTerm>
-                          {words("events.column.message")}
-                        </DescriptionListTerm>
-                        <DescriptionListDescription
-                          aria-label={`Event-message-${index}`}
-                        >
-                          {event.message}
-                        </DescriptionListDescription>
-                      </DescriptionListGroup>
-                      <DescriptionListGroup>
-                        <DescriptionListTerm>
-                          {words("events.details.title")}
-                        </DescriptionListTerm>
-                        <DescriptionListDescription
-                          aria-label={`Event-details-${index}`}
-                        >
-                          <pre
-                            style={{
-                              whiteSpace: "pre-wrap",
-                              fontFamily: "Liberation Mono",
-                            }}
+                  </Td>
+                  <Td aria-label={`Event-source-${index}`}>{event.source}</Td>
+                  <Td aria-label={`Event-target-${index}`}>
+                    {event.destination}
+                  </Td>
+                  <Td aria-label={`Event-compile-${index}`}>
+                    {event.id_compile_report && (
+                      <CompileReportLink
+                        compileId={event.id_compile_report}
+                        isExport={isExportReport(event.message)}
+                      />
+                    )}
+                  </Td>
+                </Tr>
+                <Tr
+                  isExpanded={isExpanded(event.id)}
+                  data-testid={`details_${event.id}`}
+                  className={event.is_error_transition ? "warning" : ""}
+                >
+                  <Td colSpan={6}>
+                    <ExpandableRowContent>
+                      <DescriptionList>
+                        <DescriptionListGroup>
+                          <DescriptionListTerm>
+                            {words("events.column.message")}
+                          </DescriptionListTerm>
+                          <DescriptionListDescription
+                            aria-label={`Event-message-${index}`}
                           >
-                            <code>{JSON.stringify(event, null, 2)}</code>
-                          </pre>
-                        </DescriptionListDescription>
-                      </DescriptionListGroup>
-                    </DescriptionList>
-                  </ExpandableRowContent>
-                </Td>
-              </Tr>
-            </BodyWithHighlightedRows>
-          ))}
-        </Table>
+                            {event.message}
+                          </DescriptionListDescription>
+                        </DescriptionListGroup>
+                        <DescriptionListGroup>
+                          <DescriptionListTerm>
+                            {words("events.details.title")}
+                          </DescriptionListTerm>
+                          <DescriptionListDescription
+                            aria-label={`Event-details-${index}`}
+                          >
+                            <pre
+                              style={{
+                                whiteSpace: "pre-wrap",
+                                fontFamily: "Liberation Mono",
+                              }}
+                            >
+                              <code>{JSON.stringify(event, null, 2)}</code>
+                            </pre>
+                          </DescriptionListDescription>
+                        </DescriptionListGroup>
+                      </DescriptionList>
+                    </ExpandableRowContent>
+                  </Td>
+                </Tr>
+              </Tbody>
+            ))}
+          </Table>
+        </Stack>
       </TabContentWrapper>
     </TabContent>
   );
 };
-
-/**
- * The transitions we would like to highlight in the UI
- */
-type HighlightedTransition = Pick<
-  InstanceEvent,
-  "ignored_transition" | "is_error_transition"
->;
-
-/**
- * If the transition is `is_error_transition` then we want the rows in an orange/golden hue.
- * Unlike on the main event page, the history logs don't contain the `ignored_transition`.
- * These are grayed out in the main event page.
- */
-const BodyWithHighlightedRows = styled(Tbody)<{
-  $transition: HighlightedTransition;
-}>`
-  ${({ $transition }) => {
-    return $transition.is_error_transition
-      ? "background-color: var(--pf-t--global--color--status--warning--default)"
-      : "background-color: inherit";
-  }};
-`;

--- a/src/Slices/ServiceInventory/UI/Components/RowActionsMenu/DestroyAction/DestroyAction.tsx
+++ b/src/Slices/ServiceInventory/UI/Components/RowActionsMenu/DestroyAction/DestroyAction.tsx
@@ -95,7 +95,7 @@ export const DestroyAction: React.FC<Props> = ({
         itemId="expert-destroy"
         style={{
           backgroundColor:
-            "var(--pf-t--global--border--color--status--danger--default)",
+            "var(--pf-t--global--color--nonstatus--red--default)",
         }}
         isDanger
         onClick={openModal}

--- a/src/Slices/ServiceInventory/UI/Components/RowActionsMenu/ForceStateAction/ForceStateAction.tsx
+++ b/src/Slices/ServiceInventory/UI/Components/RowActionsMenu/ForceStateAction/ForceStateAction.tsx
@@ -162,7 +162,7 @@ export const ForceStateAction: React.FC<Props> = ({
           direction="down"
           style={{
             backgroundColor:
-              "var(--pf-t--global--border--color--status--danger--default)",
+              "var(--pf-t--global--color--nonstatus--red--default)",
           }}
           drilldownMenu={
             <DrilldownMenu
@@ -172,12 +172,13 @@ export const ForceStateAction: React.FC<Props> = ({
               <MenuItem
                 style={{
                   backgroundColor:
-                    "var(--pf-t--global--border--color--status--danger--default)",
+                    "var(--pf-t--global--color--nonstatus--red--default)",
                 }}
                 icon={<WarningTriangleIcon />}
                 itemId="group:expertstate_breadcrumb"
                 direction="up"
                 aria-hidden
+                isDanger
               >
                 Force state to:
               </MenuItem>

--- a/src/Slices/ServiceInventory/UI/InstanceRow.tsx
+++ b/src/Slices/ServiceInventory/UI/InstanceRow.tsx
@@ -50,8 +50,8 @@ export const InstanceRow: React.FC<Props> = ({
 
   return (
     <Tbody isExpanded={false}>
-      <StyledRow
-        $deleted={row.deleted}
+      <Tr
+        className={row.deleted ? "danger" : ""}
         id={`instance-row-${row.id.short}`}
         aria-label="InstanceRow-Intro"
       >
@@ -94,7 +94,7 @@ export const InstanceRow: React.FC<Props> = ({
           <DateWithTooltip timestamp={row.updatedAt} />
         </Td>
         <Td dataLabel="actions">{rowActions}</Td>
-      </StyledRow>
+      </Tr>
       <Tr
         isExpanded={isExpanded}
         data-testid={`details_${row.id.short}`}
@@ -119,11 +119,4 @@ export const InstanceRow: React.FC<Props> = ({
 
 const ActionWrapper = styled.span`
   cursor: pointer;
-`;
-
-const StyledRow = styled(Tr)<{ $deleted: boolean }>`
-  ${(p) =>
-    p.$deleted
-      ? "background-color: var(--pf-t--global--color--nonstatus--red--default)"
-      : ""}
 `;

--- a/src/Slices/Settings/UI/Tabs/Configuration/Components/BooleanInput.tsx
+++ b/src/Slices/Settings/UI/Tabs/Configuration/Components/BooleanInput.tsx
@@ -1,6 +1,5 @@
 import React from "react";
-import { Switch } from "@patternfly/react-core";
-import styled from "styled-components";
+import { Flex, FlexItem, Switch } from "@patternfly/react-core";
 import { EnvironmentSettings } from "@/Core";
 import { Warning } from "./Warning";
 
@@ -9,22 +8,17 @@ interface Props {
 }
 
 export const BooleanInput: React.FC<Props> = ({ info }) => (
-  <Container>
-    <Switch
-      isChecked={info.value}
-      onChange={(_event, value) => info.set(value)}
-      aria-label={`Toggle-${info.name}`}
-    />
-    {info.isUpdateable(info) && <StyledWarning />}
-  </Container>
+  <Flex direction={{ default: "row" }}>
+    <FlexItem>
+      <Switch
+        isChecked={info.value}
+        onChange={(_event, value) => info.set(value)}
+        aria-label={`Toggle-${info.name}`}
+      />
+    </FlexItem>
+
+    <FlexItem style={{ minWidth: "20px" }}>
+      {info.isUpdateable(info) && <Warning />}
+    </FlexItem>
+  </Flex>
 );
-
-const StyledWarning = styled(Warning)`
-  margin-left: 16px;
-`;
-
-const Container = styled.div`
-  display: inline-flex;
-  align-items: center;
-  vertical-align: bottom;
-`;

--- a/src/Slices/Settings/UI/Tabs/Configuration/Components/DictInput.tsx
+++ b/src/Slices/Settings/UI/Tabs/Configuration/Components/DictInput.tsx
@@ -49,7 +49,7 @@ export const DictInputWithRow: React.FC<Props> = ({ info }) => {
         </FlexItem>
 
         <FlexItem style={{ minWidth: "20px" }}>
-          {info.isUpdateable(info) && <Warning />}
+          {customInfo.isUpdateable() && <Warning />}
         </FlexItem>
       </Flex>
     </Row>

--- a/src/Slices/Settings/UI/Tabs/Configuration/Components/DictInput.tsx
+++ b/src/Slices/Settings/UI/Tabs/Configuration/Components/DictInput.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import styled from "styled-components";
+import { Flex, FlexItem } from "@patternfly/react-core";
 import { EnvironmentSettings, Maybe } from "@/Core";
 import { DictEditor, Entry, Dict } from "@/UI/Components";
 import { Row } from "./Row";
@@ -32,33 +32,29 @@ export const DictInputWithRow: React.FC<Props> = ({ info }) => {
     },
     isUpdateable: () => info.isUpdateable(info) || newEntry[0].length > 0,
   };
-  const isDeleteEntryAllowed = (value: Dict, key: string) =>
+  const isDeleteEntryAllowed = (_value: Dict, key: string) =>
     !Object.keys(info.default).includes(key);
 
   return (
     <Row info={customInfo}>
-      <Container hasWarning={customInfo.isUpdateable()}>
-        <DictEditor
-          value={info.value}
-          setValue={info.set}
-          newEntry={newEntry}
-          setNewEntry={setNewEntry}
-          isDeleteEntryAllowed={isDeleteEntryAllowed}
-        />
-        {customInfo.isUpdateable() && <StyledWarning />}
-      </Container>
+      <Flex direction={{ default: "row" }}>
+        <FlexItem grow={{ default: "grow" }}>
+          <DictEditor
+            value={info.value}
+            setValue={info.set}
+            newEntry={newEntry}
+            setNewEntry={setNewEntry}
+            isDeleteEntryAllowed={isDeleteEntryAllowed}
+          />
+        </FlexItem>
+
+        <FlexItem style={{ minWidth: "20px" }}>
+          {info.isUpdateable(info) && <Warning />}
+        </FlexItem>
+      </Flex>
     </Row>
   );
 };
-
-const StyledWarning = styled(Warning)`
-  height: 36px;
-`;
-
-const Container = styled.div<{ hasWarning: boolean }>`
-  display: flex;
-  margin-right: ${(p) => (p.hasWarning ? "0" : "16px")};
-`;
 
 const getSanitizedNewEntry = ([key, value]: Entry) => {
   if (key.length <= 0) return {};

--- a/src/Slices/Settings/UI/Tabs/Configuration/Components/EnumInput.tsx
+++ b/src/Slices/Settings/UI/Tabs/Configuration/Components/EnumInput.tsx
@@ -1,6 +1,5 @@
 import React from "react";
-import { SelectOptionProps } from "@patternfly/react-core";
-import styled from "styled-components";
+import { Flex, FlexItem, SelectOptionProps } from "@patternfly/react-core";
 import { EnvironmentSettings } from "@/Core";
 import { SingleTextSelect } from "@/UI/Components";
 import { Warning } from "./Warning";
@@ -16,23 +15,19 @@ export const EnumInput: React.FC<Props> = ({ info }) => {
   });
 
   return (
-    <>
-      <StyledSingleTextSelect
-        selected={info.value}
-        setSelected={setSelected}
-        options={options}
-        toggleAriaLabel={`EnumInput-${info.name}`}
-      />
-      {info.isUpdateable(info) && <StyledWarning />}
-    </>
+    <Flex direction={{ default: "row" }}>
+      <FlexItem grow={{ default: "grow" }}>
+        <SingleTextSelect
+          selected={info.value}
+          setSelected={setSelected}
+          options={options}
+          toggleAriaLabel={`EnumInput-${info.name}`}
+        />
+      </FlexItem>
+
+      <FlexItem style={{ minWidth: "20px" }}>
+        {info.isUpdateable(info) && <Warning />}
+      </FlexItem>
+    </Flex>
   );
 };
-
-const StyledWarning = styled(Warning)`
-  height: 36px;
-  margin-left: 16px;
-`;
-
-const StyledSingleTextSelect = styled(SingleTextSelect)`
-  width: 300px;
-`;

--- a/src/Slices/Settings/UI/Tabs/Configuration/Components/IntInput.tsx
+++ b/src/Slices/Settings/UI/Tabs/Configuration/Components/IntInput.tsx
@@ -1,6 +1,5 @@
 import React from "react";
-import { NumberInput } from "@patternfly/react-core";
-import styled from "styled-components";
+import { Flex, FlexItem, NumberInput } from "@patternfly/react-core";
 import { EnvironmentSettings } from "@/Core";
 import { Warning } from "./Warning";
 
@@ -16,24 +15,24 @@ export const IntInput: React.FC<Props> = ({ info }) => {
   const onPlus = () => info.set(Number(info.value) + 1);
 
   return (
-    <>
-      <NumberInput
-        value={Number(info.value)}
-        onMinus={onMinus}
-        onChange={onChange}
-        onPlus={onPlus}
-        inputName="input"
-        inputAriaLabel="number input"
-        minusBtnAriaLabel="minus"
-        plusBtnAriaLabel="plus"
-        widthChars={10}
-      />
-      {info.isUpdateable(info) && <StyledWarning />}
-    </>
+    <Flex direction={{ default: "row" }}>
+      <FlexItem>
+        <NumberInput
+          value={Number(info.value)}
+          onMinus={onMinus}
+          onChange={onChange}
+          onPlus={onPlus}
+          inputName="input"
+          inputAriaLabel="number input"
+          minusBtnAriaLabel="minus"
+          plusBtnAriaLabel="plus"
+          widthChars={10}
+        />
+      </FlexItem>
+
+      <FlexItem style={{ minWidth: "20px" }}>
+        {info.isUpdateable(info) && <Warning />}
+      </FlexItem>
+    </Flex>
   );
 };
-
-const StyledWarning = styled(Warning)`
-  height: 36px;
-  margin-left: 16px;
-`;

--- a/src/Slices/Settings/UI/Tabs/Configuration/Components/PositiveFloatInput.tsx
+++ b/src/Slices/Settings/UI/Tabs/Configuration/Components/PositiveFloatInput.tsx
@@ -1,6 +1,5 @@
 import React from "react";
-import { NumberInput } from "@patternfly/react-core";
-import styled from "styled-components";
+import { Flex, FlexItem, NumberInput } from "@patternfly/react-core";
 import { EnvironmentSettings } from "@/Core";
 import { Warning } from "./Warning";
 
@@ -21,25 +20,25 @@ export const PositiveFloatInput: React.FC<Props> = ({ info }) => {
   const onPlus = () => info.set(Number(info.value) + 1);
 
   return (
-    <>
-      <NumberInput
-        value={Number(info.value)}
-        onMinus={onMinus}
-        onChange={onChange}
-        onPlus={onPlus}
-        min={MINVALUE}
-        inputName="input"
-        inputAriaLabel="number input"
-        minusBtnAriaLabel="minus"
-        plusBtnAriaLabel="plus"
-        widthChars={10}
-      />
-      {info.isUpdateable(info) && <StyledWarning />}
-    </>
+    <Flex direction={{ default: "row" }}>
+      <FlexItem grow={{ default: "grow" }}>
+        <NumberInput
+          value={Number(info.value)}
+          onMinus={onMinus}
+          onChange={onChange}
+          onPlus={onPlus}
+          min={MINVALUE}
+          inputName="input"
+          inputAriaLabel="number input"
+          minusBtnAriaLabel="minus"
+          plusBtnAriaLabel="plus"
+          widthChars={10}
+        />
+      </FlexItem>
+
+      <FlexItem style={{ minWidth: "20px" }}>
+        {info.isUpdateable(info) && <Warning />}
+      </FlexItem>
+    </Flex>
   );
 };
-
-const StyledWarning = styled(Warning)`
-  height: 36px;
-  margin-left: 16px;
-`;

--- a/src/Slices/Settings/UI/Tabs/Configuration/Components/Row.tsx
+++ b/src/Slices/Settings/UI/Tabs/Configuration/Components/Row.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { Tooltip } from "@patternfly/react-core";
 import { OutlinedQuestionCircleIcon } from "@patternfly/react-icons";
 import { Td, Tr } from "@patternfly/react-table";
-import styled from "styled-components";
 import { EnvironmentSettings } from "@/Core";
 import { InputActions } from "./InputActions";
 
@@ -17,11 +16,11 @@ export const Row: React.FC<React.PropsWithChildren<Props>> = ({
   <Tr aria-label={`Row-${info.name}`}>
     <Td>
       {info.name}{" "}
-      <StyledTooltip content={getDescription(info)}>
+      <Tooltip content={getDescription(info)}>
         <OutlinedQuestionCircleIcon />
-      </StyledTooltip>
+      </Tooltip>
     </Td>
-    <Td style={{ verticalAlign: "middle" }}>{children}</Td>
+    <Td>{children}</Td>
     <Td>
       <InputActions info={info} />
     </Td>
@@ -37,7 +36,3 @@ const getDescription = (
 
   return `${info.doc}\ndefault: ${info.default}`;
 };
-
-const StyledTooltip = styled(Tooltip)`
-  white-space: pre-line;
-`;

--- a/src/Slices/Settings/UI/Tabs/Configuration/Components/StringInput.tsx
+++ b/src/Slices/Settings/UI/Tabs/Configuration/Components/StringInput.tsx
@@ -1,6 +1,5 @@
 import React from "react";
-import { TextInput } from "@patternfly/react-core";
-import styled from "styled-components";
+import { Flex, FlexItem, TextInput } from "@patternfly/react-core";
 import { EnvironmentSettings } from "@/Core";
 import { Warning } from "./Warning";
 
@@ -10,23 +9,19 @@ interface Props {
 
 export const StringInput: React.FC<Props> = ({ info }) => {
   return (
-    <Container hasWarning={info.isUpdateable(info)}>
-      <TextInput
-        value={info.value}
-        onChange={(_event, value) => info.set(value)}
-        aria-label="string input"
-        type="text"
-      />
-      {info.isUpdateable(info) && <StyledWarning />}
-    </Container>
+    <Flex direction={{ default: "row" }}>
+      <FlexItem grow={{ default: "grow" }}>
+        <TextInput
+          value={info.value}
+          onChange={(_event, value) => info.set(value)}
+          aria-label="string input"
+          type="text"
+        />
+      </FlexItem>
+
+      <FlexItem style={{ minWidth: "20px" }}>
+        {info.isUpdateable(info) && <Warning />}
+      </FlexItem>
+    </Flex>
   );
 };
-
-const StyledWarning = styled(Warning)`
-  height: 36px;
-  margin-left: 16px;
-`;
-const Container = styled.div<{ hasWarning: boolean }>`
-  display: flex;
-  margin-right: ${(p) => (p.hasWarning ? "0" : "16px")};
-`;

--- a/src/Slices/Settings/UI/Tabs/Configuration/Components/Warning.tsx
+++ b/src/Slices/Settings/UI/Tabs/Configuration/Components/Warning.tsx
@@ -1,10 +1,11 @@
 import React from "react";
 import { Icon, Tooltip } from "@patternfly/react-core";
 import { ExclamationTriangleIcon } from "@patternfly/react-icons";
+import { words } from "@/UI";
 
 export const Warning: React.FC = () => (
   <Icon status="warning" isInline>
-    <Tooltip content="Changed value has not been saved">
+    <Tooltip content={words("settings.warning.update")}>
       <ExclamationTriangleIcon data-testid="Warning" />
     </Tooltip>
   </Icon>

--- a/src/Slices/Settings/UI/Tabs/Configuration/Components/Warning.tsx
+++ b/src/Slices/Settings/UI/Tabs/Configuration/Components/Warning.tsx
@@ -3,9 +3,9 @@ import { Icon, Tooltip } from "@patternfly/react-core";
 import { ExclamationTriangleIcon } from "@patternfly/react-icons";
 
 export const Warning: React.FC = () => (
-  <Icon status="warning" data-testid="Warning" isInline>
+  <Icon status="warning" isInline>
     <Tooltip content="Changed value has not been saved">
-      <ExclamationTriangleIcon />
+      <ExclamationTriangleIcon data-testid="Warning" />
     </Tooltip>
   </Icon>
 );

--- a/src/Slices/Settings/UI/Tabs/Configuration/Components/Warning.tsx
+++ b/src/Slices/Settings/UI/Tabs/Configuration/Components/Warning.tsx
@@ -1,22 +1,11 @@
 import React from "react";
 import { Icon, Tooltip } from "@patternfly/react-core";
 import { ExclamationTriangleIcon } from "@patternfly/react-icons";
-import { t_global_icon_color_status_warning_default } from "@patternfly/react-tokens";
-import styled from "styled-components";
 
-export const Warning: React.FC<{ className?: string }> = ({ className }) => (
-  <Tooltip content="Changed value has not been saved">
-    <IconWrapper className={className} data-testid="Warning">
-      <Icon style={{ color: t_global_icon_color_status_warning_default.var }}>
-        <ExclamationTriangleIcon />
-      </Icon>
-    </IconWrapper>
-  </Tooltip>
+export const Warning: React.FC = () => (
+  <Icon status="warning" data-testid="Warning" isInline>
+    <Tooltip content="Changed value has not been saved">
+      <ExclamationTriangleIcon />
+    </Tooltip>
+  </Icon>
 );
-
-const IconWrapper = styled.span`
-  font-size: 16px;
-  display: inline-flex;
-  align-items: center;
-  vertical-align: bottom;
-`;

--- a/src/Slices/Settings/UI/Tabs/Configuration/Container.tsx
+++ b/src/Slices/Settings/UI/Tabs/Configuration/Container.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from "react";
-import { Alert, AlertActionCloseButton } from "@patternfly/react-core";
+import { Alert, AlertActionCloseButton, Stack } from "@patternfly/react-core";
 import { Tbody, Table } from "@patternfly/react-table";
-import styled from "styled-components";
 import { EnvironmentSettings } from "@/Core";
 import { words } from "@/UI";
 import { InputRow } from "./Components";
@@ -37,9 +36,9 @@ export const Container: React.FC<Props> = ({
   }, [setShowUpdateBanner]);
 
   return (
-    <Wrapper className={className}>
+    <Stack hasGutter style={{ maxWidth: "1000px" }} className={className}>
       {errorMessage && (
-        <StyledAlert
+        <Alert
           variant="danger"
           title={errorMessage}
           aria-live="polite"
@@ -48,7 +47,7 @@ export const Container: React.FC<Props> = ({
         />
       )}
       {showUpdateBanner && (
-        <StyledAlert
+        <Alert
           variant="success"
           title={words("settings.update")}
           aria-live="polite"
@@ -60,26 +59,13 @@ export const Container: React.FC<Props> = ({
           isInline
         />
       )}
-      <StyledTable variant="compact" borders={false}>
+      <Table variant="compact" borders={false}>
         <Tbody>
           {infos.map((info) => (
             <InputRow info={info} key={info.name} />
           ))}
         </Tbody>
-      </StyledTable>
-    </Wrapper>
+      </Table>
+    </Stack>
   );
 };
-
-const StyledAlert = styled(Alert)`
-  margin-bottom: 1rem;
-`;
-
-const Wrapper = styled.div`
-  padding-top: 1rem;
-  overflow-x: auto;
-`;
-
-const StyledTable = styled(Table)`
-  width: auto;
-`;

--- a/src/Slices/Settings/UI/Tabs/Configuration/Tab.test.tsx
+++ b/src/Slices/Settings/UI/Tabs/Configuration/Tab.test.tsx
@@ -121,13 +121,19 @@ test("GIVEN ConfigurationTab WHEN editing a dict field THEN shows warning icon",
   const newKeyInput = within(newEntryRow).getByRole("textbox", {
     name: "editEntryKey",
   });
+  const newValueInput = within(newEntryRow).getByRole("textbox", {
+    name: /editentryvalue/i,
+  });
 
   expect(
     within(row).queryByRole("generic", { name: "Warning" }),
   ).not.toBeInTheDocument();
+
   await act(async () => {
     await userEvent.type(newKeyInput, "testKey");
+    await userEvent.type(newValueInput, "testValue");
   });
+
   expect(within(row).getByTestId("Warning")).toBeInTheDocument();
 
   await act(async () => {

--- a/src/Slices/Settings/UI/Tabs/Environment/EnvironmentSettings.tsx
+++ b/src/Slices/Settings/UI/Tabs/Environment/EnvironmentSettings.tsx
@@ -1,6 +1,5 @@
 import React, { useContext } from "react";
 import { DescriptionList } from "@patternfly/react-core";
-import styled from "styled-components";
 import { FlatEnvironment, Maybe, ProjectModel } from "@/Core";
 import {
   EditableTextField,
@@ -67,7 +66,7 @@ export const EnvironmentSettings: React.FC<Props> = ({
     });
 
   return (
-    <PaddedList>
+    <DescriptionList>
       <EditableTextField
         initialValue={environment.name}
         label={words("settings.tabs.environment.name")}
@@ -99,11 +98,6 @@ export const EnvironmentSettings: React.FC<Props> = ({
         onSubmit={onIconSubmit}
       />
       <Actions environment={environment} />
-    </PaddedList>
+    </DescriptionList>
   );
 };
-
-const PaddedList = styled(DescriptionList)`
-  padding-top: 1em;
-  max-width: 600px;
-`;

--- a/src/Slices/Settings/UI/Tabs/Tabs.tsx
+++ b/src/Slices/Settings/UI/Tabs/Tabs.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useRef } from "react";
-import { Tooltip } from "@patternfly/react-core";
+import { TabContentBody, Tooltip } from "@patternfly/react-core";
 import { CogIcon, InfoCircleIcon, KeyIcon } from "@patternfly/react-icons";
 import { ErrorView, IconTabs, TabDescriptor } from "@/UI/Components";
 import { DependencyContext } from "@/UI/Dependency";
@@ -59,7 +59,11 @@ const environmentTab = (): TabDescriptor<TabKey> => ({
   id: TabKey.Environment,
   title: words("settings.tabs.environment"),
   icon: <InfoCircleIcon />,
-  view: <EnvironmentTab />,
+  view: (
+    <TabContentBody hasPadding>
+      <EnvironmentTab />
+    </TabContentBody>
+  ),
 });
 
 const configurationTab = (environmentId: string): TabDescriptor<TabKey> => ({

--- a/src/Slices/Status/UI/Components/DownloadButton.tsx
+++ b/src/Slices/Status/UI/Components/DownloadButton.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { Button } from "@patternfly/react-core";
-import styled from "styled-components";
 import { words } from "@/UI/words";
 
 export type Phase = "Default" | "Downloading";
@@ -12,7 +11,7 @@ interface Props {
 
 export const DownloadButton: React.FC<Props> = ({ phase, onClick }) => {
   return (
-    <StyledButton
+    <Button
       spinnerAriaValueText={phaseLabelRecord[phase]}
       isLoading={phase !== "Default"}
       variant="primary"
@@ -21,7 +20,7 @@ export const DownloadButton: React.FC<Props> = ({ phase, onClick }) => {
       aria-label="DownloadArchiveButton"
     >
       {phaseLabelRecord[phase]}
-    </StyledButton>
+    </Button>
   );
 };
 
@@ -29,7 +28,3 @@ const phaseLabelRecord: Record<Phase, string> = {
   Default: words("status.supportArchive.action.download"),
   Downloading: words("status.supportArchive.action.downloading"),
 };
-
-const StyledButton = styled(Button)`
-  width: 32ch;
-`;

--- a/src/Slices/Status/UI/Page.tsx
+++ b/src/Slices/Status/UI/Page.tsx
@@ -1,6 +1,5 @@
 import React, { useContext } from "react";
 import { Flex, FlexItem } from "@patternfly/react-core";
-import styled from "styled-components";
 import { Description, PageContainer, RemoteDataView } from "@/UI/Components";
 import { DependencyContext } from "@/UI/Dependency";
 import { words } from "@/UI/words";
@@ -32,13 +31,9 @@ export const Page: React.FC = () => {
         retry={retry}
         label="ServerStatus"
         SuccessView={(status) => (
-          <PaddedStatusList status={status} apiUrl={urlManager.getApiUrl()} />
+          <StatusList status={status} apiUrl={urlManager.getApiUrl()} />
         )}
       />
     </PageContainer>
   );
 };
-
-const PaddedStatusList = styled(StatusList)`
-  margin-top: 16px;
-`;

--- a/src/Slices/Status/UI/StatusItem.tsx
+++ b/src/Slices/Status/UI/StatusItem.tsx
@@ -57,7 +57,7 @@ export const StatusItem: React.FC<Props> = ({
         dataListCells={[
           <DataListCell key={uniqueId()}>
             {details.length > 0 && (
-              <List>
+              <List isPlain>
                 {details.map(([key, value]) => {
                   if (typeof value === "object") {
                     return (
@@ -118,7 +118,7 @@ const NestedListItem: React.FC<NestedListItemProps> = ({
       <ListItem>
         <b>{name}</b>
       </ListItem>
-      <List key={`${name}-nested-list`}>
+      <List key={`${name}-nested-list`} isPlain={false}>
         {Object.entries(properties).map(([subKey, subValue]) => (
           <ListItem key={name + "_" + subKey}>
             <DescriptionList

--- a/src/UI/Components/CatalogActions/CatalogActions.tsx
+++ b/src/UI/Components/CatalogActions/CatalogActions.tsx
@@ -1,7 +1,12 @@
 import React, { useContext, useState } from "react";
-import { AlertVariant, Button, Content, Tooltip } from "@patternfly/react-core";
+import {
+  AlertVariant,
+  Button,
+  Content,
+  Flex,
+  Tooltip,
+} from "@patternfly/react-core";
 import { FileCodeIcon } from "@patternfly/react-icons";
-import styled from "styled-components";
 import { Either } from "@/Core";
 import { DependencyContext } from "@/UI/Dependency";
 import { ModalContext } from "@/UI/Root/Components/ModalProvider";
@@ -96,7 +101,11 @@ export const CatalogActions: React.FC = () => {
         setMessage={setMessage}
         type={toastType}
       />
-      <StyledWrapper>
+      <Flex
+        direction={{ default: "row" }}
+        fullWidth={{ default: "fullWidth" }}
+        justifyContent={{ default: "justifyContentFlexEnd" }}
+      >
         <Tooltip content={words("catalog.API.tooltip")} entryDelay={500}>
           <Button
             variant="plain"
@@ -110,14 +119,7 @@ export const CatalogActions: React.FC = () => {
         <Tooltip content={words("catalog.update.tooltip")}>
           <Button onClick={openModal}>{words("catalog.button.update")}</Button>
         </Tooltip>
-      </StyledWrapper>
+      </Flex>
     </>
   );
 };
-
-const StyledWrapper = styled.div`
-  display: flex;
-  flex-direction: row;
-  justify-content: flex-end;
-  padding: var(--pf-t--global--spacer--control--horizontal--default);
-`;

--- a/src/UI/Components/CopyMultiOptions/CopyMultiOptions.tsx
+++ b/src/UI/Components/CopyMultiOptions/CopyMultiOptions.tsx
@@ -10,7 +10,6 @@ import {
 } from "@patternfly/react-core";
 import { CopyIcon } from "@patternfly/react-icons";
 import copy from "copy-to-clipboard";
-import styled from "styled-components";
 import { words } from "@/UI";
 
 interface Props {
@@ -79,8 +78,10 @@ export const CopyMultiOptions: React.FC<Props> = ({
       isExpanded={isOpen}
       aria-label="Copy to clipboard"
       icon={
-        <Icon size="sm">
-          <CopyIcon />
+        <Icon>
+          <CopyIcon
+            style={{ color: "var(--pf-t--global--icon--color--subtle)" }}
+          />
         </Icon>
       }
     >
@@ -97,20 +98,16 @@ export const CopyMultiOptions: React.FC<Props> = ({
     >
       <DropdownList>
         {options.map((value, index) => (
-          <WidthLimitedTooltip
+          <Tooltip
             key={index}
             content={<div>{tooltipText}</div>}
             entryDelay={200}
             position="right"
           >
             <DropdownItem value={value}>{value}</DropdownItem>
-          </WidthLimitedTooltip>
+          </Tooltip>
         ))}
       </DropdownList>
     </Dropdown>
   );
 };
-
-const WidthLimitedTooltip = styled(Tooltip)`
-  width: 150px;
-`;

--- a/src/UI/Components/DesiredStateAttributes/AttributeList.test.tsx
+++ b/src/UI/Components/DesiredStateAttributes/AttributeList.test.tsx
@@ -7,8 +7,12 @@ test("Given the AttributeList component When rendered with the monospace variant
   render(<AttributeList attributes={classified} variant="monospace" />);
   const singleLineValue = await screen.findByText(attributes["b"]);
 
-  expect(singleLineValue).toHaveStyle("font-family: monospace");
+  expect(singleLineValue).toHaveStyle(
+    "font-family:  var(--pf-t--global--font--family--mono)",
+  );
   const multiLineValue = await screen.findByText(attributes["f"]);
 
-  expect(multiLineValue).toHaveStyle("font-family: monospace");
+  expect(multiLineValue).toHaveStyle(
+    "font-family:  var(--pf-t--global--font--family--mono)",
+  );
 });

--- a/src/UI/Components/DesiredStateAttributes/AttributeList.tsx
+++ b/src/UI/Components/DesiredStateAttributes/AttributeList.tsx
@@ -109,5 +109,7 @@ const MultiTextWithCopy = styled(TextWithCopy)`
 
 const TextContainer = styled.span<{ $variant?: AttributeTextVariant }>`
   ${(p) =>
-    p.$variant === "monospace" ? "font-family: monospace;" : "inherit"};
+    p.$variant === "monospace"
+      ? "font-family: var(--pf-t--global--font--family--mono)"
+      : "inherit"};
 `;

--- a/src/UI/Components/DiffWizard/Versus.tsx
+++ b/src/UI/Components/DiffWizard/Versus.tsx
@@ -1,33 +1,25 @@
 import React from "react";
-import { Icon } from "@patternfly/react-core";
+import { Content, Flex, FlexItem, Icon } from "@patternfly/react-core";
 import { ArrowsAltHIcon } from "@patternfly/react-icons";
-import styled from "styled-components";
 import { Diff } from "@/Core";
 
 export const Versus: React.FC<Diff.Identifiers> = ({ from, to }) => (
-  <VersusContainer>
-    <IntroHeader>{from}</IntroHeader>
-    <Icon size="md">
-      <StyledIcon />
-    </Icon>
-    <IntroHeader isTarget>{to}</IntroHeader>
-  </VersusContainer>
+  <Flex
+    direction={{ default: "row" }}
+    alignItems={{ default: "alignItemsBaseline" }}
+    fullWidth={{ default: "fullWidth" }}
+    justifyContent={{ default: "justifyContentCenter" }}
+  >
+    <FlexItem>
+      <Content component="h2">{from}</Content>
+    </FlexItem>
+    <FlexItem>
+      <Icon size="md">
+        <ArrowsAltHIcon />
+      </Icon>
+    </FlexItem>
+    <FlexItem>
+      <Content component="h2">{to}</Content>
+    </FlexItem>
+  </Flex>
 );
-
-const StyledIcon = styled(ArrowsAltHIcon)`
-  flex-shrink: 0;
-  height: 36px;
-`;
-
-const IntroHeader = styled.div<{ isTarget?: boolean }>`
-  font-size: 21px;
-  line-height: 36px;
-  width: 100%;
-  text-align: center;
-  ${(p) => (p.isTarget ? "padding-right" : "padding-left")}: 12px;
-`;
-
-const VersusContainer = styled.div`
-  display: flex;
-  justify-content: center;
-`;

--- a/src/UI/Components/EventsTable/EventsTableRow.tsx
+++ b/src/UI/Components/EventsTable/EventsTableRow.tsx
@@ -6,7 +6,6 @@ import {
   DescriptionListTerm,
 } from "@patternfly/react-core";
 import { ExpandableRowContent, Tbody, Td, Tr } from "@patternfly/react-table";
-import styled from "styled-components";
 import { EventRow } from "@/Core";
 import { DateWithTooltip } from "@/UI/Components/DateWithTooltip";
 import { EventIcon } from "@/UI/Components/EventIcon";
@@ -28,8 +27,13 @@ export const EventsTableRow: React.FC<Props> = ({
   onToggle,
   numberOfColumns,
 }) => (
-  <StyledBody isExpanded={false} $transition={row}>
-    <Tr id={`event-row-${row.id}`} aria-label="Event table row">
+  <Tbody isExpanded={false}>
+    <Tr
+      id={`event-row-${row.id}`}
+      aria-label="Event table row"
+      className={row.isErrorTransition ? "warning" : ""}
+      isStriped={row.ignoredTransition}
+    >
       <Td
         expand={{
           rowIndex: index,
@@ -47,7 +51,12 @@ export const EventsTableRow: React.FC<Props> = ({
       <Td>{row.source}</Td>
       <Td>{row.destination}</Td>
     </Tr>
-    <Tr isExpanded={isExpanded} data-testid={`details_${row.id}`}>
+    <Tr
+      isExpanded={isExpanded}
+      data-testid={`details_${row.id}`}
+      className={row.isErrorTransition ? "warning" : ""}
+      isStriped={row.ignoredTransition}
+    >
       <Td colSpan={numberOfColumns}>
         <ExpandableRowContent>
           <DescriptionList>
@@ -81,16 +90,5 @@ export const EventsTableRow: React.FC<Props> = ({
         </ExpandableRowContent>
       </Td>
     </Tr>
-  </StyledBody>
+  </Tbody>
 );
-
-type Transition = Pick<EventRow, "ignoredTransition" | "isErrorTransition">;
-
-const StyledBody = styled(Tbody)<{ $transition: Transition }>`
-  ${({ $transition }) =>
-    $transition.isErrorTransition
-      ? "var(--pf-t--global--background--color--highlight--default)"
-      : $transition.ignoredTransition
-        ? "var(--pf-t--global--background--color--disabled--default)"
-        : ""};
-`;

--- a/src/UI/Components/InstanceState/InstanceStateLabel.tsx
+++ b/src/UI/Components/InstanceState/InstanceStateLabel.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Label } from "@patternfly/react-core";
+import { Content, Label } from "@patternfly/react-core";
 import { State } from "@/Core";
 
 export const InstanceStateLabel: React.FC<State> = ({ name, label }) => {
@@ -11,5 +11,5 @@ export const InstanceStateLabel: React.FC<State> = ({ name, label }) => {
     );
   }
 
-  return <Label>{name}</Label>;
+  return <Content>{name}</Content>;
 };

--- a/src/UI/Styles/Global.ts
+++ b/src/UI/Styles/Global.ts
@@ -15,9 +15,48 @@ export const GlobalStyles = createGlobalStyle`
    * PF-6 has by default the inherit value for the vertical-align property on the tr element and tbody element. 
    * Which results in the content of the tr element to be aligned to the top of the row as it inherits the userAgent stylesheet value "top".
    **/
-  tr {
+  tbody tr {
     vertical-align: middle;
   }
+
+  /**
+   * Add the .danger class to the table row to apply the danger color to the row.
+   **/
+  .pf-v6-c-table tr:where(.danger) {
+    background-color: var(--pf-t--global--color--nonstatus--red--default);
+    &.pf-m-clickable {
+      background-color: var(--pf-t--global--color--nonstatus--red--default);
+    }
+    &.pf-m-selected {
+      background-color: var(--pf-t--global--color--nonstatus--red--clicked);
+    }
+    &:hover {
+      background-color: var(--pf-t--global--color--nonstatus--red--hover);
+    }
+  }
+
+  /**
+   * Add the .warning class to the table row to apply the danger color to the row.
+   **/
+  .pf-v6-c-table tr:where(.warning) {
+    background-color: var(--pf-t--global--color--nonstatus--yellow--default);
+    &.pf-m-clickable {
+      background-color: var(--pf-t--global--color--nonstatus--yellow--default);
+    }
+    &.pf-m-selected {
+      background-color: var(--pf-t--global--color--nonstatus--yellow--clicked);
+    }
+    &:not(.pf-m-expanded):hover {
+      background-color: var(--pf-t--global--color--nonstatus--yellow--hover);
+    }
+  }
+
+  /**
+   * Enforce the toggle columns to have the minimal width everywhere.
+   **/
+  .pf-v6-c-table .pf-v6-c-table__toggle {
+    --pf-v6-c-table--cell--Width: 0%;
+  } 
 
   .pf-v6-c-select {
     min-width: 180px;

--- a/src/UI/words.tsx
+++ b/src/UI/words.tsx
@@ -700,6 +700,7 @@ const dict = {
     "Generate authentication tokens for authorizing agents, api or compiler for this specific environment.",
   "settings.tabs.token.generate": "Generate",
   "settings.update": "Setting Changed",
+  "settings.warning.update": "Changed value has not been saved",
 
   /**
    * Status


### PR DESCRIPTION
# Description

This should close the PF-6 migration. I believe I got nearly all the visual issues removed, whatever is left, will be reported.
I introduced two new css-classes that can be added to table rows to highlight danger/warnings. 
