### PR TITLE
Enforce clearing the cookies when the user is not authenticated.

### DIFF
--- a/changelogs/unreleased/token-refresh.yml
+++ b/changelogs/unreleased/token-refresh.yml
@@ -1,0 +1,5 @@
+description: Enforce clearing the cookies when the user is not authenticated.
+change-type: patch
+destination-branches: [master, iso8]
+sections:
+  bugfix: "{{description}}"

--- a/src/Data/Auth/Providers/DatabaseAuthProvider.tsx
+++ b/src/Data/Auth/Providers/DatabaseAuthProvider.tsx
@@ -17,15 +17,23 @@ export const DatabaseAuthProvider: React.FC<React.PropsWithChildren> = ({ childr
   );
   const basePathname = baseUrlManager.getBasePathname();
 
+  const clearCookies = (): void => {
+    removeCookie("inmanta_user");
+    localStorage.removeItem("inmanta_user");
+  };
+
   const getUser = (): string | null => user;
 
   const logout = useCallback((): void => {
-    removeCookie("inmanta_user");
-    localStorage.removeItem("inmanta_user");
+    clearCookies();
     navigate(`${basePathname}/login`);
   }, [navigate, basePathname]);
 
   const login = (): void => {
+    // The login function is called when we also get a 401 error.
+    // This means that the user is not authenticated and
+    // we need to clear the cookies to avoid lingering cookies that are invalid.
+    clearCookies();
     navigate(`${basePathname}/login`);
   };
 


### PR DESCRIPTION
# Description

Enforce clearing the cookies when the user is not authenticated.
This wasn't yet the case when we were in the scenario where a 401 redirected to the login page in the database auth provider. The token was kept in the cookies even if it expired.