### PR TITLE
Fix submit button styling when disabled

### DIFF
--- a/changelogs/unreleased/6237-submit-styling.yml
+++ b/changelogs/unreleased/6237-submit-styling.yml
@@ -1,0 +1,6 @@
+description: Fix styling of disabled submit button in the service instance form
+issue-nr: 6237
+change-type: patch
+destination-branches: [master, iso8]
+sections:
+  bugfix: "{{description}}"

--- a/src/UI/Components/ActionDisabledTooltip/ActionDisabledTooltip.tsx
+++ b/src/UI/Components/ActionDisabledTooltip/ActionDisabledTooltip.tsx
@@ -31,5 +31,11 @@ export const ActionDisabledTooltip: React.FC<
 };
 
 const CursorNotAllowedContainer = styled.span`
+  margin-block-start: calc(-1 * var(--pf-v6-c-form__actions--MarginBlockStart));
+  margin-block-end: calc(-1 * var(--pf-v6-c-form__actions--MarginBlockEnd));
+  margin-inline-start: calc(
+    -1 * var(--pf-v6-c-form__actions--MarginInlineStart)
+  );
+  margin-inline-end: calc(-1 * var(--pf-v6-c-form__actions--MarginInlineEnd));
   cursor: not-allowed;
 `;


### PR DESCRIPTION
# Description

Fix submit button styling when disabled
![Screenshot 2025-03-27 at 12 52 23](https://github.com/user-attachments/assets/2c476596-7ea2-4605-be3a-ed5b8f0a58c5)

closes #6237 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Code is clear and sufficiently documented
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
