### PR TITLE
cherrypick security update for iso7

### DIFF
--- a/changelogs/unreleased/buildmaster-security-undici.yml
+++ b/changelogs/unreleased/buildmaster-security-undici.yml
@@ -1,0 +1,3 @@
+description: Fix security alert regarding the undici package
+change-type: patch
+destination-branches: [master, iso8, iso7]

--- a/package.json
+++ b/package.json
@@ -202,7 +202,7 @@
     "loader-utils": "2.0.4 || 1.4.2",
     "word-wrap": "^1.2.4",
     "follow-redirects": "^1.15.4",
-    "undici": "^5",
+    "undici": "^5.28.5",
     "ws": "^8.17.1"
   },
   "madge": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -15359,12 +15359,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici@npm:^5":
-  version: 5.28.4
-  resolution: "undici@npm:5.28.4"
+"undici@npm:^5.28.5":
+  version: 5.28.5
+  resolution: "undici@npm:5.28.5"
   dependencies:
     "@fastify/busboy": "npm:^2.0.0"
-  checksum: 10/a666a9f5ac4270c659fafc33d78b6b5039a0adbae3e28f934774c85dcc66ea91da907896f12b414bd6f578508b44d5dc206fa636afa0e49a4e1c9e99831ff065
+  checksum: 10/459cd84ab75fe90d696fa2634a8b5b23f9e1080b27236c6809bd74e51862be85df6d95b4a8fed3ee42554495008cb3c05f1bc9d4a1807478f433cca567003d70
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Cherry pick of yesterday PR, it turns out bot could not merge it automatically due to the conflicts
