### PR TITLE
Improve casing of names of instance groups in Instance Composer

### DIFF
--- a/changelogs/unreleased/6155-casing-composer.yml
+++ b/changelogs/unreleased/6155-casing-composer.yml
@@ -1,0 +1,6 @@
+description: Improve casing of names of instance groups in Instance Composer
+issue-nr: 6155
+change-type: patch
+destination-branches: [master, iso8]
+sections:
+  minor-improvement: "{{description}}"

--- a/src/UI/Components/Diagram/styles.ts
+++ b/src/UI/Components/Diagram/styles.ts
@@ -40,6 +40,16 @@ export const CanvasWrapper = styled.div`
     border: 0;
     background-color: var(--pf-t--global--background--color--primary--default);
 
+    .group > .group-label {
+      text-transform: none;
+      color: var(--pf-t--global--text--color--regular);
+      font-size: var(--pf-t_global_font_size_body_lg);
+
+      &::before {
+        border-top-color: var(--pf-t--global--text--color--regular);
+      }
+    }
+
     &.joint-hidden {
       visibility: hidden; //note: display: none breaks the stencil-groups
     }


### PR DESCRIPTION
# Description

Improve casing of names of instance groups in Instance Composer
![Screenshot 2025-02-17 at 15 10 40](https://github.com/user-attachments/assets/b3938b67-2ddc-4e6d-874a-250032d8438f)


closes #6155

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Code is clear and sufficiently documented
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
