### PR TITLE
Fix un-responsive space in service inventory dropdown

### DIFF
--- a/changelogs/unreleased/6134-dropdown-fix.yml
+++ b/changelogs/unreleased/6134-dropdown-fix.yml
@@ -1,0 +1,4 @@
+description: Fix un-responsive space in service inventory dropdown
+issue-nr: 6125
+change-type: patch
+destination-branches: [master]

--- a/src/Slices/ServiceInventory/UI/Components/RowActionsMenu/RowActions.tsx
+++ b/src/Slices/ServiceInventory/UI/Components/RowActionsMenu/RowActions.tsx
@@ -70,81 +70,82 @@ export const RowActions: React.FunctionComponent<InstanceActionsProps> = ({
       popperProps={{ position: "right" }}
     >
       <DropdownList>
-        <DropdownItem
-          itemId="diagnose"
+        <Link
+          variant="plain"
+          pathname={routeManager.getUrl("Diagnose", {
+            service: entity,
+            instance: instanceId,
+          })}
           isDisabled={diagnoseDisabled}
-          icon={<FileMedicalAltIcon />}
         >
+          <DropdownItem
+            itemId="diagnose"
+            isDisabled={diagnoseDisabled}
+            icon={<FileMedicalAltIcon />}
+          >
+            {words("inventory.statustab.diagnose")}
+          </DropdownItem>
+        </Link>
+        {composerEnabled && (
           <Link
             variant="plain"
-            pathname={routeManager.getUrl("Diagnose", {
+            pathname={routeManager.getUrl("InstanceComposerEditor", {
               service: entity,
               instance: instanceId,
             })}
-            isDisabled={diagnoseDisabled}
+            isDisabled={editDisabled}
           >
-            {words("inventory.statustab.diagnose")}
+            <DropdownItem
+              itemId="edit-composer"
+              isDisabled={editDisabled}
+              icon={<ToolsIcon />}
+            >
+              {words("instanceComposer.editButton")}
+            </DropdownItem>
           </Link>
-        </DropdownItem>
-        {composerEnabled && (
+        )}
+        {featureManager.isComposerEnabled() && (
+          <Link
+            variant="plain"
+            pathname={routeManager.getUrl("InstanceComposerViewer", {
+              service: entity,
+              instance: instanceId,
+            })}
+          >
+            <DropdownItem itemId="show-composer" icon={<EyeIcon />}>
+              {words("instanceComposer.showButton")}
+            </DropdownItem>
+          </Link>
+        )}
+        <Link
+          variant="plain"
+          pathname={routeManager.getUrl("EditInstance", {
+            service: entity,
+            instance: instanceId,
+          })}
+          isDisabled={editDisabled}
+        >
           <DropdownItem
-            itemId="edit-composer"
+            itemId="edit"
             isDisabled={editDisabled}
             icon={<ToolsIcon />}
           >
-            <Link
-              variant="plain"
-              pathname={routeManager.getUrl("InstanceComposerEditor", {
-                service: entity,
-                instance: instanceId,
-              })}
-              isDisabled={editDisabled}
-            >
-              {words("instanceComposer.editButton")}
-            </Link>
-          </DropdownItem>
-        )}
-        {featureManager.isComposerEnabled() && (
-          <DropdownItem itemId="show-composer" icon={<EyeIcon />}>
-            <Link
-              variant="plain"
-              pathname={routeManager.getUrl("InstanceComposerViewer", {
-                service: entity,
-                instance: instanceId,
-              })}
-            >
-              {words("instanceComposer.showButton")}
-            </Link>
-          </DropdownItem>
-        )}
-        <DropdownItem
-          itemId="edit"
-          isDisabled={editDisabled}
-          icon={<ToolsIcon />}
-        >
-          <Link
-            variant="plain"
-            pathname={routeManager.getUrl("EditInstance", {
-              service: entity,
-              instance: instanceId,
-            })}
-            isDisabled={editDisabled}
-          >
             {words("inventory.editInstance.button")}
-          </Link>
-        </DropdownItem>
+          </DropdownItem>
+        </Link>
 
-        <DropdownItem itemId="duplicate" icon={<CopyIcon />}>
-          <Link
-            variant="plain"
-            pathname={routeManager.getUrl("DuplicateInstance", {
-              service: entity,
-              instance: instanceId,
-            })}
-          >
+        <Link
+          variant="plain"
+          pathname={routeManager.getUrl("DuplicateInstance", {
+            service: entity,
+            instance: instanceId,
+          })}
+        >
+          <DropdownItem itemId="duplicate" icon={<CopyIcon />}>
             {words("inventory.duplicateInstance.button")}
-          </Link>
-        </DropdownItem>
+          </DropdownItem>
+        </Link>
+
         <Divider component="li" />
         <DeleteAction
           isDisabled={deleteDisabled}


### PR DESCRIPTION
# Description

Fix un-responsive space in service inventory dropdown.
No description in changelog as it's probably introduced in between releases so there is no need for the end user to see that in changelog

closes #6134 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Code is clear and sufficiently documented
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
