### PR TITLE
Add Link with Discovery resources uri to the Discovered Resources Page

### DIFF
--- a/changelogs/unreleased/5946-discovery-uri.yml
+++ b/changelogs/unreleased/5946-discovery-uri.yml
@@ -1,0 +1,6 @@
+description: Adds discovery uri to the Discovered Resources Page
+issue-nr: 5946
+change-type: patch
+destination-branches: [master]
+sections:
+  minor-improvement: "{{description}}"

--- a/src/Slices/ResourceDiscovery/Core/Query.ts
+++ b/src/Slices/ResourceDiscovery/Core/Query.ts
@@ -32,6 +32,7 @@ export interface Manifest {
 export interface DiscoveredResource {
   discovered_resource_id: string;
   managed_resource_uri: string | null;
+  discovery_resource_uri: string | null;
   values: unknown;
 }
 

--- a/src/Slices/ResourceDiscovery/Data/Mock.ts
+++ b/src/Slices/ResourceDiscovery/Data/Mock.ts
@@ -4,6 +4,8 @@ export const response = {
       discovered_resource_id: "vcenter::VirtualMachine[lab,name=acisim]",
       managed_resource_uri:
         "/api/v2/resource/cloudflare::dns_record::CnameRecord[https://api.cloudflare.com/client/v4/,name=artifacts.ssh.inmanta.com]",
+      discovery_resource_uri:
+        "/api/v2/resource/cloudflare::dns_record::CnameRecord[https://api.cloudflare.com/client/v4/,name=artifacts.ssh.inmanta.com]",
       values: {
         name: "acisim",
         path: "/bedc/vm/acisim",
@@ -37,6 +39,7 @@ export const response = {
     {
       discovered_resource_id: "vcenter::VirtualMachine[lab,name=acisim-5.2-7f]",
       managed_resource_uri: null,
+      discovery_resource_uri: null,
       values: {
         name: "acisim-5.2-7f",
         path: "/bedc/vm/acisim-5.2-7f",
@@ -70,6 +73,7 @@ export const response = {
     {
       discovered_resource_id: "vcenter::VirtualMachine[lab,name=acisim-5.7]",
       managed_resource_uri: "invalid/uri1/",
+      discovery_resource_uri: "invalid/uri1/",
       values: {
         name: "acisim-5.7",
         path: "/bedc/vm/acisim-5.7",
@@ -104,6 +108,7 @@ export const response = {
       discovered_resource_id:
         "vcenter::VirtualMachine[lab,name=CentOS7Template]",
       managed_resource_uri: "",
+      discovery_resource_uri: "",
       values: {
         name: "CentOS7Template",
         path: "/bedc/vm/CentOS7Template",
@@ -132,6 +137,7 @@ export const response = {
       discovered_resource_id:
         "vcenter::VirtualMachine[lab,name=CentOS7TestNfvApiTemplate]",
       managed_resource_uri: null,
+      discovery_resource_uri: null,
       values: {
         name: "CentOS7TestNfvApiTemplate",
         path: "/bedc/vm/CentOS7TestNfvApiTemplate",
@@ -160,6 +166,7 @@ export const response = {
       discovered_resource_id:
         "vcenter::VirtualMachine[lab,name=ma-test-1705069110.4363039_1]",
       managed_resource_uri: null,
+      discovery_resource_uri: null,
       values: {
         name: "ma-test-1705069110.4363039_1",
         path: "/bedc/vm/test_lab_root_ma/ma-test-1705069110.4363039_1",
@@ -193,6 +200,7 @@ export const response = {
     {
       discovered_resource_id: "vcenter::VirtualMachine[lab,name=rocky-8]",
       managed_resource_uri: null,
+      discovery_resource_uri: null,
       values: {
         name: "rocky-8",
         path: "/bedc/vm/rocky-8",
@@ -221,6 +229,8 @@ export const response = {
       discovered_resource_id:
         "vcenter::VirtualMachine[lab,name=t160_srv_example]",
       managed_resource_uri: null,
+      discovery_resource_uri: null,
+
       values: {
         name: "t160_srv_example",
         path: "/bedc/vm/test_lab_root/t160_srv_example",
@@ -242,6 +252,7 @@ export const response = {
       discovered_resource_id:
         "vcenter::VirtualMachine[lab,name=t160_srv_example_2]",
       managed_resource_uri: null,
+      discovery_resource_uri: null,
       values: {
         name: "t160_srv_example_2",
         path: "/bedc/vm/test_lab_root/t160_srv_example_2",
@@ -262,6 +273,7 @@ export const response = {
     {
       discovered_resource_id: "vcenter::VirtualMachine[lab,name=test]",
       managed_resource_uri: null,
+      discovery_resource_uri: null,
       values: {
         name: "test",
         path: "/bedc/vm/test",
@@ -290,6 +302,7 @@ export const response = {
       discovered_resource_id:
         "vcenter::VirtualMachine[lab,name=ubuntu-18.04.6]",
       managed_resource_uri: null,
+      discovery_resource_uri: null,
       values: {
         name: "ubuntu-18.04.6",
         path: "/bedc/vm/ubuntu-18.04.6",
@@ -323,6 +336,7 @@ export const response = {
     {
       discovered_resource_id: "vcenter::VirtualMachine[lab,name=ubuntu-22.04]",
       managed_resource_uri: null,
+      discovery_resource_uri: null,
       values: {
         name: "ubuntu-22.04",
         path: "/bedc/vm/ubuntu-22.04",
@@ -351,6 +365,7 @@ export const response = {
       discovered_resource_id:
         "vcenter::VirtualMachine[lab,name=vCLS-8d6212c5-a9be-40a9-a99e-f8b563a6f284]",
       managed_resource_uri: null,
+      discovery_resource_uri: null,
       values: {
         name: "vCLS-8d6212c5-a9be-40a9-a99e-f8b563a6f284",
         path: "/bedc/vm/vCLS/vCLS-8d6212c5-a9be-40a9-a99e-f8b563a6f284",
@@ -372,6 +387,7 @@ export const response = {
       discovered_resource_id:
         "vcenter::VirtualMachine[lab,name=vCLS-a11c52cf-ce5c-438b-a4dc-40ef661f16c3]",
       managed_resource_uri: null,
+      discovery_resource_uri: null,
       values: {
         name: "vCLS-a11c52cf-ce5c-438b-a4dc-40ef661f16c3",
         path: "/bedc/vm/vCLS/vCLS-a11c52cf-ce5c-438b-a4dc-40ef661f16c3",
@@ -393,6 +409,7 @@ export const response = {
       discovered_resource_id:
         "vcenter::VirtualMachine[lab,name=VMware_Cloud_Director-10.5.1.10593-22821417_OVF10]",
       managed_resource_uri: null,
+      discovery_resource_uri: null,
       values: {
         name: "VMware_Cloud_Director-10.5.1.10593-22821417_OVF10",
         path: "/bedc/vm/VMware_Cloud_Director-10.5.1.10593-22821417_OVF10",
@@ -427,6 +444,7 @@ export const response = {
       discovered_resource_id:
         "vcenter::VirtualMachine[lab,name=VMware vCenter Server 8]",
       managed_resource_uri: null,
+      discovery_resource_uri: null,
       values: {
         name: "VMware vCenter Server 8",
         path: "/bedc/vm/Discovered virtual machine/VMware vCenter Server 8",
@@ -455,6 +473,7 @@ export const response = {
       discovered_resource_id:
         "vcenter::VirtualMachine[lab,name=WindowsServer2016Template]",
       managed_resource_uri: null,
+      discovery_resource_uri: null,
       values: {
         name: "WindowsServer2016Template",
         path: "/bedc/vm/WindowsServer2016Template",

--- a/src/Slices/ResourceDiscovery/UI/Components/ManagedResourceLink.tsx
+++ b/src/Slices/ResourceDiscovery/UI/Components/ManagedResourceLink.tsx
@@ -4,19 +4,20 @@ import { ResourceLink } from "@/UI/Components";
 
 interface Props {
   resourceUri: string | null;
+  type: "managed" | "discovery";
 }
 
 /**
- * @Component that renders a link to the managed resource
+ * @Component that renders a link to the managed or the discovery resource
  * or a "-" if the resourceUri is null or empty.
  *
- * managed_resource_uri comes in format : /api/v2/resource/<rid>
+ * uris comes in format : /api/v2/resource/<rid>
  *
- * @param resourceUri : API URI of the managed resource
+ * @param resourceUri : API URI of the managed/discovery resource
  *
  * @returns ManagedResourceLink component
  */
-export const ManagedResourceLink: React.FC<Props> = ({ resourceUri }) => {
+export const ManagedResourceLink: React.FC<Props> = ({ resourceUri, type }) => {
   if (!resourceUri) {
     return <></>;
   }
@@ -30,7 +31,7 @@ export const ManagedResourceLink: React.FC<Props> = ({ resourceUri }) => {
   return (
     <ResourceLink
       resourceId={rid}
-      linkText={words("discovered_resources.show_resource")}
+      linkText={words(`discovered_resources.show_resource.${type}`)}
     />
   );
 };

--- a/src/Slices/ResourceDiscovery/UI/DiscoveredResourceTablePresenter.test.ts
+++ b/src/Slices/ResourceDiscovery/UI/DiscoveredResourceTablePresenter.test.ts
@@ -12,6 +12,7 @@ test("Rows should have two items", () => {
 test("TablePresenter converts column index to name correctly", () => {
   expect(presenter.getColumnNameForIndex(0)).toEqual("discovered_resource_id");
   expect(presenter.getColumnNameForIndex(1)).toEqual("managed_resource_id");
+  expect(presenter.getColumnNameForIndex(2)).toEqual("discovery_resource_uri");
   expect(presenter.getColumnNameForIndex(-1)).toBeUndefined();
   expect(presenter.getColumnNameForIndex(10)).toBeUndefined();
 });
@@ -19,6 +20,7 @@ test("TablePresenter converts column index to name correctly", () => {
 test("TablePresenter converts column name to index correctly", () => {
   expect(presenter.getIndexForColumnName("discovered_resource_id")).toEqual(0);
   expect(presenter.getIndexForColumnName("managed_resource_id")).toEqual(1);
+  expect(presenter.getIndexForColumnName("discovery_resource_uri")).toEqual(2);
   expect(presenter.getIndexForColumnName(undefined)).toEqual(-1);
 });
 

--- a/src/Slices/ResourceDiscovery/UI/DiscoveredResourcesRow.tsx
+++ b/src/Slices/ResourceDiscovery/UI/DiscoveredResourcesRow.tsx
@@ -4,6 +4,7 @@ import {
   DescriptionListDescription,
   DescriptionListGroup,
   DescriptionListTerm,
+  Truncate,
 } from "@patternfly/react-core";
 import { Tbody, Tr, Td } from "@patternfly/react-table";
 import styled from "styled-components";
@@ -39,11 +40,12 @@ export const DiscoveredResourceRow: React.FC<Props> = ({
           dataLabel={words("discovered.column.resource_id")}
           data-testid={words("discovered.column.resource_id")}
         >
-          {row.discovered_resource_id}
+          <Truncate content={row.discovered_resource_id} />
         </Td>
         <Td
           dataLabel={words("discovered.column.managed_resource")}
           data-testid={words("discovered.column.managed_resource")}
+          width={15}
         >
           <ManagedResourceLink
             resourceUri={row.managed_resource_uri}
@@ -53,6 +55,7 @@ export const DiscoveredResourceRow: React.FC<Props> = ({
         <Td
           dataLabel={words("discovered.column.discovery_resource")}
           data-testid={words("discovered.column.discovery_resource")}
+          width={20}
         >
           <ManagedResourceLink
             resourceUri={row.discovery_resource_uri}

--- a/src/Slices/ResourceDiscovery/UI/DiscoveredResourcesRow.tsx
+++ b/src/Slices/ResourceDiscovery/UI/DiscoveredResourcesRow.tsx
@@ -13,10 +13,7 @@ import { DiscoveredResource } from "../Core/Query";
 import { ManagedResourceLink } from "./Components";
 
 interface Props {
-  row: Pick<
-    DiscoveredResource,
-    "discovered_resource_id" | "values" | "managed_resource_uri"
-  >;
+  row: DiscoveredResource;
   isExpanded: boolean;
   onToggle: () => void;
   numberOfColumns: number;
@@ -31,7 +28,7 @@ export const DiscoveredResourceRow: React.FC<Props> = ({
   return (
     <Tbody>
       <Tr aria-label="DiscoveredResourceRow">
-        <Td style={{ width: "15px" }}>
+        <Td>
           <Toggle
             expanded={isExpanded}
             onToggle={onToggle}
@@ -40,7 +37,6 @@ export const DiscoveredResourceRow: React.FC<Props> = ({
         </Td>
         <Td
           dataLabel={words("discovered.column.resource_id")}
-          style={{ width: "50vw" }}
           data-testid={words("discovered.column.resource_id")}
         >
           {row.discovered_resource_id}
@@ -49,28 +45,43 @@ export const DiscoveredResourceRow: React.FC<Props> = ({
           dataLabel={words("discovered.column.managed_resource")}
           data-testid={words("discovered.column.managed_resource")}
         >
-          <ManagedResourceLink resourceUri={row.managed_resource_uri} />
+          <ManagedResourceLink
+            resourceUri={row.managed_resource_uri}
+            type="managed"
+          />
+        </Td>
+        <Td
+          dataLabel={words("discovered.column.discovery_resource")}
+          data-testid={words("discovered.column.discovery_resource")}
+          colSpan={numberOfColumns}
+        >
+          <ManagedResourceLink
+            resourceUri={row.discovery_resource_uri}
+            type="discovery"
+          />
         </Td>
       </Tr>
       {isExpanded && (
-        <Tr aria-label="Expanded-Discovered-Row" isExpanded={isExpanded}>
-          <Td colSpan={numberOfColumns}>
-            <PaddedDescriptionList isHorizontal>
-              <DescriptionListGroup>
-                <DescriptionListTerm>
-                  {words("discovered_resources.values")}
-                </DescriptionListTerm>
-                <DescriptionListDescription>
-                  <CodeHighlighter
-                    keyId="Json"
-                    code={JSON.stringify(row.values, null, 2)}
-                    language="json"
-                  />
-                </DescriptionListDescription>
-              </DescriptionListGroup>
-            </PaddedDescriptionList>
-          </Td>
-        </Tr>
+        <>
+          <Tr aria-label="Expanded-Discovered-Row" isExpanded={isExpanded}>
+            <Td colSpan={numberOfColumns}>
+              <PaddedDescriptionList isHorizontal>
+                <DescriptionListGroup>
+                  <DescriptionListTerm>
+                    {words("discovered_resources.values")}
+                  </DescriptionListTerm>
+                  <DescriptionListDescription>
+                    <CodeHighlighter
+                      keyId="Json"
+                      code={JSON.stringify(row.values, null, 2)}
+                      language="json"
+                    />
+                  </DescriptionListDescription>
+                </DescriptionListGroup>
+              </PaddedDescriptionList>
+            </Td>
+          </Tr>
+        </>
       )}
     </Tbody>
   );

--- a/src/Slices/ResourceDiscovery/UI/DiscoveredResourcesRow.tsx
+++ b/src/Slices/ResourceDiscovery/UI/DiscoveredResourcesRow.tsx
@@ -53,7 +53,6 @@ export const DiscoveredResourceRow: React.FC<Props> = ({
         <Td
           dataLabel={words("discovered.column.discovery_resource")}
           data-testid={words("discovered.column.discovery_resource")}
-          colSpan={numberOfColumns}
         >
           <ManagedResourceLink
             resourceUri={row.discovery_resource_uri}

--- a/src/Slices/ResourceDiscovery/UI/DiscoveredResourcesTablePresenter.ts
+++ b/src/Slices/ResourceDiscovery/UI/DiscoveredResourcesTablePresenter.ts
@@ -20,7 +20,7 @@ export class DiscoveredResourcesTablePresenter
       },
       {
         displayName: words("discovered.column.discovery_resource"),
-        apiName: "discovery_resource_id",
+        apiName: "discovery_resource_uri",
       },
     ];
     this.numberOfColumns = this.columnHeads.length + 1;

--- a/src/Slices/ResourceDiscovery/UI/DiscoveredResourcesTablePresenter.ts
+++ b/src/Slices/ResourceDiscovery/UI/DiscoveredResourcesTablePresenter.ts
@@ -18,6 +18,10 @@ export class DiscoveredResourcesTablePresenter
         displayName: words("discovered.column.managed_resource"),
         apiName: "managed_resource_id",
       },
+      {
+        displayName: words("discovered.column.discovery_resource"),
+        apiName: "discovery_resource_id",
+      },
     ];
     this.numberOfColumns = this.columnHeads.length + 1;
   }

--- a/src/Slices/ResourceDiscovery/UI/Page.test.tsx
+++ b/src/Slices/ResourceDiscovery/UI/Page.test.tsx
@@ -84,14 +84,35 @@ test("GIVEN Discovered Resources page THEN shows table", async () => {
     "/resources/cloudflare%3A%3Adns_record%3A%3ACnameRecord%5Bhttps%3A%2F%2Fapi.cloudflare.com%2Fclient%2Fv4%2F%2Cname%3Dartifacts.ssh.inmanta.com%5D",
   );
 
+  // with correct uri to discovery resource
+  const rowWithDiscoveryResource = within(rows[0]).getByRole("cell", {
+    name: "Show discovery resource",
+  });
+
+  expect(rowWithDiscoveryResource).toBeVisible();
+
+  expect(within(rowWithDiscoveryResource).getByRole("link")).toHaveAttribute(
+    "href",
+    "/resources/cloudflare%3A%3Adns_record%3A%3ACnameRecord%5Bhttps%3A%2F%2Fapi.cloudflare.com%2Fclient%2Fv4%2F%2Cname%3Dartifacts.ssh.inmanta.com%5D",
+  );
+
   // uri is null
   expect(within(rows[1]).getByTestId("Managed resource")).toHaveTextContent("");
+  expect(within(rows[1]).getByTestId("Discovery resource")).toHaveTextContent(
+    "",
+  );
 
   // uri doesn't have a rid
   expect(within(rows[2]).getByTestId("Managed resource")).toHaveTextContent("");
+  expect(within(rows[2]).getByTestId("Discovery resource")).toHaveTextContent(
+    "",
+  );
 
   // uri is an empty string
   expect(within(rows[3]).getByTestId("Managed resource")).toHaveTextContent("");
+  expect(within(rows[3]).getByTestId("Discovery resource")).toHaveTextContent(
+    "",
+  );
 
   await act(async () => {
     const results = await axe(document.body);

--- a/src/UI/words.tsx
+++ b/src/UI/words.tsx
@@ -595,9 +595,11 @@ const dict = {
   /** Discovered Resources related text */
   "discovered.column.resource_id": "Resource Id",
   "discovered.column.managed_resource": "Managed resource",
+  "discovered.column.discovery_resource": "Discovery resource",
   "discovered_resources.title": "Discovered Resources",
   "discovered_resources.values": "values",
-  "discovered_resources.show_resource": "Show managed resource",
+  "discovered_resources.show_resource.managed": "Show managed resource",
+  "discovered_resources.show_resource.discovery": "Show discovery resource",
 
   /** Compile report related text */
   "compileReports.title": "Compile Reports",


### PR DESCRIPTION
# Description

Add Link with Discovery resources uri to the Discovered Resources Page

![Screenshot 2025-01-13 at 13 54 58](https://github.com/user-attachments/assets/a77caf8d-861b-4fd8-88d8-d52ac46cc282)


closes #5946 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Code is clear and sufficiently documented
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
