### PR TITLE
6347 - fail on warnings and errors in test logs

### DIFF
--- a/changelogs/unreleased/6347-improve-build-checks-jest.yml
+++ b/changelogs/unreleased/6347-improve-build-checks-jest.yml
@@ -1,0 +1,6 @@
+description: Improve build checks in Jest to fail tests on console.error and console.warn.
+issue-nr: 6347
+change-type: patch
+destination-branches: [master, iso8]
+sections:
+  minor-improvement: "{{description}}"

--- a/jestSetupAfterEnv.js
+++ b/jestSetupAfterEnv.js
@@ -8,3 +8,77 @@ import "@testing-library/jest-dom";
 jest.setTimeout(10000);
 //JointJS mock to make library work
 window.SVGAngle = jest.fn();
+
+// Collect console warnings and errors
+const consoleIssues = [];
+
+// Store original console methods to restore them later
+const originalWarn = console.warn;
+const originalError = console.error;
+
+// Setup console spies
+jest.spyOn(console, "warn").mockImplementation((...args) => {
+  // Format the args for better readability
+  const formattedArgs = args.map((arg) => {
+    if (typeof arg === "object" && arg !== null) {
+      try {
+        return JSON.stringify(arg, null, 2);
+      } catch (_error) {
+        return `[${typeof arg}: Circular or complex object]`;
+      }
+    }
+    return String(arg);
+  });
+
+  consoleIssues.push({
+    type: "warn",
+    message: formattedArgs.join(" "),
+  });
+
+  // Call original implementation
+  originalWarn.apply(console, args);
+});
+
+jest.spyOn(console, "error").mockImplementation((...args) => {
+  // Format the args for better readability
+  const formattedArgs = args.map((arg) => {
+    if (typeof arg === "object" && arg !== null) {
+      try {
+        return JSON.stringify(arg, null, 2);
+      } catch (_error) {
+        return `[${typeof arg}: Circular or complex object]`;
+      }
+    }
+    return String(arg);
+  });
+
+  consoleIssues.push({
+    type: "error",
+    message: formattedArgs.join(" "),
+  });
+
+  // Call original implementation
+  originalError.apply(console, args);
+});
+
+// Check for issues after all tests have completed
+afterAll(() => {
+  // Clear the console spy mocks after all tests
+  console.warn.mockClear();
+  console.error.mockClear();
+
+  // Fail if any console warnings or errors were detected during test execution
+  if (consoleIssues.length > 0) {
+    const summary = consoleIssues
+      .map(({ type, message }) => {
+        const color = type === "warn" ? "\x1b[33m" : "\x1b[31m"; // Yellow for warnings, red for errors
+        return `${color}${type.toUpperCase()}: \n${message}\x1b[0m`; // Reset color at end
+      })
+      .join("\n\n");
+
+    consoleIssues.length = 0; // Clear for next test run
+    throw new Error(
+      `\x1b[31mFAILURE: Tests produced the following console warnings/errors:\n\n${summary}\x1b[0m`
+    );
+  }
+});

--- a/jestSetupAfterEnv.js
+++ b/jestSetupAfterEnv.js
@@ -16,23 +16,27 @@ const consoleIssues = [];
 const originalWarn = console.warn;
 const originalError = console.error;
 
+// Helper function to format console args
+const formatConsoleArgs = (args) => {
+  return args
+    .map((arg) => {
+      if (typeof arg === "object" && arg !== null) {
+        try {
+          return JSON.stringify(arg, null, 2);
+        } catch (_error) {
+          return `[${typeof arg}: Circular or complex object]`;
+        }
+      }
+      return String(arg);
+    })
+    .join(" ");
+};
+
 // Setup console spies
 jest.spyOn(console, "warn").mockImplementation((...args) => {
-  // Format the args for better readability
-  const formattedArgs = args.map((arg) => {
-    if (typeof arg === "object" && arg !== null) {
-      try {
-        return JSON.stringify(arg, null, 2);
-      } catch (_error) {
-        return `[${typeof arg}: Circular or complex object]`;
-      }
-    }
-    return String(arg);
-  });
-
   consoleIssues.push({
     type: "warn",
-    message: formattedArgs.join(" "),
+    message: formatConsoleArgs(args),
   });
 
   // Call original implementation
@@ -40,21 +44,9 @@ jest.spyOn(console, "warn").mockImplementation((...args) => {
 });
 
 jest.spyOn(console, "error").mockImplementation((...args) => {
-  // Format the args for better readability
-  const formattedArgs = args.map((arg) => {
-    if (typeof arg === "object" && arg !== null) {
-      try {
-        return JSON.stringify(arg, null, 2);
-      } catch (_error) {
-        return `[${typeof arg}: Circular or complex object]`;
-      }
-    }
-    return String(arg);
-  });
-
   consoleIssues.push({
     type: "error",
-    message: formattedArgs.join(" "),
+    message: formatConsoleArgs(args),
   });
 
   // Call original implementation

--- a/jestSetupAfterEnv.js
+++ b/jestSetupAfterEnv.js
@@ -77,8 +77,14 @@ afterAll(() => {
       .join("\n\n");
 
     consoleIssues.length = 0; // Clear for next test run
-    throw new Error(
-      `\x1b[31mFAILURE: Tests produced the following console warnings/errors:\n\n${summary}\x1b[0m`
-    );
+
+    // Create error object with custom message
+    const errorMessage = `\x1b[31mFAILURE: Tests produced the following console warnings/errors:\n\n${summary}\x1b[0m`;
+    const error = new Error(errorMessage);
+
+    // Remove this file from the stack trace
+    Error.captureStackTrace(error, afterAll);
+
+    throw error;
   }
 });


### PR DESCRIPTION
# Description

Implement a tracker in Jest configuration for warnings and error messages. If any are present, they will be printed at the end of the tests. 
The failure is on the full test suite that ran. This is to avoid masking the output of individual test cases. 

closes #6347 

preview of what the failure would look like when msw catches an unhandled http call:

![image](https://github.com/user-attachments/assets/bbc9f54f-e15e-4690-a6bb-36927cb45149)



