### PR TITLE
Add more white space between buttons on Service Catalog page

### DIFF
--- a/changelogs/unreleased/add-space-buttons.yml
+++ b/changelogs/unreleased/add-space-buttons.yml
@@ -1,0 +1,3 @@
+description: Add more white space between buttons on Service Catalog page
+change-type: patch
+destination-branches: [master, iso8]

--- a/src/UI/Components/CatalogActions/CatalogActions.tsx
+++ b/src/UI/Components/CatalogActions/CatalogActions.tsx
@@ -4,6 +4,7 @@ import {
   Button,
   Content,
   Flex,
+  FlexItem,
   Tooltip,
 } from "@patternfly/react-core";
 import { FileCodeIcon } from "@patternfly/react-icons";
@@ -105,20 +106,27 @@ export const CatalogActions: React.FC = () => {
         direction={{ default: "row" }}
         fullWidth={{ default: "fullWidth" }}
         justifyContent={{ default: "justifyContentFlexEnd" }}
+        rowGap={{ default: "rowGap" }}
       >
-        <Tooltip content={words("catalog.API.tooltip")} entryDelay={500}>
-          <Button
-            variant="plain"
-            aria-label="API-Documentation"
-            icon={<FileCodeIcon />}
-            component="a"
-            href={urlManager.getLSMAPILink(environmentHandler.useId())}
-            target="_blank"
-          ></Button>
-        </Tooltip>
-        <Tooltip content={words("catalog.update.tooltip")}>
-          <Button onClick={openModal}>{words("catalog.button.update")}</Button>
-        </Tooltip>
+        <FlexItem>
+          <Tooltip content={words("catalog.API.tooltip")} entryDelay={500}>
+            <Button
+              variant="plain"
+              aria-label="API-Documentation"
+              icon={<FileCodeIcon />}
+              component="a"
+              href={urlManager.getLSMAPILink(environmentHandler.useId())}
+              target="_blank"
+            ></Button>
+          </Tooltip>
+        </FlexItem>
+        <FlexItem>
+          <Tooltip content={words("catalog.update.tooltip")}>
+            <Button onClick={openModal}>
+              {words("catalog.button.update")}
+            </Button>
+          </Tooltip>
+        </FlexItem>
       </Flex>
     </>
   );


### PR DESCRIPTION
# Description

Add white space between the Catalog action buttons.

<img width="229" alt="image" src="https://github.com/user-attachments/assets/152a382b-ea21-4363-95d2-3402fa874592" />
