### PR TITLE
Align the inputs in the forms

### DIFF
--- a/changelogs/unreleased/5921-input-description.yml
+++ b/changelogs/unreleased/5921-input-description.yml
@@ -1,0 +1,6 @@
+description: Align all the input descriptions in the service instance forms
+issue-nr: 5921
+change-type: minor
+destination-branches: [master, iso7]
+sections:
+  minor-improvement: "{{description}}"

--- a/src/UI/Components/ServiceInstanceForm/Components/AutoCompleteInput.tsx
+++ b/src/UI/Components/ServiceInstanceForm/Components/AutoCompleteInput.tsx
@@ -77,6 +77,11 @@ export const AutoCompleteInput: React.FC<Props> = ({
       label={attributeName}
       aria-label={`${attributeName}-select-input`}
     >
+      <FormHelperText>
+        <HelperText>
+          <HelperTextItem>{description}</HelperTextItem>
+        </HelperText>
+      </FormHelperText>
       {multi ? (
         <MultiTextSelect
           options={initialOptions}
@@ -103,11 +108,6 @@ export const AutoCompleteInput: React.FC<Props> = ({
           onSearchTextChanged={onSearchTextChanged}
         />
       )}
-      <FormHelperText>
-        <HelperText>
-          <HelperTextItem>{description}</HelperTextItem>
-        </HelperText>
-      </FormHelperText>
     </FormGroup>
   );
 };

--- a/src/UI/Components/ServiceInstanceForm/Components/TextFormInput.tsx
+++ b/src/UI/Components/ServiceInstanceForm/Components/TextFormInput.tsx
@@ -101,6 +101,11 @@ export const TextFormInput: React.FC<Props> = ({
         )
       }
     >
+      <FormHelperText>
+        <HelperText>
+          <HelperTextItem>{description}</HelperTextItem>
+        </HelperText>
+      </FormHelperText>
       {isTextarea ? (
         <TextArea
           value={inputValue || ""}
@@ -145,11 +150,6 @@ export const TextFormInput: React.FC<Props> = ({
           )}
         </>
       )}
-      <FormHelperText>
-        <HelperText>
-          <HelperTextItem>{description}</HelperTextItem>
-        </HelperText>
-      </FormHelperText>
     </FormGroup>
   );
 };


### PR DESCRIPTION
# Description

Align the inputs in the forms, I opted to move description above the input because other way around would look weird for booleans

![Screenshot 2025-01-06 at 14 49 21](https://github.com/user-attachments/assets/5514d86c-df03-4806-828a-f937e680dc1c)

closes #5921 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Code is clear and sufficiently documented
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
