### PR TITLE
Issue/6345 expert banner fix

### DIFF
--- a/changelogs/unreleased/6345-expert-banner-fix.yml
+++ b/changelogs/unreleased/6345-expert-banner-fix.yml
@@ -1,0 +1,5 @@
+description: Fix Expert mode banner flickering and spinner not hiding after making the banner reappear.
+issue-nr: 6345
+change-type: patch
+destination-branches: [master, iso8]
+

--- a/src/Data/Managers/V2/Environment/ResetEnvironmentSetting/useResetEnvironmentSetting.ts
+++ b/src/Data/Managers/V2/Environment/ResetEnvironmentSetting/useResetEnvironmentSetting.ts
@@ -21,7 +21,7 @@ export const useResetEnvironmentSetting = (
     mutationFn: (id) => deleteFn(`/api/v2/environment_settings/${id}`),
     mutationKey: ["reset_environment_setting"],
     onSuccess: () => {
-      client.refetchQueries();
+      client.refetchQueries({ queryKey: ["get_environment_settings-one_time"] });
     },
     ...options,
   });

--- a/src/Data/Managers/V2/Environment/UpdateEnvironmentSetting/useUpdateEnvironmentSetting.ts
+++ b/src/Data/Managers/V2/Environment/UpdateEnvironmentSetting/useUpdateEnvironmentSetting.ts
@@ -29,7 +29,7 @@ export const useUpdateEnvironmentSetting = (
     mutationFn: ({ id, value }) => post(`/api/v2/environment_settings/${id}`, { value }),
     mutationKey: ["update_environment_setting"],
     onSuccess: () => {
-      queryClient.refetchQueries();
+      queryClient.refetchQueries({ queryKey: ["get_environment_settings-one_time"] });
     },
     ...options,
   });

--- a/src/Slices/Settings/UI/Tabs/Configuration/Provider.tsx
+++ b/src/Slices/Settings/UI/Tabs/Configuration/Provider.tsx
@@ -76,7 +76,7 @@ export const Provider: React.FC<Props> = ({ settings: { settings, definition } }
 
   const updateSetting = useUpdateEnvironmentSetting({
     onSuccess: () => {
-      client.refetchQueries();
+      client.refetchQueries({ queryKey: ["get_environment_settings-one_time"] });
       document.dispatchEvent(new Event("settings-update"));
       setErrorMessage("");
       setShowUpdateBanner(true);
@@ -90,7 +90,7 @@ export const Provider: React.FC<Props> = ({ settings: { settings, definition } }
   const resetSetting = useResetEnvironmentSetting({
     onSuccess: () => {
       setErrorMessage("");
-      client.refetchQueries();
+      client.refetchQueries({ queryKey: ["get_environment_settings-one_time"] });
     },
     onError: (error) => setErrorMessage(error.message),
   });

--- a/src/UI/Components/ExpertBanner/ExpertBanner.tsx
+++ b/src/UI/Components/ExpertBanner/ExpertBanner.tsx
@@ -4,6 +4,7 @@ import { useUpdateEnvironmentSetting } from "@/Data/Managers/V2/Environment";
 import { DependencyContext } from "@/UI/Dependency";
 import { words } from "@/UI/words";
 import { ToastAlert } from "../ToastAlert";
+import { useQueryClient } from "@tanstack/react-query";
 
 /**
  * A React component that displays a banner when the expert mode is enabled.
@@ -12,15 +13,20 @@ import { ToastAlert } from "../ToastAlert";
  * @returns { React.FC<Props> | null} The rendered banner if the expert mode is enabled, otherwise null.
  */
 export const ExpertBanner: React.FC = () => {
-  const [errorMessage, setMessage] = useState<string | undefined>(undefined);
   const { environmentModifier } = useContext(DependencyContext);
+  const queryClient = useQueryClient();
+  const [isLoading, setIsLoading] = useState(false);
+  const [errorMessage, setMessage] = useState<string | undefined>(undefined);
   const { mutate } = useUpdateEnvironmentSetting({
+    onSuccess: () => {
+      queryClient.refetchQueries();
+      setIsLoading(false);
+    },
     onError: (error) => {
       setMessage(error.message);
       setIsLoading(false);
     },
   });
-  const [isLoading, setIsLoading] = useState(false); // isLoading is to indicate the asynchronous operation is in progress, as we need to wait until setting will be updated, getters are still in the V1 - task https://github.com/inmanta/web-console/issues/5999
 
   return environmentModifier.useIsExpertModeEnabled() ? (
     <>

--- a/src/UI/Components/ExpertBanner/ExpertBanner.tsx
+++ b/src/UI/Components/ExpertBanner/ExpertBanner.tsx
@@ -14,6 +14,7 @@ import { ToastAlert } from "../ToastAlert";
 export const ExpertBanner: React.FC = () => {
   const { environmentModifier } = useContext(DependencyContext);
   const [isLoading, setIsLoading] = useState(false);
+  const expertModeEnabled = environmentModifier.useIsExpertModeEnabled();
   const [errorMessage, setMessage] = useState<string | undefined>(undefined);
   const { mutate } = useUpdateEnvironmentSetting({
     onError: (error) => {
@@ -24,9 +25,9 @@ export const ExpertBanner: React.FC = () => {
 
   useEffect(() => {
     setIsLoading(false); //changing it onSuccess doesn't necessarily mean that the expert mode is changed yet, the most reliable way is to check the value of the expert mode directly from the environmentModifier
-  }, [environmentModifier.useIsExpertModeEnabled()]);
+  }, [expertModeEnabled]);
 
-  return environmentModifier.useIsExpertModeEnabled() ? (
+  return expertModeEnabled ? (
     <>
       {errorMessage && (
         <ToastAlert

--- a/src/UI/Components/ExpertBanner/ExpertBanner.tsx
+++ b/src/UI/Components/ExpertBanner/ExpertBanner.tsx
@@ -1,10 +1,10 @@
 import React, { useContext, useState } from "react";
 import { Banner, Button, Flex, Spinner } from "@patternfly/react-core";
+import { useQueryClient } from "@tanstack/react-query";
 import { useUpdateEnvironmentSetting } from "@/Data/Managers/V2/Environment";
 import { DependencyContext } from "@/UI/Dependency";
 import { words } from "@/UI/words";
 import { ToastAlert } from "../ToastAlert";
-import { useQueryClient } from "@tanstack/react-query";
 
 /**
  * A React component that displays a banner when the expert mode is enabled.
@@ -19,7 +19,7 @@ export const ExpertBanner: React.FC = () => {
   const [errorMessage, setMessage] = useState<string | undefined>(undefined);
   const { mutate } = useUpdateEnvironmentSetting({
     onSuccess: () => {
-      queryClient.refetchQueries();
+      queryClient.refetchQueries({ queryKey: ["get_environment_settings-one_time"] });
       setIsLoading(false);
     },
     onError: (error) => {

--- a/src/UI/Components/ExpertBanner/ExpertBanner.tsx
+++ b/src/UI/Components/ExpertBanner/ExpertBanner.tsx
@@ -1,6 +1,5 @@
-import React, { useContext, useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import { Banner, Button, Flex, Spinner } from "@patternfly/react-core";
-import { useQueryClient } from "@tanstack/react-query";
 import { useUpdateEnvironmentSetting } from "@/Data/Managers/V2/Environment";
 import { DependencyContext } from "@/UI/Dependency";
 import { words } from "@/UI/words";
@@ -14,19 +13,18 @@ import { ToastAlert } from "../ToastAlert";
  */
 export const ExpertBanner: React.FC = () => {
   const { environmentModifier } = useContext(DependencyContext);
-  const queryClient = useQueryClient();
   const [isLoading, setIsLoading] = useState(false);
   const [errorMessage, setMessage] = useState<string | undefined>(undefined);
   const { mutate } = useUpdateEnvironmentSetting({
-    onSuccess: () => {
-      queryClient.refetchQueries({ queryKey: ["get_environment_settings-one_time"] });
-      setIsLoading(false);
-    },
     onError: (error) => {
       setMessage(error.message);
       setIsLoading(false);
     },
   });
+
+  useEffect(() => {
+    setIsLoading(false); //changing it onSuccess doesn't necessarily mean that the expert mode is changed yet, the most reliable way is to check the value of the expert mode directly from the environmentModifier
+  }, [environmentModifier.useIsExpertModeEnabled()]);
 
   return environmentModifier.useIsExpertModeEnabled() ? (
     <>

--- a/src/UI/Dependency/EnvironmentModifier.test.tsx
+++ b/src/UI/Dependency/EnvironmentModifier.test.tsx
@@ -27,11 +27,27 @@ describe("EnvironmentModifier", () => {
   );
 
   test("Given the environmentModifier When the server compile setting is requested Then returns the correct value", async () => {
+    let counter = 0;
     server.use(
       http.get("/api/v2/environment_settings", () => {
+        if (counter === 0) {
+          counter++;
+          return HttpResponse.json({
+            data: {
+              settings: {
+                enable_lsm_expert_mode: false,
+                server_compile: true,
+              },
+              definition: EnvironmentSettings.definition,
+            },
+          });
+        }
         return HttpResponse.json({
           data: {
-            settings: {},
+            settings: {
+              enable_lsm_expert_mode: false,
+              server_compile: false,
+            },
             definition: EnvironmentSettings.definition,
           },
         });
@@ -59,7 +75,9 @@ describe("EnvironmentModifier", () => {
       });
     });
 
-    expect(result.current.useIsServerCompileEnabled()).toBe(false);
+    await waitFor(() => {
+      expect(result.current.useIsServerCompileEnabled()).toBe(false);
+    });
   });
 
   test("given the environmentModifier When the missing setting is requested and the definition is not missing Then return definition default value", async () => {

--- a/src/UI/Dependency/EnvironmentModifier.tsx
+++ b/src/UI/Dependency/EnvironmentModifier.tsx
@@ -19,7 +19,12 @@ export function useEnvironmentModifierImpl(): EnvironmentModifier {
   const envSettings = useGetEnvironmentSettings(env?.id).useOneTime();
 
   function setEnvironment(environmentToSet: FlatEnvironment): void {
-    setEnv(environmentToSet);
+    setEnv((prev) => {
+      if (prev?.id === environmentToSet.id) {
+        envSettings.refetch();
+      }
+      return environmentToSet;
+    });
   }
 
   function useIsHalted(): boolean {
@@ -37,14 +42,13 @@ export function useEnvironmentModifierImpl(): EnvironmentModifier {
    * @returns {boolean}
    */
   function useSetting(settingName: keyof EnvironmentSettings.DefinitionMap): boolean {
-    if (env === null) return false;
-
-    if (env.settings[settingName] !== undefined && env.settings[settingName] !== null) {
-      return Boolean(env.settings[settingName]);
-    }
-
     if (envSettings.data) {
       if (
+        envSettings.data.settings[settingName] !== undefined &&
+        envSettings.data.settings[settingName] !== null
+      ) {
+        return Boolean(envSettings.data.settings[settingName]);
+      } else if (
         envSettings.data.definition[settingName] !== undefined &&
         envSettings.data.definition[settingName] !== null
       ) {

--- a/src/UI/Dependency/EnvironmentModifier.tsx
+++ b/src/UI/Dependency/EnvironmentModifier.tsx
@@ -19,12 +19,7 @@ export function useEnvironmentModifierImpl(): EnvironmentModifier {
   const envSettings = useGetEnvironmentSettings(env?.id).useOneTime();
 
   function setEnvironment(environmentToSet: FlatEnvironment): void {
-    setEnv((prev) => {
-      if (prev?.id === environmentToSet.id) {
-        envSettings.refetch();
-      }
-      return environmentToSet;
-    });
+    setEnv(environmentToSet);
   }
 
   function useIsHalted(): boolean {

--- a/src/UI/Dependency/EnvironmentModifier.tsx
+++ b/src/UI/Dependency/EnvironmentModifier.tsx
@@ -19,7 +19,12 @@ export function useEnvironmentModifierImpl(): EnvironmentModifier {
   const envSettings = useGetEnvironmentSettings(env?.id).useOneTime();
 
   function setEnvironment(environmentToSet: FlatEnvironment): void {
-    setEnv(environmentToSet);
+    setEnv((prev) => {
+      if (prev && prev.id === environmentToSet.id && !envSettings.isPending) {
+        envSettings.refetch(); //env could get updated without env.id changing, so we need to refetch the envSettings to get the latest data - solution until GraphQL is implemented
+      }
+      return environmentToSet;
+    });
   }
 
   function useIsHalted(): boolean {


### PR DESCRIPTION
# Description

Fix banner flickering with direct access to settings from the useGetSettings which get refetch on env change/update, provides smoother experience

Fix loading icon from staying after expertMode is disabled from the banner itself

closes #6345 

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Code is clear and sufficiently documented
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
