### PR TITLE
Increase the default page size for the Resources page.

### DIFF
--- a/changelogs/unreleased/6277-increase-default-pagesize-resources.yml
+++ b/changelogs/unreleased/6277-increase-default-pagesize-resources.yml
@@ -1,0 +1,6 @@
+description: Increase the default page size for the Resources page.
+issue-nr: 6277
+change-type: patch
+destination-branches: [master, iso8]
+sections:
+  minor-improvement: "{{description}}"

--- a/cypress/e2e/scenario-6-resources.cy.js
+++ b/cypress/e2e/scenario-6-resources.cy.js
@@ -569,6 +569,11 @@ describe("Scenario 6 : Resources", () => {
       cy.get('[aria-label="Sidebar-Navigation-Item"]').contains("Resources").click();
       cy.get('[aria-label="LegendItem-deployed"]', { timeout: 60000 }).should("have.text", "49");
 
+      // set page size to 20 for the test, 100 should be the default
+      cy.get('[aria-label="PaginationWidget-top"] .pf-v6-c-menu-toggle').click();
+      cy.contains(".pf-v6-c-menu__list-item", "100").find("svg").should("exist");
+      cy.contains(".pf-v6-c-menu__list-item", "20").click();
+
       cy.get(
         "#PaginationWidget-top-top-toggle > .pf-v6-c-menu-toggle__text > b:first-of-type"
       ).should("have.text", "1 - 20");

--- a/src/Data/Common/UrlState/useUrlStateWithPageSize.spec.ts
+++ b/src/Data/Common/UrlState/useUrlStateWithPageSize.spec.ts
@@ -2,14 +2,16 @@ import { PageSize } from "@/Core";
 import { handleUrlStateWithPageSize } from "./useUrlStateWithPageSize";
 
 test.each`
-  search                            | searchText | expectedValue          | valueText
-  ${""}                             | ${"empty"} | ${PageSize.initial}    | ${"default"}
-  ${"?state.Inventory.pageSize=10"} | ${"10"}    | ${PageSize.from("10")} | ${"10"}
+  route                | search                            | expectedValue           | valueText
+  ${"Inventory"}       | ${""}                             | ${PageSize.initial}     | ${"default"}
+  ${"Inventory"}       | ${"?state.Inventory.pageSize=10"} | ${PageSize.from("10")}  | ${"10"}
+  ${"ResourceDetails"} | ${""}                             | ${PageSize.from("100")} | ${"100"}
+  ${"Resources"}       | ${""}                             | ${PageSize.from("100")} | ${"100"}
 `(
-  "GIVEN handleUrlState with PageSize WHEN search is $searchText THEN returns $valueText",
-  async ({ search, expectedValue }) => {
+  "GIVEN handleUrlState with PageSize WHEN route is $route and search is $search THEN returns $valueText",
+  async ({ route, search, expectedValue }) => {
     const [value] = handleUrlStateWithPageSize(
-      { route: "Inventory" },
+      { route },
       { pathname: "", search, hash: "" },
       () => undefined
     );

--- a/src/Data/Common/UrlState/useUrlStateWithPageSize.ts
+++ b/src/Data/Common/UrlState/useUrlStateWithPageSize.ts
@@ -5,12 +5,14 @@ import { handleUrlState } from "./useUrlState";
 
 export const useUrlStateWithPageSize = provide(handleUrlStateWithPageSize);
 
+const LARGE_PAGES = ["ResourceDetails", "Resources"];
+
 export function handleUrlStateWithPageSize(
   config: Pick<StateConfig<PageSize.Type>, "route">,
   location: Location,
   replace: Replace
 ): [PageSize.Type, Update<PageSize.Type>] {
-  const defaultPageSize = config.route === "ResourceDetails" ? from("100") : PageSize.initial;
+  const defaultPageSize = LARGE_PAGES.includes(config.route) ? from("100") : PageSize.initial;
 
   return handleUrlState<PageSize.Type>(
     {

--- a/src/Slices/Resource/UI/ResourcesPage/Page.test.tsx
+++ b/src/Slices/Resource/UI/ResourcesPage/Page.test.tsx
@@ -695,7 +695,7 @@ describe("ResourcesPage", () => {
         });
       })
     );
-    const { component } = setup();
+    const { component } = setup(["/resources?pageSize=20"]);
 
     render(component);
 

--- a/src/Test/Data/Resource.ts
+++ b/src/Test/Data/Resource.ts
@@ -77,10 +77,10 @@ export const response = {
   ],
   links: { self: "/api/v2/resource?limit=20&sort=resource_type.DESC" },
   metadata: {
-    total: 22,
+    total: 102,
     before: 0,
     after: 2,
-    page_size: 20,
+    page_size: 100,
     deploy_summary: {
       total: 20,
       by_state: {
@@ -173,7 +173,7 @@ export const responseFromVersion: Resource.ResponseFromVersion = {
     total: 6,
     before: 0,
     after: 0,
-    page_size: 20,
+    page_size: 100,
   },
 };
 


### PR DESCRIPTION
# Description

Considering the amount of resources in general, it was decided to increase the page size for the resource page to 100 instead of 20.

closes #6277 
