### PR TITLE
implement a copy button to keep the escaped characters

### DIFF
--- a/changelogs/unreleased/6268-copy-raw-markdown.yml
+++ b/changelogs/unreleased/6268-copy-raw-markdown.yml
@@ -1,0 +1,6 @@
+description: Add a way to copy the markdown with escaped newlines.
+issue-nr: 6268
+change-type: patch
+destination-branches: [master, iso8]
+sections:
+  minor-improvement: "{{description}}"

--- a/src/Slices/MarkdownPreviewer/UI/CodeEditorControls.test.tsx
+++ b/src/Slices/MarkdownPreviewer/UI/CodeEditorControls.test.tsx
@@ -1,0 +1,95 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { words } from "@/UI/words";
+import { CodeEditorControls, escapeNewlines } from "./CodeEditorControls";
+
+// Mock the clipboard API
+const mockClipboard = {
+  writeText: jest.fn(),
+};
+
+// Mock the PatternFly CodeEditorControl component since all we want to test is the onClick event.
+// The original component relies on the Monaco Editor which is not available in the test environment.
+jest.mock("@patternfly/react-code-editor", () => ({
+  CodeEditorControl: ({ onClick, icon, "aria-label": ariaLabel }) => (
+    <button onClick={onClick} aria-label={ariaLabel} data-testid={`control-${ariaLabel}`}>
+      {icon}
+    </button>
+  ),
+}));
+
+beforeAll(() => {
+  Object.assign(navigator, {
+    clipboard: mockClipboard,
+  });
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("CodeEditorControls", () => {
+  const defaultProps = {
+    code: "# Test Markdown\n\nThis is a test",
+    service: "test-service",
+    instance: "test-instance",
+  };
+
+  it("should render all control buttons", () => {
+    render(<CodeEditorControls {...defaultProps} />);
+
+    expect(screen.getByTestId("control-Copy")).toBeInTheDocument();
+    expect(screen.getByTestId("control-Copy raw")).toBeInTheDocument();
+    expect(
+      screen.getByTestId(`control-${words("markdownPreviewer.download")}`)
+    ).toBeInTheDocument();
+  });
+
+  it("should copy markdown content when copy button is clicked", () => {
+    render(<CodeEditorControls {...defaultProps} />);
+
+    const copyButton = screen.getByTestId("control-Copy");
+    fireEvent.click(copyButton);
+
+    expect(mockClipboard.writeText).toHaveBeenCalledWith(defaultProps.code);
+  });
+
+  it("should copy raw markdown content with escaped newlines when raw copy button is clicked", () => {
+    render(<CodeEditorControls {...defaultProps} />);
+
+    const rawCopyButton = screen.getByTestId("control-Copy raw");
+    fireEvent.click(rawCopyButton);
+
+    expect(mockClipboard.writeText).toHaveBeenCalledWith("# Test Markdown\\n\\nThis is a test");
+  });
+});
+
+describe("escapeNewlines", () => {
+  it("should escape newlines in a string", () => {
+    const input = "Line 1\nLine 2\nLine 3";
+    const expected = "Line 1\\nLine 2\\nLine 3";
+    const result = escapeNewlines(input);
+    expect(result).toBe(expected);
+  });
+
+  it("should handle empty string", () => {
+    const input = "";
+    const expected = "";
+    const result = escapeNewlines(input);
+    expect(result).toBe(expected);
+  });
+
+  it("should handle string without newlines", () => {
+    const input = "No newlines here";
+    const expected = "No newlines here";
+    const result = escapeNewlines(input);
+    expect(result).toBe(expected);
+  });
+
+  it("should handle multiple consecutive newlines", () => {
+    const input = "Line 1\n\n\nLine 2";
+    const expected = "Line 1\\n\\n\\nLine 2";
+    const result = escapeNewlines(input);
+    expect(result).toBe(expected);
+  });
+});

--- a/src/Slices/MarkdownPreviewer/UI/CodeEditorControls.tsx
+++ b/src/Slices/MarkdownPreviewer/UI/CodeEditorControls.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { CodeEditorControl } from "@patternfly/react-code-editor";
-import { CopyIcon, DownloadIcon } from "@patternfly/react-icons";
+import { CopyIcon, DownloadIcon, CodeIcon } from "@patternfly/react-icons";
 import { words } from "@/UI/words";
 
 interface Props {
@@ -31,6 +31,16 @@ const handleDownload = (code: string, service: string, instance: string) => {
 };
 
 /**
+ * Escapes newlines in a string by replacing them with \n
+ *
+ * @param {string} text - The string to escape
+ * @returns {string} The string with escaped newlines
+ */
+export const escapeNewlines = (text: string): string => {
+  return text.replace(/\n/g, "\\n");
+};
+
+/**
  * The CodeEditorControls Component
  *
  * @props {Props} props - The props of the component.
@@ -48,6 +58,14 @@ export const CodeEditorControls: React.FC<Props> = ({ code, service, instance })
         tooltipProps={{ content: words("copy") }}
         onClick={() => {
           navigator.clipboard.writeText(code);
+        }}
+      />
+      <CodeEditorControl
+        icon={<CodeIcon />}
+        aria-label={words("copy.raw")}
+        tooltipProps={{ content: words("copy.raw.tooltip") }}
+        onClick={() => {
+          navigator.clipboard.writeText(escapeNewlines(code));
         }}
       />
       <CodeEditorControl

--- a/src/Slices/MarkdownPreviewer/UI/Page.test.tsx
+++ b/src/Slices/MarkdownPreviewer/UI/Page.test.tsx
@@ -92,7 +92,7 @@ describe("MarkdownPreviewer", () => {
 
     render(setup());
 
-    // Wait for t  load
+    // Wait for the content to load
     await waitFor(() => {
       // The code editor should be visible
       const codeEditor = screen.getByTestId("code-editor");

--- a/src/UI/words.tsx
+++ b/src/UI/words.tsx
@@ -42,6 +42,9 @@ const dict = {
   password: "Password",
   "load.previous": "Load previous",
   "load.next": "Load next",
+  copy: "Copy",
+  "copy.raw": "Copy raw",
+  "copy.raw.tooltip": "Copy with escaped newlines",
 
   /**
    * Error related text
@@ -78,7 +81,6 @@ const dict = {
    */
   "id.copy": "Copy full service instance id to clipboard",
   "serviceIdentity.copy": "Copy identifier to clipboard",
-  copy: "Copy",
   "copy.feedback": "Copied to clipboard",
   "attributes.active": "Active Attributes",
   "attributes.candidate": "Candidate Attributes",
@@ -851,7 +853,7 @@ const dict = {
    */
   "markdownPreviewer.hint.title": "Preview Only",
   "markdownPreviewer.hint.body":
-    "This editor is for preview purposes only. Changes made here will not be saved. To make permanent changes, please update the documentation attribute(s) in the service instance.",
+    "This editor is for preview purposes only. Changes made here will not be saved into the service attributes.",
   "markdownPreviewer.pageTitle": (service: string, instance: string) =>
     `Markdown Preview: ${service} - ${instance}`,
   "markdownPreviewer.download.tooltip": "Download markdown file",


### PR DESCRIPTION
# Description

Update the Markdown Previewer based on feedback.
- add button to copy raw string, keeping escaped new lines.
- update message in hint box.


https://github.com/user-attachments/assets/c283a7d9-8743-476e-bece-247a7f68c530


