### PR TITLE
Debug monaco

### DIFF
--- a/__mocks__/monaco-editor.js
+++ b/__mocks__/monaco-editor.js
@@ -2,89 +2,89 @@
 // This is a simplified mock that covers the basic functionality needed for the tests.
 
 module.exports = {
-    editor: {
-        create: jest.fn(() => ({
-            getModel: jest.fn(),
-            onDidChangeModelContent: jest.fn(),
-            createModel: jest.fn(),
-            setModelLanguage: jest.fn(),
-            setValue: jest.fn(),
-            getValue: jest.fn(),
-            updateOptions: jest.fn(),
-            dispose: jest.fn(),
-            layout: jest.fn(),
-            focus: jest.fn(),
-            onDidBlurEditorWidget: jest.fn(),
-            onDidFocusEditorWidget: jest.fn(),
-            restoreViewState: jest.fn(),
-            saveViewState: jest.fn(),
-            getSelection: jest.fn(),
-            getScrollTop: jest.fn(),
-            getScrollLeft: jest.fn(),
-            onDidChangeMarkers: jest.fn(),
-        })),
-        createDiffEditor: jest.fn(() => ({
-            setModel: jest.fn(),
-            getModel: jest.fn(() => ({
-                original: {
-                    dispose: jest.fn(),
-                    getValue: jest.fn(),
-                    setValue: jest.fn(),
-                    onDidChangeContent: jest.fn(),
-                },
-                modified: {
-                    dispose: jest.fn(),
-                    getValue: jest.fn(),
-                    setValue: jest.fn(),
-                    onDidChangeContent: jest.fn(),
-                }
-            })),
-            updateOptions: jest.fn(),
-            dispose: jest.fn(),
-            layout: jest.fn(),
-            focus: jest.fn(),
-            onDidUpdateDiff: jest.fn(),
-            getDiffLineInformationForOriginal: jest.fn(),
-            getDiffLineInformationForModified: jest.fn(),
-            restoreViewState: jest.fn(),
-            saveViewState: jest.fn(),
-        })),
-        defineTheme: jest.fn(),
-        setTheme: jest.fn(),
-        getModel: jest.fn(),
-        onDidCreateEditor: jest.fn(),
-        createModel: jest.fn(() => ({
-            dispose: jest.fn(),
-            onDidChangeContent: jest.fn(),
-            setValue: jest.fn(),
-            getValue: jest.fn(),
-        })),
-        onDidChangeMarkers: jest.fn(),
-        setModelMarkers: jest.fn(),
-        getModelMarkers: jest.fn().mockReturnValue([]),
-    },
-    languages: {
-        json: {
-            jsonDefaults: {
-                setModeConfiguration: jest.fn(),
-                setDiagnosticsOptions: jest.fn(),
-            }
+  editor: {
+    create: jest.fn(() => ({
+      getModel: jest.fn(),
+      onDidChangeModelContent: jest.fn(),
+      createModel: jest.fn(),
+      setModelLanguage: jest.fn(),
+      setValue: jest.fn(),
+      getValue: jest.fn(),
+      updateOptions: jest.fn(),
+      dispose: jest.fn(),
+      layout: jest.fn(),
+      focus: jest.fn(),
+      onDidBlurEditorWidget: jest.fn(),
+      onDidFocusEditorWidget: jest.fn(),
+      restoreViewState: jest.fn(),
+      saveViewState: jest.fn(),
+      getSelection: jest.fn(),
+      getScrollTop: jest.fn(),
+      getScrollLeft: jest.fn(),
+      onDidChangeMarkers: jest.fn(),
+    })),
+    createDiffEditor: jest.fn(() => ({
+      setModel: jest.fn(),
+      getModel: jest.fn(() => ({
+        original: {
+          dispose: jest.fn(),
+          getValue: jest.fn(),
+          setValue: jest.fn(),
+          onDidChangeContent: jest.fn(),
         },
-        register: jest.fn(),
-        setMonarchTokensProvider: jest.fn(),
-        setLanguageConfiguration: jest.fn(),
+        modified: {
+          dispose: jest.fn(),
+          getValue: jest.fn(),
+          setValue: jest.fn(),
+          onDidChangeContent: jest.fn(),
+        },
+      })),
+      updateOptions: jest.fn(),
+      dispose: jest.fn(),
+      layout: jest.fn(),
+      focus: jest.fn(),
+      onDidUpdateDiff: jest.fn(),
+      getDiffLineInformationForOriginal: jest.fn(),
+      getDiffLineInformationForModified: jest.fn(),
+      restoreViewState: jest.fn(),
+      saveViewState: jest.fn(),
+    })),
+    defineTheme: jest.fn(),
+    setTheme: jest.fn(),
+    getModel: jest.fn(),
+    onDidCreateEditor: jest.fn(),
+    createModel: jest.fn(() => ({
+      dispose: jest.fn(),
+      onDidChangeContent: jest.fn(),
+      setValue: jest.fn(),
+      getValue: jest.fn(),
+    })),
+    onDidChangeMarkers: jest.fn(),
+    setModelMarkers: jest.fn(),
+    getModelMarkers: jest.fn().mockReturnValue([]),
+  },
+  languages: {
+    json: {
+      jsonDefaults: {
+        setModeConfiguration: jest.fn(),
+        setDiagnosticsOptions: jest.fn(),
+      },
     },
-    Uri: {
-        parse: jest.fn(),
-        file: jest.fn(),
-    },
-    KeyMod: {
-        CtrlCmd: 2048,
-        Shift: 1024,
-        Alt: 512,
-        WinCtrl: 256,
-    },
-    KeyCode: {
-        KEY_IN: 0
-    }
-}; 
+    register: jest.fn(),
+    setMonarchTokensProvider: jest.fn(),
+    setLanguageConfiguration: jest.fn(),
+  },
+  Uri: {
+    parse: jest.fn(),
+    file: jest.fn(),
+  },
+  KeyMod: {
+    CtrlCmd: 2048,
+    Shift: 1024,
+    Alt: 512,
+    WinCtrl: 256,
+  },
+  KeyCode: {
+    KEY_IN: 0,
+  },
+};

--- a/__mocks__/monaco-editor.js
+++ b/__mocks__/monaco-editor.js
@@ -1,0 +1,90 @@
+// Considering we aren't allowed to use the CDN for the monaco editor, we need to mock it for Jest to work.
+// This is a simplified mock that covers the basic functionality needed for the tests.
+
+module.exports = {
+    editor: {
+        create: jest.fn(() => ({
+            getModel: jest.fn(),
+            onDidChangeModelContent: jest.fn(),
+            createModel: jest.fn(),
+            setModelLanguage: jest.fn(),
+            setValue: jest.fn(),
+            getValue: jest.fn(),
+            updateOptions: jest.fn(),
+            dispose: jest.fn(),
+            layout: jest.fn(),
+            focus: jest.fn(),
+            onDidBlurEditorWidget: jest.fn(),
+            onDidFocusEditorWidget: jest.fn(),
+            restoreViewState: jest.fn(),
+            saveViewState: jest.fn(),
+            getSelection: jest.fn(),
+            getScrollTop: jest.fn(),
+            getScrollLeft: jest.fn(),
+            onDidChangeMarkers: jest.fn(),
+        })),
+        createDiffEditor: jest.fn(() => ({
+            setModel: jest.fn(),
+            getModel: jest.fn(() => ({
+                original: {
+                    dispose: jest.fn(),
+                    getValue: jest.fn(),
+                    setValue: jest.fn(),
+                    onDidChangeContent: jest.fn(),
+                },
+                modified: {
+                    dispose: jest.fn(),
+                    getValue: jest.fn(),
+                    setValue: jest.fn(),
+                    onDidChangeContent: jest.fn(),
+                }
+            })),
+            updateOptions: jest.fn(),
+            dispose: jest.fn(),
+            layout: jest.fn(),
+            focus: jest.fn(),
+            onDidUpdateDiff: jest.fn(),
+            getDiffLineInformationForOriginal: jest.fn(),
+            getDiffLineInformationForModified: jest.fn(),
+            restoreViewState: jest.fn(),
+            saveViewState: jest.fn(),
+        })),
+        defineTheme: jest.fn(),
+        setTheme: jest.fn(),
+        getModel: jest.fn(),
+        onDidCreateEditor: jest.fn(),
+        createModel: jest.fn(() => ({
+            dispose: jest.fn(),
+            onDidChangeContent: jest.fn(),
+            setValue: jest.fn(),
+            getValue: jest.fn(),
+        })),
+        onDidChangeMarkers: jest.fn(),
+        setModelMarkers: jest.fn(),
+        getModelMarkers: jest.fn().mockReturnValue([]),
+    },
+    languages: {
+        json: {
+            jsonDefaults: {
+                setModeConfiguration: jest.fn(),
+                setDiagnosticsOptions: jest.fn(),
+            }
+        },
+        register: jest.fn(),
+        setMonarchTokensProvider: jest.fn(),
+        setLanguageConfiguration: jest.fn(),
+    },
+    Uri: {
+        parse: jest.fn(),
+        file: jest.fn(),
+    },
+    KeyMod: {
+        CtrlCmd: 2048,
+        Shift: 1024,
+        Alt: 512,
+        WinCtrl: 256,
+    },
+    KeyCode: {
+        KEY_IN: 0
+    }
+}; 

--- a/changelogs/unreleased/debug-monaco.yml
+++ b/changelogs/unreleased/debug-monaco.yml
@@ -1,0 +1,3 @@
+description: Replace CDN import for monace with local dependency.
+change-type: patch
+destination-branches: [master, iso8]

--- a/cypress.config.cjs
+++ b/cypress.config.cjs
@@ -13,7 +13,7 @@ module.exports = defineConfig({
   },
   e2e: {
     baseUrl: "http://127.0.0.1:8888",
-    supportFile: false,
+    supportFile: "cypress/support/e2e.js",
     defaultCommandTimeout: 10000,
     requestTimeout: 10000,
   },

--- a/cypress/e2e/scenario-1-environment.cy.js
+++ b/cypress/e2e/scenario-1-environment.cy.js
@@ -2,6 +2,7 @@ const testProjectName = (id) => "Test Project Name " + id;
 const testName = (id) => "TestName " + id;
 
 beforeEach(() => {
+  localStorage.setItem("theme-preference", "light");
   cy.fixture("test-icon.png", { encoding: null }).as("icon");
   cy.intercept("POST", "/api/v2/environment_settings/**").as(
     "postEnvConfigEdit",

--- a/cypress/e2e/scenario-2.1-basic-service.cy.js
+++ b/cypress/e2e/scenario-2.1-basic-service.cy.js
@@ -62,6 +62,10 @@ const forceUpdateEnvironment = (nameEnvironment = "test") => {
   });
 };
 
+beforeEach(() => {
+  localStorage.setItem("theme-preference", "light");
+});
+
 if (Cypress.env("edition") === "iso") {
   describe("Scenario 2.1 Service Catalog - basic-service", () => {
     before(() => {

--- a/cypress/e2e/scenario-2.1-basic-service.cy.js
+++ b/cypress/e2e/scenario-2.1-basic-service.cy.js
@@ -393,6 +393,7 @@ if (Cypress.env("edition") === "iso") {
 
     it("2.1.6 Instance Details page", () => {
       cy.visit("/console/");
+
       cy.get(`[aria-label="Select-environment-test"]`).click();
       cy.get('[aria-label="Sidebar-Navigation-Item"]')
         .contains("Service Catalog")

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -1,0 +1,13 @@
+// Wrap in before() to ensure it runs before any test
+beforeEach(() => {
+  cy.on("uncaught:exception", (err) => {
+    // Only ignore the specific Monaco editor disposal error
+    console.log(err.message);
+    if (err.message.includes("TextModel")) {
+      return false; // Prevents the error from failing tests
+    }
+
+    // Allow other uncaught exceptions to fail tests
+    return true;
+  });
+});

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -26,8 +26,8 @@ module.exports = {
     // mapper for the aliassing '@joint/core': '@intmant/rappid'
     "^@joint/core$": "<rootDir>/node_modules/@inmanta/rappid",
     // Force module uuid to resolve with the CJS entry point, because Jest does not support package.json.exports. See https://github.com/uuidjs/uuid/issues/451
-    "uuid": require.resolve("uuid"),
-    "^monaco-editor$": "<rootDir>/__mocks__/monaco-editor.js"
+    uuid: require.resolve("uuid"),
+    "^monaco-editor$": "<rootDir>/__mocks__/monaco-editor.js",
   },
 
   // A preset that is used as a base for Jest's configuration
@@ -57,7 +57,7 @@ module.exports = {
 
   // The react-syntax-highlighter, mermaid and @inmanta/rappid esm modules have to be handled by jest
   transformIgnorePatterns: [
-    "node_modules/(?!(react-syntax-highlighter|@inmanta/rappid|mermaid/dist/mermaid.js|monaco-editor|@monaco-editor/react)/)"
+    "node_modules/(?!(react-syntax-highlighter|@inmanta/rappid|mermaid/dist/mermaid.js|monaco-editor|@monaco-editor/react)/)",
   ],
   globals: {
     "ts-jest": {

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -26,9 +26,8 @@ module.exports = {
     // mapper for the aliassing '@joint/core': '@intmant/rappid'
     "^@joint/core$": "<rootDir>/node_modules/@inmanta/rappid",
     // Force module uuid to resolve with the CJS entry point, because Jest does not support package.json.exports. See https://github.com/uuidjs/uuid/issues/451
-    uuid: require.resolve("uuid"),
-    "^monaco-editor$":
-      "<rootDir>/node_modules/monaco-editor/esm/vs/editor/editor.api.d.ts",
+    "uuid": require.resolve("uuid"),
+    "^monaco-editor$": "<rootDir>/__mocks__/monaco-editor.js"
   },
 
   // A preset that is used as a base for Jest's configuration
@@ -58,7 +57,7 @@ module.exports = {
 
   // The react-syntax-highlighter, mermaid and @inmanta/rappid esm modules have to be handled by jest
   transformIgnorePatterns: [
-    "node_modules/(?!react-syntax-highlighter|@inmanta/rappid|mermaid/dist/mermaid.js|monaco-editor)",
+    "node_modules/(?!(react-syntax-highlighter|@inmanta/rappid|mermaid/dist/mermaid.js|monaco-editor|@monaco-editor/react)/)"
   ],
   globals: {
     "ts-jest": {

--- a/src/Slices/ServiceInstanceDetails/Test/Page.test.tsx
+++ b/src/Slices/ServiceInstanceDetails/Test/Page.test.tsx
@@ -117,7 +117,7 @@ describe("ServiceInstanceDetailsPage", () => {
     server.close();
   });
 
-  xit("Should render a success view without config", async () => {
+  it("Should render a success view without config", async () => {
     const server = defaultServer;
 
     server.listen();
@@ -233,10 +233,7 @@ describe("ServiceInstanceDetailsPage", () => {
 
     await userEvent.click(toggleJson);
 
-    // expect the view to be updated
-    expect(screen.getByTestId("loading-spinner")).toBeVisible();
-
-    // We can't test the monaco editor in jest yet, this is covered in the E2E cases.
+    // We can't test the monaco editor in jest, this is covered in the E2E cases.
     // We can just test that the dropdown is now pressent too and set on the candidate set.
     expect(
       screen.getByRole("combobox", {
@@ -271,7 +268,7 @@ describe("ServiceInstanceDetailsPage", () => {
   // TODO: @LukasStordeur Implement test when config tab has usecases.
   //it("Should render a success view and with config section if present", async () => { });
 
-  xit("Should render a success view with documentation", async () => {
+  it("Should render a success view with documentation", async () => {
     const server = serverWithDocumentation;
 
     server.listen();

--- a/src/Slices/ServiceInstanceDetails/Test/mockSetup.tsx
+++ b/src/Slices/ServiceInstanceDetails/Test/mockSetup.tsx
@@ -12,6 +12,8 @@ import {
   EnvironmentModifierImpl,
 } from "@/UI";
 import { ServiceInstanceDetails } from "../UI/Page";
+import { loader } from "@monaco-editor/react";
+import * as monaco from "monaco-editor";
 
 /**
  * Mock setup for the test cases of the Instance Details page.
@@ -61,6 +63,9 @@ export const SetupWrapper: React.FC<PropsWithChildren<Props>> = ({
     },
   });
   const store = getStoreInstance();
+
+  loader.config({ monaco });
+  loader.init();
 
   const environmentHandler = EnvironmentHandlerImpl(
     useLocation,

--- a/src/Slices/ServiceInstanceDetails/Test/mockSetup.tsx
+++ b/src/Slices/ServiceInstanceDetails/Test/mockSetup.tsx
@@ -1,8 +1,10 @@
 import React, { PropsWithChildren } from "react";
 import { MemoryRouter, useLocation } from "react-router-dom";
+import { loader } from "@monaco-editor/react";
 import { Page } from "@patternfly/react-core";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { StoreProvider } from "easy-peasy";
+import * as monaco from "monaco-editor";
 import { RemoteData } from "@/Core";
 import { getStoreInstance } from "@/Data";
 import { dependencies } from "@/Test";
@@ -12,8 +14,6 @@ import {
   EnvironmentModifierImpl,
 } from "@/UI";
 import { ServiceInstanceDetails } from "../UI/Page";
-import { loader } from "@monaco-editor/react";
-import * as monaco from "monaco-editor";
 
 /**
  * Mock setup for the test cases of the Instance Details page.

--- a/src/Slices/ServiceInstanceDetails/UI/Components/AttributesComponents/AttributesCompare.tsx
+++ b/src/Slices/ServiceInstanceDetails/UI/Components/AttributesComponents/AttributesCompare.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { DiffEditor, loader } from "@monaco-editor/react";
+import { DiffEditor } from "@monaco-editor/react";
 import {
   Divider,
   Flex,
@@ -7,7 +7,6 @@ import {
   FormSelect,
   FormSelectOption,
 } from "@patternfly/react-core";
-import * as monaco from "monaco-editor";
 import styled from "styled-components";
 import { InstanceAttributeModel } from "@/Core";
 import { InstanceLog } from "@/Core/Domain/HistoryLog";
@@ -23,7 +22,6 @@ interface Props {
   instanceLogs: InstanceLog[];
   selectedVersion: string;
 }
-loader.config({ monaco });
 
 /**
  * The AttributesCompare Component.
@@ -35,6 +33,10 @@ loader.config({ monaco });
  *  @prop {InstanceLog[]} instanceLogs - The instanceLogs containing the versions with the attributesSets
  *  @prop {string} selectedVersion - the selected version of the InstanceDetails Page.
  * @returns {React.FC<Props>} A React Component displaying the AttributeSets in a DiffEditor
+ *
+ * @note See https://github.com/microsoft/vscode/pull/230713
+ * The DiffEditor doesn't make correct use of the cleanup lyfecycles. It doesn't dispose of the model as it should, creating a memory leak.
+ * There's a PR in progress on the Monaco library side.
  */
 export const AttributesCompare: React.FC<Props> = ({
   instanceLogs,

--- a/src/UI/Components/JSONEditor/JSONEditor.tsx
+++ b/src/UI/Components/JSONEditor/JSONEditor.tsx
@@ -7,7 +7,6 @@ import { words } from "@/UI";
 import { getThemePreference } from "../DarkmodeOption";
 import { ErrorMessageContainer } from "../ErrorMessageContainer";
 
-
 interface Props {
   service_entity: string;
   data: string;

--- a/src/UI/Components/JSONEditor/JSONEditor.tsx
+++ b/src/UI/Components/JSONEditor/JSONEditor.tsx
@@ -45,16 +45,6 @@ export const JSONEditor: React.FC<Props> = ({
 
   const monaco = useMonaco();
 
-  // Add cleanup effect to dispose models when component unmounts
-  useEffect(() => {
-    return () => {
-      if (monaco) {
-        // Dispose all models when component unmounts
-        monaco.editor.getModels().forEach((model) => model.dispose());
-      }
-    };
-  }, [monaco]);
-
   // local method to update state when the editor content changes
   const handleEditorChange = (value: string | undefined, _event) => {
     value && setEditorState(value);

--- a/src/UI/Components/JSONEditor/JSONEditor.tsx
+++ b/src/UI/Components/JSONEditor/JSONEditor.tsx
@@ -45,6 +45,16 @@ export const JSONEditor: React.FC<Props> = ({
 
   const monaco = useMonaco();
 
+  // Add cleanup effect to dispose models when component unmounts
+  useEffect(() => {
+    return () => {
+      if (monaco) {
+        // Dispose all models when component unmounts
+        monaco.editor.getModels().forEach((model) => model.dispose());
+      }
+    };
+  }, [monaco]);
+
   // local method to update state when the editor content changes
   const handleEditorChange = (value: string | undefined, _event) => {
     value && setEditorState(value);

--- a/src/UI/Components/JSONEditor/JSONEditor.tsx
+++ b/src/UI/Components/JSONEditor/JSONEditor.tsx
@@ -1,13 +1,12 @@
 import React, { useEffect, useState } from "react";
-import { Editor, OnValidate, useMonaco, loader } from "@monaco-editor/react";
+import { Editor, OnValidate, useMonaco } from "@monaco-editor/react";
 import { Spinner } from "@patternfly/react-core";
-import * as monaco from "monaco-editor";
+
 import { useGetJSONSchema } from "@/Data/Managers/V2/ServiceInstance";
 import { words } from "@/UI";
 import { getThemePreference } from "../DarkmodeOption";
 import { ErrorMessageContainer } from "../ErrorMessageContainer";
 
-loader.config({ monaco });
 
 interface Props {
   service_entity: string;

--- a/src/UI/Components/ServiceInstanceForm/ServiceInstanceFormEditor.test.tsx
+++ b/src/UI/Components/ServiceInstanceForm/ServiceInstanceFormEditor.test.tsx
@@ -88,7 +88,7 @@ const setup = (
   return { component, apiHelper, scheduler };
 };
 
-xit("GIVEN the ServiceInstanceForm WHEN using the JSON Editor THEN View loads without errors", async () => {
+it("GIVEN the ServiceInstanceForm WHEN using the JSON Editor THEN View loads without errors", async () => {
   // Provide the server-side API with the request handlers to get the schema
   const server = setupServer(
     http.get("/lsm/v1/service_catalog/:id/schema", async ({ params }) => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,9 +1,11 @@
 import "@patternfly/react-core/dist/styles/base.css";
 import "@/Core/Language/Extensions";
 import React from "react";
+import loader from "@monaco-editor/loader";
 import { Flex } from "@patternfly/react-core";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { StoreProvider } from "easy-peasy";
+import * as monaco from "monaco-editor";
 import { createRoot } from "react-dom/client";
 import { getStoreInstance } from "@/Data";
 import { Root } from "@/UI/Root";
@@ -12,8 +14,6 @@ import { Injector } from "./Injector";
 import CustomRouter from "./UI/Routing/CustomRouter";
 import history from "./UI/Routing/history";
 import ErrorBoundary from "./UI/Utils/ErrorBoundary";
-import * as monaco from "monaco-editor";
-import loader from "@monaco-editor/loader";
 
 loader.config({ monaco });
 loader.init();

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -12,6 +12,11 @@ import { Injector } from "./Injector";
 import CustomRouter from "./UI/Routing/CustomRouter";
 import history from "./UI/Routing/history";
 import ErrorBoundary from "./UI/Utils/ErrorBoundary";
+import * as monaco from "monaco-editor";
+import loader from "@monaco-editor/loader";
+
+loader.config({ monaco });
+loader.init();
 
 const store = getStoreInstance();
 const container = document.getElementById("root") as HTMLElement;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,7 +32,7 @@
       "@S/*": ["src/Slices/*"]
     }
   },
-  "include": ["**/*.ts", "**/*.tsx", "**/*.jsx", "jestSetupAfterEnv.cjs"],
+  "include": ["**/*.ts", "**/*.tsx", "**/*.jsx", "jestSetupAfterEnv.cjs", "cypress/support/e2e.js"],
   "exclude": ["node_modules"],
   "ts-node": {
     "compilerOptions": {

--- a/webpack.prod.cjs
+++ b/webpack.prod.cjs
@@ -53,9 +53,7 @@ module.exports = merge(common, {
     rules: [
       {
         test: /\.css$/,
-        include: [
-          path.resolve(__dirname, "node_modules/monaco-editor"),
-        ],
+        include: [path.resolve(__dirname, "node_modules/monaco-editor")],
         use: ["style-loader", "css-loader"],
       },
       {

--- a/webpack.prod.cjs
+++ b/webpack.prod.cjs
@@ -13,6 +13,8 @@ module.exports = merge(common, {
   optimization: {
     minimizer: [
       new CssMinimizerPlugin({
+        test: /\.css$/i,
+        exclude: /monaco-editor/,
         minimizerOptions: {
           sourceMap: false,
         },

--- a/webpack.prod.cjs
+++ b/webpack.prod.cjs
@@ -54,9 +54,15 @@ module.exports = merge(common, {
       {
         test: /\.css$/,
         include: [
+          path.resolve(__dirname, "node_modules/monaco-editor"),
+        ],
+        use: ["style-loader", "css-loader"],
+      },
+      {
+        test: /\.css$/,
+        include: [
           path.resolve(__dirname, "src"),
           path.resolve(__dirname, "node_modules/patternfly"),
-          path.resolve(__dirname, "node_modules/monaco-editor"),
           path.resolve(__dirname, "node_modules/@patternfly/patternfly"),
           path.resolve(__dirname, "node_modules/@patternfly/react-styles/css"),
           path.resolve(


### PR DESCRIPTION
# Description

- Enforce lightmode in cypress tests
- fix the unit and cypress tests for the bundled package of the monaco-editor.
- webpack configuration adjustments for the monaco-editor-plugin
- added mock for jest to deal with monaco-editors
- added a supportFile for the e2e tests to handle the uncaught exception thrown when using the DiffEditor. PR linked in code for the fix.
