### PR TITLE
Fix defaults filters in desired state

### DIFF
--- a/changelogs/unreleased/6177-fix-continuous-env-test.yml
+++ b/changelogs/unreleased/6177-fix-continuous-env-test.yml
@@ -1,0 +1,6 @@
+description: Fix lack of visibility of default filter for desired state page
+issue-nr: 6206
+change-type: patch
+destination-branches: [master, iso8]
+sections:
+  bugifx: "{{description}}"

--- a/changelogs/unreleased/6177-fix-continuous-env-test.yml
+++ b/changelogs/unreleased/6177-fix-continuous-env-test.yml
@@ -3,4 +3,4 @@ issue-nr: 6206
 change-type: patch
 destination-branches: [master, iso8]
 sections:
-  bugifx: "{{description}}"
+  bugfix: "{{description}}"

--- a/src/Data/Common/UrlState/useUrlStateWithFilter.spec.ts
+++ b/src/Data/Common/UrlState/useUrlStateWithFilter.spec.ts
@@ -63,3 +63,65 @@ test.each`
     expect(value).toEqual(expectedValue);
   },
 );
+
+test("GIVEN handleUrlState with Filter WHEN search is empty THEN returns default value", async () => {
+  const [value] = handleUrlStateWithFilter(
+    {
+      route: "Inventory",
+      keys: {
+        timestamp: "DateRange",
+        version: "IntRange",
+        success: "Boolean",
+        details: "Boolean",
+      },
+      default: {
+        timestamp: [],
+        version: [
+          { operator: "from", value: 10 },
+          { operator: "to", value: 20 },
+        ],
+        success: false,
+        details: false,
+      },
+    },
+    { pathname: "", search: "", hash: "" },
+    () => undefined,
+  );
+
+  expect(value).toEqual({
+    timestamp: [],
+    version: [
+      { operator: "from", value: 10 },
+      { operator: "to", value: 20 },
+    ],
+    success: false,
+    details: false,
+  });
+
+  const [value2] = handleUrlStateWithFilter(
+    {
+      route: "Inventory",
+      keys: {
+        timestamp: "DateRange",
+        version: "IntRange",
+        success: "Boolean",
+        details: "Boolean",
+      },
+      default: {
+        timestamp: [],
+        version: [],
+        success: false,
+        details: false,
+      },
+    },
+    { pathname: "", search: "", hash: "" },
+    () => undefined,
+  );
+
+  expect(value2).toEqual({
+    timestamp: [],
+    version: [],
+    success: false,
+    details: false,
+  });
+});

--- a/src/Data/Common/UrlState/useUrlStateWithFilter.ts
+++ b/src/Data/Common/UrlState/useUrlStateWithFilter.ts
@@ -44,7 +44,10 @@ const parseValue = (
 };
 
 export function handleUrlStateWithFilter<Data>(
-  config: Pick<StateConfig<Data>, "route"> & Keys,
+  config: Pick<StateConfig<Data>, "route"> &
+    Keys & {
+      default?: Data;
+    },
   location: Location,
   replace: Replace,
 ): [Data, Update<Data>] {
@@ -77,7 +80,7 @@ export function handleUrlStateWithFilter<Data>(
 
   return handleUrlState<Data>(
     {
-      default: {} as Data,
+      default: config.default || ({} as Data),
       key: "filter",
       route: config.route,
       equals: (a: Data, b: Data): boolean =>

--- a/src/Data/Managers/V2/DesiredState/GetDesiredStates/getUrl.ts
+++ b/src/Data/Managers/V2/DesiredState/GetDesiredStates/getUrl.ts
@@ -14,7 +14,7 @@ export function getUrl(
   { pageSize, filter, currentPage }: Query.SubQuery<"GetDesiredStates">,
   timezone = moment.tz.guess(),
 ): string {
-  const defaultFilter = { status: ["active", "candidate", "retired"] };
+  const defaultFilter = {};
   const filterWithDefaults =
     filter && filter.status && filter.status?.length > 0
       ? filter

--- a/src/Slices/DesiredState/UI/Page.test.tsx
+++ b/src/Slices/DesiredState/UI/Page.test.tsx
@@ -207,7 +207,7 @@ describe("DesiredStatesView", () => {
         //we are expecting that at some point the request will have the filters applied for status and we mock the adequate response
         if (
           request.url.split("?")[1] ===
-          "limit=20&sort=version.desc&filter.status=skipped_candidate"
+          "limit=20&sort=version.desc&filter.status=active&filter.status=candidate&filter.status=retired&filter.status=skipped_candidate"
         ) {
           return HttpResponse.json({
             ...DesiredStateVersions.response,
@@ -495,7 +495,7 @@ describe("DesiredStatesView", () => {
         //we are expecting that at some point the request will have the filters applied for status and we mock the adequate response
         if (
           request.url.split("?")[1] ===
-          "limit=20&sort=version.desc&filter.status=candidate"
+          "limit=20&sort=version.desc&filter.status=active&filter.status=retired"
         ) {
           return HttpResponse.json({
             ...DesiredStateVersions.response,

--- a/src/Slices/DesiredState/UI/Page.tsx
+++ b/src/Slices/DesiredState/UI/Page.tsx
@@ -19,11 +19,11 @@ import {
 import { ModalContext } from "@/UI/Root/Components/ModalProvider";
 import { words } from "@/UI/words";
 import { Filter } from "@S/DesiredState/Core/Query";
+import { DesiredStateVersionStatus } from "../Core/Domain";
 import { TableControls } from "./Components";
 import { DesiredStatesTable } from "./DesiredStatesTable";
 import { GetDesiredStatesContext } from "./GetDesiredStatesContext";
 import { CompareSelection } from "./Utils";
-import { DesiredStateVersionStatus } from "../Core/Domain";
 
 /**
  * The Page component that renders the desired state page.
@@ -46,7 +46,7 @@ export const Page: React.FC = () => {
     route: "DesiredState",
     keys: { date: "DateRange", version: "IntRange" },
   });
-  status: ["active", "candidate", "retired"];
+
   const [compareSelection, setCompareSelection] = useState<CompareSelection>({
     kind: "None",
   });
@@ -90,6 +90,7 @@ export const Page: React.FC = () => {
         ],
       });
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => {

--- a/src/Slices/DesiredState/UI/Page.tsx
+++ b/src/Slices/DesiredState/UI/Page.tsx
@@ -43,6 +43,13 @@ export const Page: React.FC = () => {
     route: "DesiredState",
   });
   const [filter, setFilter] = useUrlStateWithFilter<Filter>({
+    default: {
+      status: [
+        DesiredStateVersionStatus.active,
+        DesiredStateVersionStatus.candidate,
+        DesiredStateVersionStatus.retired,
+      ],
+    },
     route: "DesiredState",
     keys: { date: "DateRange", version: "IntRange" },
   });
@@ -77,21 +84,6 @@ export const Page: React.FC = () => {
       ),
     });
   };
-
-  useEffect(() => {
-    //set default filter to active, candidate and retired only if the filter is not set, or empty on initial load
-    if (!filter.status || filter.status.length === 0) {
-      setFilter({
-        ...filter,
-        status: [
-          DesiredStateVersionStatus.active,
-          DesiredStateVersionStatus.candidate,
-          DesiredStateVersionStatus.retired,
-        ],
-      });
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   useEffect(() => {
     if (deleteVersion.isError) {

--- a/src/Slices/DesiredState/UI/Page.tsx
+++ b/src/Slices/DesiredState/UI/Page.tsx
@@ -23,6 +23,7 @@ import { TableControls } from "./Components";
 import { DesiredStatesTable } from "./DesiredStatesTable";
 import { GetDesiredStatesContext } from "./GetDesiredStatesContext";
 import { CompareSelection } from "./Utils";
+import { DesiredStateVersionStatus } from "../Core/Domain";
 
 /**
  * The Page component that renders the desired state page.
@@ -45,7 +46,7 @@ export const Page: React.FC = () => {
     route: "DesiredState",
     keys: { date: "DateRange", version: "IntRange" },
   });
-
+  status: ["active", "candidate", "retired"];
   const [compareSelection, setCompareSelection] = useState<CompareSelection>({
     kind: "None",
   });
@@ -76,6 +77,20 @@ export const Page: React.FC = () => {
       ),
     });
   };
+
+  useEffect(() => {
+    //set default filter to active, candidate and retired only if the filter is not set, or empty on initial load
+    if (!filter.status || filter.status.length === 0) {
+      setFilter({
+        ...filter,
+        status: [
+          DesiredStateVersionStatus.active,
+          DesiredStateVersionStatus.candidate,
+          DesiredStateVersionStatus.retired,
+        ],
+      });
+    }
+  }, []);
 
   useEffect(() => {
     if (deleteVersion.isError) {


### PR DESCRIPTION
# Description

Fix visiblity of defaults filters, previously I think they were tied to global state that we are moving away from. I added init addition only if there is no parameters in the url already.

https://github.com/user-attachments/assets/d013937b-7c72-476d-adf4-cff2dc39433c

closes #6206 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Code is clear and sufficiently documented
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
