### PR TITLE
fix itemization on firefox

### DIFF
--- a/changelogs/unreleased/6183-itemization-firefox.yml
+++ b/changelogs/unreleased/6183-itemization-firefox.yml
@@ -1,0 +1,6 @@
+description: Improve itemization in Firefox for the status page.
+issue-nr: 6183
+change-type: patch
+destination-branches: [master, iso8]
+sections:
+  minor-improvement: "{{description}}"

--- a/src/Slices/Status/UI/StatusItem.tsx
+++ b/src/Slices/Status/UI/StatusItem.tsx
@@ -132,7 +132,7 @@ const NestedListItem: React.FC<NestedListItemProps> = ({ name, properties }) => 
           {name}
         </b>
       </ListItem>
-      <List key={`${name}-nested-list`} isPlain={false}>
+      <List key={`${name}-nested-list`} isPlain style={{ marginLeft: "1rem" }}>
         {Object.entries(properties).map(([subKey, subValue]) => (
           <ListItem key={name + "_" + subKey}>
             <DescriptionList


### PR DESCRIPTION
# Description

There's some glitch when nesting lists and description lists on firefox, replaced the dots with a margin.

closes #6183 

![image](https://github.com/user-attachments/assets/2b74c216-db3a-4465-97c4-9661acaccb88)