### PR TITLE
 Allow deleting embedded entities when the minimum is not reached.

### DIFF
--- a/changelogs/unreleased/6333-bugfix-form.yml
+++ b/changelogs/unreleased/6333-bugfix-form.yml
@@ -1,0 +1,6 @@
+description: Allow deleting embedded entities when the minimum is not reached.
+issue-nr: 6333
+change-type: patch
+destination-branches: [master, iso8]
+sections:
+  bugfix: "{{description}}"

--- a/src/UI/Components/ServiceInstanceForm/Components/AutoCompleteInputProvider.tsx
+++ b/src/UI/Components/ServiceInstanceForm/Components/AutoCompleteInputProvider.tsx
@@ -10,7 +10,7 @@ interface Props {
   attributeValue: string | string[] | null;
   description?: string | null;
   isOptional: boolean;
-  isDisabled?: boolean;
+  isDisabled: boolean;
   handleInputChange: (value) => void;
   alreadySelected: string[] | null;
   multi?: boolean;
@@ -38,7 +38,7 @@ export const AutoCompleteInputProvider: React.FC<Props> = ({
   attributeValue,
   description,
   isOptional,
-  isDisabled = false,
+  isDisabled,
   handleInputChange,
   alreadySelected,
   multi,

--- a/src/UI/Components/ServiceInstanceForm/Components/RelatedServiceProvider.tsx
+++ b/src/UI/Components/ServiceInstanceForm/Components/RelatedServiceProvider.tsx
@@ -10,6 +10,7 @@ interface Props {
   attributeValue: string | string[] | null;
   description?: string | null;
   isOptional: boolean;
+  isDisabled: boolean;
   handleInputChange: (value) => void;
   alreadySelected: string[];
   multi?: boolean;
@@ -36,6 +37,7 @@ export const RelatedServiceProvider: React.FC<Props> = ({
   attributeValue,
   description,
   isOptional,
+  isDisabled,
   handleInputChange,
   alreadySelected,
   multi,
@@ -64,6 +66,7 @@ export const RelatedServiceProvider: React.FC<Props> = ({
         isOptional={isOptional}
         description={description}
         handleInputChange={handleInputChange}
+        isDisabled={isDisabled}
         serviceName={serviceName}
         multi={multi}
       />

--- a/src/UI/Components/ServiceInstanceForm/ServiceInstanceForm.test.tsx
+++ b/src/UI/Components/ServiceInstanceForm/ServiceInstanceForm.test.tsx
@@ -581,8 +581,8 @@ test("GIVEN ServiceInstanceForm WHEN Deleting an item that isn't the last index,
   expect(textBoxes).toHaveLength(3);
   expect(textBoxes[0]).toHaveValue("flat_field_text_1");
 
-  // expect the first delete button to be disabled
-  expect(screen.getAllByRole("button", { name: words("delete") })[0]).toBeDisabled();
+  // the delete button should be enabled, as for this list, the minimum is 1
+  expect(screen.getAllByRole("button", { name: words("delete") })[0]).toBeEnabled();
 
   // Delete the second item of the list.
   await userEvent.click(within(group).getAllByRole("button", { name: words("delete") })[1]);
@@ -592,6 +592,17 @@ test("GIVEN ServiceInstanceForm WHEN Deleting an item that isn't the last index,
   expect(updatedTextBoxes).toHaveLength(2);
   expect(updatedTextBoxes[0]).toHaveValue("flat_field_text_1");
   expect(updatedTextBoxes[1]).toHaveValue("flat_field_text_3");
+
+  // Delete another item of the list.
+  await userEvent.click(within(group).getAllByRole("button", { name: words("delete") })[0]);
+
+  const updatedTextBoxes2 = screen.getAllByRole("textbox");
+
+  expect(updatedTextBoxes2).toHaveLength(1);
+  expect(updatedTextBoxes2[0]).toHaveValue("flat_field_text_3");
+
+  // The delete button should now be disabled, as the minimum is 1
+  expect(screen.getAllByRole("button", { name: words("delete") })[0]).toBeDisabled();
 });
 
 test("GIVEN ServiceInstanceForm WHEN clicking the submit button THEN callback is executed with formState", async () => {


### PR DESCRIPTION
# Description

closes #6333

- Allow deleting embedded entities when the minimum has not been reached yet. 
- Disable inter service relation fields when needed. 

https://github.com/user-attachments/assets/5c8ec846-b55c-4720-a433-2eb1381c2ae8

