### PR TITLE
Enable compression for HTTPS connections and improve response handling

### DIFF
--- a/changelogs/unreleased/xx-enable-compression-https.yml
+++ b/changelogs/unreleased/xx-enable-compression-https.yml
@@ -1,0 +1,3 @@
+description: Enable compression for HTTPS connections and improve response handling in API calls
+change-type: patch
+destination-branches: [master, iso8]

--- a/src/Data/Managers/V2/helpers/useQueries.ts
+++ b/src/Data/Managers/V2/helpers/useQueries.ts
@@ -101,7 +101,7 @@ export const usePost = (options?: { message?: string }) => {
   const { createHeaders, handleErrors } = useFetchHelpers();
   const headers = createHeaders({ env, message: options?.message });
 
-  return async <Body>(path: string, body: Body) => {
+  return async <Response, Body>(path: string, body: Body): Promise<Response | undefined> => {
     try {
       const response = await fetch(`${baseUrl}${path}`, {
         method: "POST",
@@ -111,12 +111,8 @@ export const usePost = (options?: { message?: string }) => {
 
       await handleErrors(response);
 
-      const contentLength = response.headers.get("Content-Length");
-      const isGzip = response.headers.get("Content-Encoding") === "gzip";
-
-      if ((contentLength && contentLength !== "0") || isGzip) {
-        return response.json();
-      }
+      const text = await response.text();
+      return text ? JSON.parse(text) : undefined;
     } catch (error) {
       console.error("Error posting data:", error);
       throw error;
@@ -157,12 +153,8 @@ export const usePostWithoutEnv = (options?: { message?: string }) => {
 
       await handleErrors(response);
 
-      const contentLength = response.headers.get("Content-Length");
-      const isGzip = response.headers.get("Content-Encoding") === "gzip";
-
-      if ((contentLength && contentLength !== "0") || isGzip) {
-        return response.json();
-      }
+      const text = await response.text();
+      return text ? JSON.parse(text) : undefined;
 
       return;
     } catch (error) {
@@ -206,12 +198,9 @@ export const usePut = (options?: { message?: string }) => {
 
       await handleErrors(response);
 
-      const contentLength = response.headers.get("Content-Length");
-      const isGzip = response.headers.get("Content-Encoding") === "gzip";
+      const text = await response.text();
+      return text ? JSON.parse(text) : undefined;
 
-      if ((contentLength && contentLength !== "0") || isGzip) {
-        return response.json();
-      }
     } catch (error) {
       console.error("Error putting data:", error);
       throw error;
@@ -252,12 +241,9 @@ export const usePutWithoutEnv = (options?: { message?: string }) => {
 
       await handleErrors(response);
 
-      const contentLength = response.headers.get("Content-Length");
-      const isGzip = response.headers.get("Content-Encoding") === "gzip";
+      const text = await response.text();
+      return text ? JSON.parse(text) : undefined;
 
-      if ((contentLength && contentLength !== "0") || isGzip) {
-        return response.json();
-      }
     } catch (error) {
       console.error("Error putting data:", error);
       throw error;
@@ -299,12 +285,9 @@ export const usePatch = (options?: { message?: string }) => {
 
       await handleErrors(response);
 
-      const contentLength = response.headers.get("Content-Length");
-      const isGzip = response.headers.get("Content-Encoding") === "gzip";
+      const text = await response.text();
+      return text ? JSON.parse(text) : undefined;
 
-      if ((contentLength && contentLength !== "0") || isGzip) {
-        return response.json();
-      }
     } catch (error) {
       console.error("Error patching data:", error);
       throw error;
@@ -345,12 +328,9 @@ export const usePatchWithoutEnv = (options?: { message?: string }) => {
 
       await handleErrors(response);
 
-      const contentLength = response.headers.get("Content-Length");
-      const isGzip = response.headers.get("Content-Encoding") === "gzip";
+      const text = await response.text();
+      return text ? JSON.parse(text) : undefined;
 
-      if ((contentLength && contentLength !== "0") || isGzip) {
-        return response.json();
-      }
     } catch (error) {
       console.error("Error patching data:", error);
       throw error;
@@ -394,12 +374,9 @@ export const useDelete = (options?: { message?: string }) => {
 
       await handleErrors(response);
 
-      const contentLength = response.headers.get("Content-Length");
-      const isGzip = response.headers.get("Content-Encoding") === "gzip";
+      const text = await response.text();
+      return text ? JSON.parse(text) : undefined;
 
-      if ((contentLength && contentLength !== "0") || isGzip) {
-        return response.json();
-      }
     } catch (error) {
       console.error("Error deleting data:", error);
       throw error;
@@ -438,12 +415,9 @@ export const useDeleteWithoutEnv = (options?: { message?: string }) => {
 
       await handleErrors(response);
 
-      const contentLength = response.headers.get("Content-Length");
-      const isGzip = response.headers.get("Content-Encoding") === "gzip";
-
-      if ((contentLength && contentLength !== "0") || isGzip) {
-        return response.json();
-      }
+      const text = await response.text();
+      return text ? JSON.parse(text) : undefined;
+      
     } catch (error) {
       console.error("Error deleting data:", error);
       throw error;

--- a/src/Data/Managers/V2/helpers/useQueries.ts
+++ b/src/Data/Managers/V2/helpers/useQueries.ts
@@ -101,10 +101,7 @@ export const usePost = (options?: { message?: string }) => {
   const { createHeaders, handleErrors } = useFetchHelpers();
   const headers = createHeaders({ env, message: options?.message });
 
-  return async <Response, Body>(
-    path: string,
-    body: Body,
-  ): Promise<Response | undefined> => {
+  return async <Body>(path: string, body: Body) => {
     try {
       const response = await fetch(`${baseUrl}${path}`, {
         method: "POST",
@@ -116,7 +113,9 @@ export const usePost = (options?: { message?: string }) => {
 
       const text = await response.text();
 
-      return text ? JSON.parse(text) : undefined;
+      if (text) {
+        return JSON.parse(text);
+      }
     } catch (error) {
       console.error("Error posting data:", error);
       throw error;
@@ -159,7 +158,9 @@ export const usePostWithoutEnv = (options?: { message?: string }) => {
 
       const text = await response.text();
 
-      return text ? JSON.parse(text) : undefined;
+      if (text) {
+        return JSON.parse(text);
+      }
 
       return;
     } catch (error) {
@@ -205,7 +206,9 @@ export const usePut = (options?: { message?: string }) => {
 
       const text = await response.text();
 
-      return text ? JSON.parse(text) : undefined;
+      if (text) {
+        return JSON.parse(text);
+      }
     } catch (error) {
       console.error("Error putting data:", error);
       throw error;
@@ -248,7 +251,9 @@ export const usePutWithoutEnv = (options?: { message?: string }) => {
 
       const text = await response.text();
 
-      return text ? JSON.parse(text) : undefined;
+      if (text) {
+        return JSON.parse(text);
+      }
     } catch (error) {
       console.error("Error putting data:", error);
       throw error;
@@ -292,7 +297,9 @@ export const usePatch = (options?: { message?: string }) => {
 
       const text = await response.text();
 
-      return text ? JSON.parse(text) : undefined;
+      if (text) {
+        return JSON.parse(text);
+      }
     } catch (error) {
       console.error("Error patching data:", error);
       throw error;
@@ -335,7 +342,9 @@ export const usePatchWithoutEnv = (options?: { message?: string }) => {
 
       const text = await response.text();
 
-      return text ? JSON.parse(text) : undefined;
+      if (text) {
+        return JSON.parse(text);
+      }
     } catch (error) {
       console.error("Error patching data:", error);
       throw error;
@@ -381,7 +390,9 @@ export const useDelete = (options?: { message?: string }) => {
 
       const text = await response.text();
 
-      return text ? JSON.parse(text) : undefined;
+      if (text) {
+        return JSON.parse(text);
+      }
     } catch (error) {
       console.error("Error deleting data:", error);
       throw error;
@@ -419,10 +430,11 @@ export const useDeleteWithoutEnv = (options?: { message?: string }) => {
       });
 
       await handleErrors(response);
-
       const text = await response.text();
 
-      return text ? JSON.parse(text) : undefined;
+      if (text) {
+        return JSON.parse(text);
+      }
     } catch (error) {
       console.error("Error deleting data:", error);
       throw error;

--- a/src/Data/Managers/V2/helpers/useQueries.ts
+++ b/src/Data/Managers/V2/helpers/useQueries.ts
@@ -101,7 +101,10 @@ export const usePost = (options?: { message?: string }) => {
   const { createHeaders, handleErrors } = useFetchHelpers();
   const headers = createHeaders({ env, message: options?.message });
 
-  return async <Response, Body>(path: string, body: Body): Promise<Response | undefined> => {
+  return async <Response, Body>(
+    path: string,
+    body: Body,
+  ): Promise<Response | undefined> => {
     try {
       const response = await fetch(`${baseUrl}${path}`, {
         method: "POST",
@@ -112,6 +115,7 @@ export const usePost = (options?: { message?: string }) => {
       await handleErrors(response);
 
       const text = await response.text();
+
       return text ? JSON.parse(text) : undefined;
     } catch (error) {
       console.error("Error posting data:", error);
@@ -154,6 +158,7 @@ export const usePostWithoutEnv = (options?: { message?: string }) => {
       await handleErrors(response);
 
       const text = await response.text();
+
       return text ? JSON.parse(text) : undefined;
 
       return;
@@ -199,8 +204,8 @@ export const usePut = (options?: { message?: string }) => {
       await handleErrors(response);
 
       const text = await response.text();
-      return text ? JSON.parse(text) : undefined;
 
+      return text ? JSON.parse(text) : undefined;
     } catch (error) {
       console.error("Error putting data:", error);
       throw error;
@@ -242,8 +247,8 @@ export const usePutWithoutEnv = (options?: { message?: string }) => {
       await handleErrors(response);
 
       const text = await response.text();
-      return text ? JSON.parse(text) : undefined;
 
+      return text ? JSON.parse(text) : undefined;
     } catch (error) {
       console.error("Error putting data:", error);
       throw error;
@@ -286,8 +291,8 @@ export const usePatch = (options?: { message?: string }) => {
       await handleErrors(response);
 
       const text = await response.text();
-      return text ? JSON.parse(text) : undefined;
 
+      return text ? JSON.parse(text) : undefined;
     } catch (error) {
       console.error("Error patching data:", error);
       throw error;
@@ -329,8 +334,8 @@ export const usePatchWithoutEnv = (options?: { message?: string }) => {
       await handleErrors(response);
 
       const text = await response.text();
-      return text ? JSON.parse(text) : undefined;
 
+      return text ? JSON.parse(text) : undefined;
     } catch (error) {
       console.error("Error patching data:", error);
       throw error;
@@ -375,8 +380,8 @@ export const useDelete = (options?: { message?: string }) => {
       await handleErrors(response);
 
       const text = await response.text();
-      return text ? JSON.parse(text) : undefined;
 
+      return text ? JSON.parse(text) : undefined;
     } catch (error) {
       console.error("Error deleting data:", error);
       throw error;
@@ -416,8 +421,8 @@ export const useDeleteWithoutEnv = (options?: { message?: string }) => {
       await handleErrors(response);
 
       const text = await response.text();
+
       return text ? JSON.parse(text) : undefined;
-      
     } catch (error) {
       console.error("Error deleting data:", error);
       throw error;

--- a/src/Slices/CreateInstance/UI/CreateInstance.tsx
+++ b/src/Slices/CreateInstance/UI/CreateInstance.tsx
@@ -47,20 +47,11 @@ export const CreateInstance: React.FC<Props> = ({ serviceEntity }) => {
       setIsDirty(true);
       setErrorMessage(error.message);
     },
-    onSuccess: (response) => {
-      if (!response || !response.data) {
-        console.warn(
-          "The response failed to return the expected data to redirect.",
-          response,
-        );
-
-        return;
-      }
+    onSuccess: ({ data }) => {
       const newUrl = routeManager.getUrl("InstanceDetails", {
         service: serviceEntity.name,
-        instance:
-          response.data.service_identity_attribute_value || response.data.id,
-        instanceId: response.data.id,
+        instance: data.service_identity_attribute_value || data.id,
+        instanceId: data.id,
       });
 
       navigate(`${newUrl}${location.search}`);

--- a/src/Slices/CreateInstance/UI/CreateInstance.tsx
+++ b/src/Slices/CreateInstance/UI/CreateInstance.tsx
@@ -47,11 +47,15 @@ export const CreateInstance: React.FC<Props> = ({ serviceEntity }) => {
       setIsDirty(true);
       setErrorMessage(error.message);
     },
-    onSuccess: ({ data }) => {
+    onSuccess: ( response ) => {
+      if (!response || !response.data) {
+        console.warn("The response failed to return the expected data to redirect.", response);
+        return;
+      }
       const newUrl = routeManager.getUrl("InstanceDetails", {
         service: serviceEntity.name,
-        instance: data.service_identity_attribute_value || data.id,
-        instanceId: data.id,
+        instance: response.data.service_identity_attribute_value || response.data.id,
+        instanceId: response.data.id,
       });
 
       navigate(`${newUrl}${location.search}`);

--- a/src/Slices/CreateInstance/UI/CreateInstance.tsx
+++ b/src/Slices/CreateInstance/UI/CreateInstance.tsx
@@ -47,14 +47,19 @@ export const CreateInstance: React.FC<Props> = ({ serviceEntity }) => {
       setIsDirty(true);
       setErrorMessage(error.message);
     },
-    onSuccess: ( response ) => {
+    onSuccess: (response) => {
       if (!response || !response.data) {
-        console.warn("The response failed to return the expected data to redirect.", response);
+        console.warn(
+          "The response failed to return the expected data to redirect.",
+          response,
+        );
+
         return;
       }
       const newUrl = routeManager.getUrl("InstanceDetails", {
         service: serviceEntity.name,
-        instance: response.data.service_identity_attribute_value || response.data.id,
+        instance:
+          response.data.service_identity_attribute_value || response.data.id,
         instanceId: response.data.id,
       });
 


### PR DESCRIPTION
Enable compression for HTTPS connections and improve response handling.

Cloudflare has compression enabled by default, which doesn't provide a content-lenght in the API responses like we used to assert whether there is a response or not.
