### PR TITLE
Improve the tags for the versions on the instance details page.

### DIFF
--- a/changelogs/unreleased/6142-version-tags.yml
+++ b/changelogs/unreleased/6142-version-tags.yml
@@ -1,0 +1,6 @@
+description: Improve the tags for the versions on the instance details page.
+issue-nr: 6142
+change-type: patch
+destination-branches: [master]
+sections:
+  minor-improvement: "{{description}}"

--- a/cypress/e2e/scenario-8-instance-composer.cy.js
+++ b/cypress/e2e/scenario-8-instance-composer.cy.js
@@ -876,10 +876,6 @@ if (Cypress.env("edition") === "iso") {
       cy.get('[aria-label="instance-details-link"]', { timeout: 20000 })
         .first()
         .click();
-      cy.get('[data-testid="selected-version"]').should(
-        "have.text",
-        "Version: 8",
-      ); // initial open of the details view will show the outdated version
 
       //Make sure we are at the active attirubtes
       cy.get('[aria-label="Select-AttributeSet"]').select("active_attributes");

--- a/src/Slices/ServiceInstanceDetails/Test/Page.test.tsx
+++ b/src/Slices/ServiceInstanceDetails/Test/Page.test.tsx
@@ -133,11 +133,6 @@ describe("ServiceInstanceDetailsPage", () => {
       await screen.findByRole("region", { name: "Instance-Details-Success" }),
     ).toBeInTheDocument();
 
-    expect(screen.getByText("Latest Version")).toBeInTheDocument();
-    expect(screen.getByTestId("selected-version")).toHaveTextContent(
-      "Version: 4",
-    );
-
     // Test that the table has collapsibles
     // this value is located inside the collapsible section.
     expect(screen.getByText(/inmanta\-lab/i)).not.toBeVisible();
@@ -292,12 +287,8 @@ describe("ServiceInstanceDetailsPage", () => {
       await screen.findByRole("region", { name: "Instance-Details-Success" }),
     ).toBeInTheDocument();
 
-    // active attribute set
-    // in this version, we should have documentation available
-    expect(screen.getByText("Latest Version")).toBeInTheDocument();
-    expect(screen.getByTestId("selected-version")).toHaveTextContent(
-      "Version: 4",
-    );
+    // active attribute set. By default, the latest version is selected, and shouldn't display a label.
+    expect(screen.queryByTestId("selected-version")).not.toBeInTheDocument();
 
     // should display the right timestamp in the rows for each version
     expect(screen.getByTestId("version-4-timestamp")).toHaveTextContent(
@@ -319,7 +310,6 @@ describe("ServiceInstanceDetailsPage", () => {
     // in this version, we should have documentation available
     await userEvent.click(screen.getByRole("cell", { name: "3" }));
 
-    expect(screen.queryByText("Latest Version")).not.toBeInTheDocument();
     expect(screen.getByTestId("selected-version")).toHaveTextContent(
       "Version: 3",
     );
@@ -335,7 +325,6 @@ describe("ServiceInstanceDetailsPage", () => {
     // in this version, topography documentation is an empty string, so fall back to message informing the user.
     await userEvent.click(screen.getByRole("cell", { name: "2" }));
 
-    expect(screen.queryByText("Latest Version")).not.toBeInTheDocument();
     expect(screen.getByTestId("selected-version")).toHaveTextContent(
       "Version: 2",
     );
@@ -350,7 +339,6 @@ describe("ServiceInstanceDetailsPage", () => {
     // in this version, topography attribute didn't exist yet in any attribute set, but is available in the ServiceModel.
     await userEvent.click(screen.getByRole("cell", { name: "1" }));
 
-    expect(screen.queryByText("Latest Version")).not.toBeInTheDocument();
     expect(screen.getByTestId("selected-version")).toHaveTextContent(
       "Version: 1",
     );

--- a/src/Slices/ServiceInstanceDetails/UI/Components/Sections/VersionedPageTitleWithActions.tsx
+++ b/src/Slices/ServiceInstanceDetails/UI/Components/Sections/VersionedPageTitleWithActions.tsx
@@ -1,7 +1,5 @@
 import React, { useContext } from "react";
-import { Label } from "@patternfly/react-core";
-import { InfoAltIcon } from "@patternfly/react-icons";
-import styled from "styled-components";
+import { Flex, FlexItem, Label } from "@patternfly/react-core";
 import { useUrlStateWithString } from "@/Data";
 import { words } from "@/UI";
 import { InstanceDetailsContext } from "../../../Core/Context";
@@ -14,8 +12,9 @@ interface Props {
 /**
  * The PageTitleWithVersion Component
  *
- * When the version is the latest active version,
- * an additional tag is displayed to inform the user they are visualizing the latest version.
+ * When the version is the latest active version, we don't display a tag.
+ * When the version is not the latest active version, we display a tag with the version number.
+ * If the instance is deleted, we display a label with the terminated-state.
  *
  * The title section also contains InstanceActions
  *
@@ -38,30 +37,28 @@ export const VersionedPageTitleWithActions: React.FC<Props> = ({ title }) => {
   const isLatest = selectedVersion === String(instance.version);
 
   return (
-    <>
-      {title}
-      <LabelContainer>
-        <Label data-testid="selected-version">
-          {words("instanceDetails.title.tag")(selectedVersion)}
-        </Label>
-        {isLatest && (
-          <Label color="green" icon={<InfoAltIcon />}>
-            {words("instanceDetails.title.latest")}
-          </Label>
-        )}
+    <Flex justifyContent={{ default: "justifyContentSpaceBetween" }}>
+      <Flex
+        alignItems={{ default: "alignItemsCenter" }}
+        gap={{ default: "gapSm" }}
+      >
+        {title}
+        {!isLatest && [
+          <Label
+            data-testid="selected-version"
+            key="selected-version"
+            color="purple"
+          >
+            {words("instanceDetails.title.tag")(selectedVersion)}
+          </Label>,
+        ]}
         {instance.deleted && (
-          <Label color="red" icon={<InfoAltIcon />}>
+          <Label status="danger" data-testid="terminated" key="terminated">
             {instance.state}
           </Label>
         )}
-      </LabelContainer>
-      {isLatest && <InstanceActions />}
-    </>
+      </Flex>
+      <FlexItem>{isLatest && <InstanceActions />}</FlexItem>
+    </Flex>
   );
 };
-
-const LabelContainer = styled.span`
-  margin-left: var(--pf-t--global--spacer--md);
-  display: inline-flex;
-  gap: var(--pf-t--global--spacer--sm);
-`;

--- a/src/UI/Styles/MarkdownStyles.ts
+++ b/src/UI/Styles/MarkdownStyles.ts
@@ -6,7 +6,7 @@ export const MarkdownStyles = `
   -webkit-text-size-adjust: 100%;
   margin: 0;
   color: var(--pf-t--global--text--color--regular);
-  font-family: var(--pf-t--global--font--family--mono);
+  font-family: var(--pf-t--global--font--family--body);
   font-size: 16px;
   line-height: 1.5;
   word-wrap: break-word;
@@ -62,7 +62,7 @@ export const MarkdownStyles = `
 
 .markdown-body b,
 .markdown-body strong {
-  font-weight: 600;
+  font-weight: var(--pf-t--global--font--weight--200);
 }
 
 .markdown-body dfn {
@@ -71,7 +71,7 @@ export const MarkdownStyles = `
 
 .markdown-body h1 {
   margin: .67em 0;
-  font-weight: 600;
+  font-weight: var(--pf-t--global--font--weight--200);
   padding-bottom: .3em;
   font-size: 2em;
   border-bottom: 1px solid hsla(210,18%,87%,1);
@@ -113,7 +113,7 @@ export const MarkdownStyles = `
 .markdown-body kbd,
 .markdown-body pre,
 .markdown-body samp {
-  font-family: monospace;
+  font-family: var(--pf-t--global--font--family--mono);
   font-size: 1em;
 }
 
@@ -275,34 +275,34 @@ export const MarkdownStyles = `
 .markdown-body h6 {
   margin-top: 24px;
   margin-bottom: 16px;
-  font-weight: 600;
+  font-weight: var(--pf-t--global--font--weight--200);
   line-height: 1.25;
 }
 
 .markdown-body h2 {
-  font-weight: 600;
+  font-weight: var(--pf-t--global--font--weight--200);
   padding-bottom: .3em;
   font-size: 1.5em;
   border-bottom: 1px solid hsla(210,18%,87%,1);
 }
 
 .markdown-body h3 {
-  font-weight: 600;
+  font-weight: var(--pf-t--global--font--weight--200);
   font-size: 1.25em;
 }
 
 .markdown-body h4 {
-  font-weight: 600;
+  font-weight: var(--pf-t--global--font--weight--200);
   font-size: 1em;
 }
 
 .markdown-body h5 {
-  font-weight: 600;
+  font-weight: var(--pf-t--global--font--weight--200);
   font-size: .875em;
 }
 
 .markdown-body h6 {
-  font-weight: 600;
+  font-weight: var(--pf-t--global--font--weight--200);
   font-size: .85em;
   color: #656d76;
 }
@@ -345,14 +345,14 @@ export const MarkdownStyles = `
 .markdown-body tt,
 .markdown-body code,
 .markdown-body samp {
-  font-family: ui-monospace,SFMono-Regular,SF Mono,Menlo,Consolas,Liberation Mono,monospace;
+  font-family: var(--pf-t--global--font--family--mono);
   font-size: 12px;
 }
 
 .markdown-body pre {
   margin-top: 0;
   margin-bottom: 0;
-  font-family: ui-monospace,SFMono-Regular,SF Mono,Menlo,Consolas,Liberation Mono,monospace;
+  font-family: var(--pf-t--global--font--family--mono);
   font-size: 12px;
   word-wrap: normal;
 }
@@ -562,7 +562,7 @@ export const MarkdownStyles = `
   margin-top: 16px;
   font-size: 1em;
   font-style: italic;
-  font-weight: 600;
+  font-weight: var(--pf-t--global--font--weight--200);
 }
 
 .markdown-body dl dd {
@@ -571,7 +571,7 @@ export const MarkdownStyles = `
 }
 
 .markdown-body table th {
-  font-weight: 600;
+  font-weight: var(--pf-t--global--font--weight--200);
 }
 
 .markdown-body table th,
@@ -790,7 +790,7 @@ export const MarkdownStyles = `
 }
 
 .markdown-body .csv-data th {
-  font-weight: 600;
+  font-weight: var(--pf-t--global--font--weight--200);
   background: #f6f8fa;
   border-top: 0;
 }
@@ -840,7 +840,7 @@ export const MarkdownStyles = `
 }
 
 .markdown-body .footnotes .data-footnote-backref g-emoji {
-  font-family: monospace;
+  font-family: var(--pf-t--global--font--family--mono);
 }
 
 .markdown-body .pl-c {
@@ -900,7 +900,7 @@ export const MarkdownStyles = `
 }
 
 .markdown-body .pl-sr .pl-cce {
-  font-weight: bold;
+  font-weight: var(--pf-t--global--font--weight--200);
   color: #116329;
 }
 
@@ -911,7 +911,7 @@ export const MarkdownStyles = `
 .markdown-body .pl-mh,
 .markdown-body .pl-mh .pl-en,
 .markdown-body .pl-ms {
-  font-weight: bold;
+  font-weight: var(--pf-t--global--font--weight--200);
   color: #0550ae;
 }
 
@@ -921,7 +921,7 @@ export const MarkdownStyles = `
 }
 
 .markdown-body .pl-mb {
-  font-weight: bold;
+  font-weight: var(--pf-t--global--font--weight--200);
   color: #24292f;
 }
 
@@ -946,7 +946,7 @@ export const MarkdownStyles = `
 }
 
 .markdown-body .pl-mdr {
-  font-weight: bold;
+  font-weight: var(--pf-t--global--font--weight--200);
   color: #8250df;
 }
 
@@ -969,7 +969,7 @@ export const MarkdownStyles = `
   font-family: "Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
   font-size: 1em;
   font-style: normal !important;
-  font-weight: 400;
+  font-weight: var(--pf-t--global--font--weight--body);
   line-height: 1;
   vertical-align: -0.075em;
 }
@@ -984,7 +984,7 @@ export const MarkdownStyles = `
 }
 
 .markdown-body .task-list-item label {
-  font-weight: 400;
+  font-weight: var(--pf-t--global--font--weight--body);
 }
 
 .markdown-body .task-list-item.enabled label {
@@ -1042,7 +1042,7 @@ export const MarkdownStyles = `
 
 .markdown-body .markdown-alert .markdown-alert-title {
   display: flex;
-  font-weight: 500;
+  font-weight: var(--pf-t--global--font--weight--heading);
   align-items: center;
   line-height: 1;
 }


### PR DESCRIPTION
# Description

closes #6142 

As agreed, the latest version is now the default and not the exception. A label is only added when we are not on the default, aka, when an instance is terminated or if we are visualizing an older version. 

I also quickly updated the css sheet for the markdown.

https://github.com/user-attachments/assets/858dffe2-a82f-4520-9a8e-7fcdf3f9a97f

