### PR TITLE
6125 primary button inventory

### DIFF
--- a/changelogs/unreleased/6125-primary-button-inventory.yml
+++ b/changelogs/unreleased/6125-primary-button-inventory.yml
@@ -1,0 +1,6 @@
+description: Move the option to go to the instance details into the row as primary action button.
+issue-nr: 6125
+change-type: patch
+destination-branches: [master]
+sections:
+  minor-improvement: "{{description}}"

--- a/cypress/e2e/scenario-2.1-basic-service.cy.js
+++ b/cypress/e2e/scenario-2.1-basic-service.cy.js
@@ -69,7 +69,7 @@ if (Cypress.env("edition") === "iso") {
       forceUpdateEnvironment();
     });
 
-    it.only("2.1.1 Add Instance Cancel form", () => {
+    it("2.1.1 Add Instance Cancel form", () => {
       // Go from Home page to Service Inventory of Basic-service
       cy.visit("/console/");
 
@@ -109,7 +109,7 @@ if (Cypress.env("edition") === "iso") {
       cy.get('[aria-label="ServiceInventory-Empty"]').should("to.be.visible");
     });
 
-    it.only("2.1.2 Add Instance Submit form, INVALID form, EDIT form, VALID form", () => {
+    it("2.1.2 Add Instance Submit form, INVALID form, EDIT form, VALID form", () => {
       // Go from Home page to Service Inventory of Basic-service
       cy.visit("/console/");
       cy.get(`[aria-label="Select-environment-test"]`).click();
@@ -172,9 +172,9 @@ if (Cypress.env("edition") === "iso") {
       cy.get("#basic-service").contains("Show inventory").click();
 
       // Check Instance Details page
-      cy.get('[aria-label="row actions toggle"]', { timeout: 60000 }).click();
+      // cy.get('[aria-label="row actions toggle"]', { timeout: 60000 }).click();
       // The first button should be the one redirecting to the details page.
-      cy.get('[role="menuitem"]').contains("Instance Details").click();
+      cy.get('[aria-label="instance-details-link"]').first().click();
 
       // Check if there are three versions in the history table
       cy.get('[aria-label="History-Row"]', { timeout: 60000 }).should(
@@ -242,22 +242,21 @@ if (Cypress.env("edition") === "iso") {
       cy.get("#address_r1").type("1.2.3.8/32");
       cy.get("button").contains("Confirm").click();
 
-      // expect to land on Service Inventory page and to find attributes tab button
-      cy.get("#expand-toggle0").click();
-      cy.get(".pf-v6-c-tabs__list")
-        .contains("Attributes", { timeout: 20000 })
+      // check attributes on instance details page
+      cy.get('[aria-label="instance-details-link"]', { timeout: 20000 })
+        .first()
         .click();
+      cy.get(".pf-v6-c-tabs__list").contains("Attributes").click();
 
-      // Expect to find new value as candidate and old value in active and no rollback value
-      cy.get('[aria-label="Row-address_r1"')
-        .find('[data-label="candidate"]', { timeout: 20000 })
-        .should("contain", "1.2.3.8/32");
-      cy.get('[aria-label="Row-address_r1"')
-        .find('[data-label="active"]')
-        .should("contain", "1.2.3.5/32");
-      cy.get('[aria-label="Row-address_r1"')
-        .find('[data-label="rollback"]')
-        .should("contain", "");
+      // Expect to find new value as candidate and old value in active
+      cy.get('[aria-label="address_r1_value"]').should("contain", "1.2.3.5/32");
+
+      // change to candidate attribute set
+      cy.get('[aria-label="Select-AttributeSet"]').select(
+        "candidate_attributes",
+      );
+
+      cy.get('[aria-label="address_r1_value"]').should("contain", "1.2.3.8/32");
     });
 
     it("2.1.4 Duplicate instance with Editor", () => {
@@ -392,11 +391,9 @@ if (Cypress.env("edition") === "iso") {
       cy.get("#basic-service").contains("Show inventory").click();
 
       // Check Instance Details page
-      cy.get('[aria-label="row actions toggle"]', { timeout: 60000 })
+      cy.get('[aria-label="instance-details-link"]', { timeout: 20000 })
         .last()
         .click();
-      // The first button should be the one redirecting to the details page.
-      cy.get('[role="menuitem"]').contains("Instance Details").click();
 
       // click on the attributes tab
       cy.get('[aria-label="attributes-content"]').click();
@@ -415,7 +412,7 @@ if (Cypress.env("edition") === "iso") {
         .should("contain", "address_r1");
 
       // this row should contain the active_attribute value 1.2.3.5/32
-      cy.get('[data-testid="address_r1"]').should("contain", "1.2.3.5/32");
+      cy.get('[aria-label="address_r1_value"]').should("contain", "1.2.3.5/32");
 
       // assert you can reset the sorting
       cy.get('[aria-label="table-options"]').click();
@@ -430,7 +427,7 @@ if (Cypress.env("edition") === "iso") {
       );
 
       // assert that the address_r1 attribute value is now the candidate value 1.2.3.8/32
-      cy.get('[data-testid="address_r1"]').should("contain", "1.2.3.8/32");
+      cy.get('[aria-label="address_r1_value"]').should("contain", "1.2.3.8/32");
 
       // click on the JSON-editor tab
       cy.get("#JSON").click();
@@ -498,11 +495,9 @@ if (Cypress.env("edition") === "iso") {
       cy.get("#basic-service").contains("Show inventory").click();
 
       // go back to the details page
-      cy.get('[aria-label="row actions toggle"]', { timeout: 60000 })
+      cy.get('[aria-label="instance-details-link"]', { timeout: 20000 })
         .last()
         .click();
-
-      cy.get('[role="menuitem"]').contains("Instance Details").click();
 
       // change version and go to events page. The second version should contain a validation report.
       cy.get('[aria-label="History-Row"]').eq(7).click();
@@ -561,11 +556,9 @@ if (Cypress.env("edition") === "iso") {
       cy.get("#basic-service").contains("Show inventory").click();
 
       // Check Instance Details page
-      cy.get('[aria-label="row actions toggle"]', { timeout: 60000 })
+      cy.get('[aria-label="instance-details-link"]', { timeout: 20000 })
         .first()
         .click();
-      // The first button should be the one redirecting to the details page.
-      cy.get('[role="menuitem"]').contains("Instance Details").click();
 
       // Check the state of the instance is up in the history section.
       cy.get('[aria-label="History-Row"]', { timeout: 60000 }).should(
@@ -582,7 +575,6 @@ if (Cypress.env("edition") === "iso") {
       cy.get('[aria-label="row actions toggle"]', { timeout: 60000 })
         .last()
         .click();
-      cy.get('[role="menuitem"]').contains("More actions").click();
       cy.get('[role="menuitem"]').contains("Delete").click();
       cy.get(".pf-v6-c-modal-box__header").should("contain", "Delete instance");
       cy.get(".pf-v6-c-form__actions").contains("No").click();
@@ -591,7 +583,6 @@ if (Cypress.env("edition") === "iso") {
       cy.get('[aria-label="row actions toggle"]', { timeout: 60000 })
         .last()
         .click();
-      cy.get('[role="menuitem"]').contains("More actions").click();
       cy.get('[role="menuitem"]').contains("Delete").click();
       cy.get(".pf-v6-c-modal-box__header").should("contain", "Delete instance");
       cy.get(".pf-v6-c-form__actions").contains("Yes").click();

--- a/cypress/e2e/scenario-2.3-embedded-entity.cy.js
+++ b/cypress/e2e/scenario-2.3-embedded-entity.cy.js
@@ -127,9 +127,9 @@ if (Cypress.env("edition") === "iso") {
       cy.get('[aria-label="ServiceInventory-Success"]').should("to.be.visible");
 
       // Check Instance Details page
-      cy.get('[aria-label="row actions toggle"]', { timeout: 60000 }).click();
-      // The first button should be the one redirecting to the details page.
-      cy.get('[role="menuitem"]').contains("Instance Details").click();
+      cy.get('[aria-label="instance-details-link"]', { timeout: 20000 })
+        .first()
+        .click();
 
       // Check if there are three versions in the history table
       cy.get('[aria-label="History-Row"]', { timeout: 60000 }).should(
@@ -161,7 +161,7 @@ if (Cypress.env("edition") === "iso") {
       cy.visit("/console/");
     });
 
-    it("2.3.3 - Show history view", () => {
+    it("2.3.3 - Deploy progress bar should navigate to Resources of instance details", () => {
       cy.visit("/console/");
       cy.get(`[aria-label="Select-environment-test"]`).click();
       cy.get('[aria-label="Sidebar-Navigation-Item"]')
@@ -174,10 +174,15 @@ if (Cypress.env("edition") === "iso") {
         .should("have.length", 1);
       cy.get("#embedded-entity-service").contains("Show inventory").click();
 
-      //await for instance state to change to up
-      cy.get('[data-label="State"]')
-        .find(".pf-v6-c-label", { timeout: 60000 })
-        .should("contain", "up");
+      cy.get('[aria-label="deploy-progress"]', { timeout: 20000 })
+        .first()
+        .click();
+
+      cy.get('[aria-label="resources-content"]').should(
+        "have.attr",
+        "aria-selected",
+        "true",
+      );
 
       cy.visit("/console/");
     });

--- a/cypress/e2e/scenario-2.4-expert-mode.cy.js
+++ b/cypress/e2e/scenario-2.4-expert-mode.cy.js
@@ -179,8 +179,9 @@ if (Cypress.env("edition") === "iso") {
       cy.get("#basic-service").contains("Show inventory").click();
 
       // Go to the instance details
-      cy.get('[aria-label="row actions toggle"]').click();
-      cy.get('[role="menuitem"]').contains("Instance Details").click();
+      cy.get('[aria-label="instance-details-link"]', { timeout: 20000 })
+        .last()
+        .click();
 
       // Go to the attributes tab and select the JSON view
       cy.get('[aria-label="attributes-content"]').click();

--- a/src/Slices/ServiceInstanceDetails/UI/Components/AttributesComponents/AttributesTable.tsx
+++ b/src/Slices/ServiceInstanceDetails/UI/Components/AttributesComponents/AttributesTable.tsx
@@ -295,8 +295,9 @@ export const AttributesTable: React.FC<Props> = ({
           width={60}
           data-testid={node.name}
           aria-label={node.id + "_value"}
+          modifier="truncate"
         >
-          <TableText wrapModifier="truncate">{printValue(node)}</TableText>
+          {printValue(node)}
         </Td>
       </TreeRowWrapper>,
       ...childRows,
@@ -396,7 +397,7 @@ export const AttributesTable: React.FC<Props> = ({
             >
               {words("instanceDetails.table.attributeKey")}
             </Th>
-            <Th>{words("instanceDetails.table.valueKey")}</Th>
+            <Th width={60}>{words("instanceDetails.table.valueKey")}</Th>
           </Tr>
         </Thead>
         <Tbody>{renderRows(tableData)}</Tbody>

--- a/src/Slices/ServiceInventory/UI/Components/RowActionsMenu/RowActions.tsx
+++ b/src/Slices/ServiceInventory/UI/Components/RowActionsMenu/RowActions.tsx
@@ -12,7 +12,6 @@ import {
   EllipsisVIcon,
   EyeIcon,
   FileMedicalAltIcon,
-  InfoAltIcon,
   ToolsIcon,
 } from "@patternfly/react-icons";
 import { ParsedNumber } from "@/Core";
@@ -71,18 +70,6 @@ export const RowActions: React.FunctionComponent<InstanceActionsProps> = ({
       popperProps={{ position: "right" }}
     >
       <DropdownList>
-        <DropdownItem itemId="instance-details" icon={<InfoAltIcon />}>
-          <Link
-            variant="plain"
-            pathname={routeManager.getUrl("InstanceDetails", {
-              service: entity,
-              instance: service_identity_attribute_value || instanceId,
-              instanceId: instanceId,
-            })}
-          >
-            {words("instanceDetails.button")}
-          </Link>
-        </DropdownItem>
         <DropdownItem
           itemId="diagnose"
           isDisabled={diagnoseDisabled}

--- a/src/Slices/ServiceInventory/UI/InstanceRow.tsx
+++ b/src/Slices/ServiceInventory/UI/InstanceRow.tsx
@@ -1,8 +1,11 @@
-import React from "react";
+import React, { useContext } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { Button, Flex, FlexItem } from "@patternfly/react-core";
 import { Tbody, Tr, Td } from "@patternfly/react-table";
 import styled from "styled-components";
 import { Row, ServiceModel } from "@/Core";
 import { StateLabel } from "@/Slices/ServiceInstanceDetails/UI/Components/Sections";
+import { DependencyContext } from "@/UI";
 import { DateWithTooltip } from "@/UI/Components";
 import { CopyMultiOptions } from "@/UI/Components/CopyMultiOptions";
 import { words } from "@/UI/words";
@@ -22,9 +25,14 @@ export const InstanceRow: React.FC<Props> = ({
   idDataLabel,
   service,
 }) => {
-  const openTabAndScrollTo = () => () => {
-    // Replace with opening the instance details and opening the resource tab
-  };
+  const { routeManager } = useContext(DependencyContext);
+
+  const instanceDetailsUrl = routeManager.useUrl("InstanceDetails", {
+    service: service.name,
+    instance: row.serviceIdentityValue || row.id.full,
+    instanceId: row.id.full,
+  });
+  const navigate = useNavigate();
 
   return (
     <Tbody>
@@ -54,7 +62,12 @@ export const InstanceRow: React.FC<Props> = ({
         <Td dataLabel={words("inventory.collumn.deploymentProgress")}>
           <ActionWrapper
             id={`instance-row-resources-${row.id.short}`}
-            onClick={openTabAndScrollTo()}
+            aria-label="deploy-progress"
+            onClick={() =>
+              navigate(
+                `${instanceDetailsUrl}&state.InstanceDetails.tab=Resources`,
+              )
+            }
           >
             <DeploymentProgressBar progress={row.deploymentProgress} />
           </ActionWrapper>
@@ -66,15 +79,36 @@ export const InstanceRow: React.FC<Props> = ({
           <DateWithTooltip timestamp={row.updatedAt} />
         </Td>
         <Td dataLabel="actions" isActionCell>
-          <RowActions
-            instanceId={row.id.full}
-            service_identity_attribute_value={row.serviceIdentityValue}
-            entity={service.name}
-            editDisabled={row.editDisabled}
-            deleteDisabled={row.deleteDisabled}
-            diagnoseDisabled={row.deleted}
-            version={row.version}
-          />
+          <Flex flexWrap={{ default: "nowrap" }}>
+            <FlexItem>
+              <Link
+                aria-label="instance-details-link"
+                to={{
+                  pathname: routeManager.getUrl("InstanceDetails", {
+                    service: service.name,
+                    instance: row.serviceIdentityValue || row.id.full,
+                    instanceId: row.id.full,
+                  }),
+                  search: location.search,
+                }}
+              >
+                <Button variant="link">
+                  {words("instanceDetails.button")}
+                </Button>
+              </Link>
+            </FlexItem>
+            <FlexItem>
+              <RowActions
+                instanceId={row.id.full}
+                service_identity_attribute_value={row.serviceIdentityValue}
+                entity={service.name}
+                editDisabled={row.editDisabled}
+                deleteDisabled={row.deleteDisabled}
+                diagnoseDisabled={row.deleted}
+                version={row.version}
+              />
+            </FlexItem>
+          </Flex>
         </Td>
       </Tr>
     </Tbody>

--- a/src/Slices/ServiceInventory/UI/InventoryTable.test.tsx
+++ b/src/Slices/ServiceInventory/UI/InventoryTable.test.tsx
@@ -212,7 +212,7 @@ test("ServiceInventory sets sorting parameters correctly on click", async () => 
 });
 
 describe("Actions", () => {
-  it("Should have 7 options in total", async () => {
+  it("Should have 6 options in total", async () => {
     const component = setup();
 
     render(component);
@@ -225,6 +225,6 @@ describe("Actions", () => {
 
     const options = await screen.findAllByRole("menuitem");
 
-    expect(options).toHaveLength(7);
+    expect(options).toHaveLength(6);
   });
 });

--- a/src/UI/words.tsx
+++ b/src/UI/words.tsx
@@ -258,7 +258,7 @@ const dict = {
    */
   "instanceDetails.title.tag": (version) => `Version: ${version}`,
   "instanceDetails.title.latest": "Latest Version",
-  "instanceDetails.button": "Instance Details",
+  "instanceDetails.button": "Show instance",
   "instanceDetails.page.errorFallback":
     "Something went wrong retrieving the instance details",
   "instanceDetails.page.errorFallback.title": "Error",


### PR DESCRIPTION
# Description

closes #6125 

Moved the link to navigate to the instance details into the row, and re-implemented the navigation to the resources of the instance when clicking on the deploy progress bar.

<img width="1021" alt="image" src="https://github.com/user-attachments/assets/fa77feb5-48a4-4c5e-abfa-ed0c4cc4adaf" />
