### PR TITLE
Fix embedded entities toggling issue in the instance composer

### DIFF
--- a/changelogs/unreleased/6138-embbedded-bug-composer.yml
+++ b/changelogs/unreleased/6138-embbedded-bug-composer.yml
@@ -1,0 +1,6 @@
+description: Fix issue when toggling embedded entities of the same type in the instance composer
+issue-nr: 6138
+change-type: patch
+destination-branches: [master]
+sections:
+  bugfix: "{{description}}"

--- a/src/UI/Components/Diagram/components/EntityForm.test.tsx
+++ b/src/UI/Components/Diagram/components/EntityForm.test.tsx
@@ -10,14 +10,14 @@ import { getStoreInstance } from "@/Data";
 import { dependencies } from "@/Test";
 import { DependencyProvider, EnvironmentHandlerImpl } from "@/UI/Dependency";
 import { PrimaryRouteManager } from "@/UI/Routing";
-import { EntityForm } from "./EntityForm";
 import { CanvasContext, defaultCanvasContext } from "../Context";
-import { ComposerPaper } from "../paper";
-import { ServiceEntityBlock } from "../shapes";
-import { getCellsCoordinates } from "../helpers";
 import { parentModel } from "../Mocks";
 import { createComposerEntity } from "../actions";
+import { getCellsCoordinates } from "../helpers";
+import { ComposerPaper } from "../paper";
+import { ServiceEntityBlock } from "../shapes";
 import { defineObjectsForJointJS } from "../testSetup";
+import { EntityForm } from "./EntityForm";
 
 describe("EntityForm.", () => {
   const setup = (

--- a/src/UI/Components/Diagram/components/EntityForm.tsx
+++ b/src/UI/Components/Diagram/components/EntityForm.tsx
@@ -50,8 +50,7 @@ export const EntityForm: React.FC<Props> = ({
   showButtons,
   onRemove,
 }) => {
-  const { diagramHandlers, setServiceOrderItems, setCellToEdit } =
-    useContext(CanvasContext);
+  const { diagramHandlers, setServiceOrderItems } = useContext(CanvasContext);
   const [serviceModel, setServiceModel] = useState<ServiceModel | null>(null);
   const [fields, setFields] = useState<Field[] | null>(null);
   const [originalState, setOriginalState] = useState<InstanceAttributeModel>(

--- a/src/UI/Components/Diagram/components/EntityForm.tsx
+++ b/src/UI/Components/Diagram/components/EntityForm.tsx
@@ -159,10 +159,13 @@ export const EntityForm: React.FC<Props> = ({
         );
 
         shape.set("sanitizedAttrs", sanitizedAttrs);
-
-        setServiceOrderItems((prev) =>
-          updateServiceOrderItems(shape, ActionEnum.UPDATE, prev),
-        );
+        setServiceOrderItems((prev) => {
+          if (prev.has(String(shape.id))) {
+            return updateServiceOrderItems(shape, ActionEnum.UPDATE, prev);
+          } else {
+            return prev;
+          }
+        });
       }
     },
     [cellToEdit, diagramHandlers, fields, serviceModel, setServiceOrderItems],

--- a/src/UI/Components/Diagram/components/EntityForm.tsx
+++ b/src/UI/Components/Diagram/components/EntityForm.tsx
@@ -1,20 +1,23 @@
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useContext, useEffect, useState } from "react";
+import { dia } from "@inmanta/rappid";
 import { Alert, Button, Flex, FlexItem, Form } from "@patternfly/react-core";
 import { set } from "lodash";
 import { v4 as uuidv4 } from "uuid";
 import { Field, InstanceAttributeModel, ServiceModel } from "@/Core";
+import { sanitizeAttributes } from "@/Data";
 import {
   CreateModifierHandler,
   FieldCreator,
 } from "@/UI/Components/ServiceInstanceForm";
 import { FieldInput } from "@/UI/Components/ServiceInstanceForm/Components";
 import { words } from "@/UI/words";
+import { CanvasContext } from "../Context";
+import { updateServiceOrderItems } from "../helpers";
+import { ActionEnum } from "../interfaces";
 
 interface Props {
-  serviceModel: ServiceModel;
-  isEdited: boolean;
-  initialState: InstanceAttributeModel;
-  onSave: (fields: Field[], formState: InstanceAttributeModel) => void;
+  cellToEdit: dia.CellView;
+
   isDisabled: boolean;
   isRemovable: boolean;
   showButtons: boolean;
@@ -41,18 +44,20 @@ interface Props {
  * @returns {React.FC<Props>} The EntityForm component.
  */
 export const EntityForm: React.FC<Props> = ({
-  serviceModel,
-  isEdited,
-  initialState,
-  onSave,
+  cellToEdit,
   isDisabled,
   isRemovable,
   showButtons,
   onRemove,
 }) => {
+  const { diagramHandlers, setServiceOrderItems, setCellToEdit } =
+    useContext(CanvasContext);
+  const [serviceModel, setServiceModel] = useState<ServiceModel | null>(null);
   const [fields, setFields] = useState<Field[] | null>(null);
-  const [formState, setFormState] =
-    useState<InstanceAttributeModel>(initialState);
+  const [originalState, setOriginalState] = useState<InstanceAttributeModel>(
+    {},
+  );
+  const [formState, setFormState] = useState<InstanceAttributeModel>({});
   const [isDirty, setIsDirty] = useState(false);
 
   /**
@@ -64,9 +69,10 @@ export const EntityForm: React.FC<Props> = ({
    * @returns {void}
    */
   const getUpdate = (path: string, value: unknown, multi = false): void => {
-    if (!fields) {
+    if (!fields || !serviceModel) {
       return;
     }
+
     if (!isDirty) {
       setIsDirty(true);
     }
@@ -86,9 +92,7 @@ export const EntityForm: React.FC<Props> = ({
           selection.push(value as string);
         }
         updatedValue = set(clone, path, selection);
-        onSave(fields, updatedValue); // onSave has to be called within setState to avoid async behavior of setState
 
-        //update the form state with the new selection property with help of _lodash set function
         return updatedValue;
       });
     } else {
@@ -96,9 +100,7 @@ export const EntityForm: React.FC<Props> = ({
         const clone = { ...prev };
 
         updatedValue = set(clone, path, value);
-        onSave(fields, updatedValue); // onSave has to be called within setState to avoid async behavior of setState
 
-        //update the form state with the new value with help of _lodash set function
         return updatedValue;
       });
     }
@@ -113,13 +115,8 @@ export const EntityForm: React.FC<Props> = ({
    * @returns {void}
    */
   const onCancel = (): void => {
-    if (!fields) {
-      return;
-    }
-    onSave(fields, initialState);
+    onSave(originalState);
     createFieldsAndState();
-    setFormState(initialState);
-    setIsDirty(false);
   };
 
   /**
@@ -131,6 +128,11 @@ export const EntityForm: React.FC<Props> = ({
    * @returns {void}
    */
   const createFieldsAndState = useCallback(() => {
+    const { model } = cellToEdit;
+    const serviceModel = model.get("serviceModel") as ServiceModel;
+    const isEdited = model.get("isEdited") as boolean;
+    const instanceAttributes = model.get("instanceAttributes");
+
     const fieldCreator = new FieldCreator(
       new CreateModifierHandler(),
       isEdited,
@@ -140,13 +142,40 @@ export const EntityForm: React.FC<Props> = ({
     );
 
     setFields(selectedFields.map((field) => ({ ...field, id: uuidv4() })));
-    setFormState(initialState);
+    setServiceModel(serviceModel);
+    setFormState(instanceAttributes);
+    setOriginalState(instanceAttributes);
     setIsDirty(false);
-  }, [serviceModel, isEdited, initialState]);
+  }, [cellToEdit]);
+
+  const onSave = useCallback(
+    (formState) => {
+      if (diagramHandlers && fields && serviceModel) {
+        const sanitizedAttrs = sanitizeAttributes(fields, formState);
+
+        const shape = diagramHandlers.editEntity(
+          cellToEdit,
+          serviceModel,
+          formState,
+        );
+
+        shape.set("sanitizedAttrs", sanitizedAttrs);
+
+        setServiceOrderItems((prev) =>
+          updateServiceOrderItems(shape, ActionEnum.UPDATE, prev),
+        );
+      }
+    },
+    [cellToEdit, diagramHandlers, fields, serviceModel, setServiceOrderItems],
+  );
 
   useEffect(() => {
     createFieldsAndState();
   }, [createFieldsAndState]);
+
+  useEffect(() => {
+    onSave(formState);
+  }, [onSave, formState]);
 
   return (
     <>
@@ -169,7 +198,7 @@ export const EntityForm: React.FC<Props> = ({
           {fields &&
             fields.map((field) => (
               <FieldInput
-                originalState={initialState}
+                originalState={originalState}
                 key={field.name}
                 field={{
                   ...field,


### PR DESCRIPTION
# Description

Fix issue when toggling between embedded entities of the same type  in the instance composer, inputs weren't cleared. This issue only happend when the entities had same attributes values on initial load

https://github.com/user-attachments/assets/2dd6ba30-c163-41ff-ad16-5fc1505768d5

closes #6138 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Code is clear and sufficiently documented
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
