### PR TITLE
adjust codeEditor based on feedback

### DIFF
--- a/__mocks__/@patternfly/react-code-editor.js
+++ b/__mocks__/@patternfly/react-code-editor.js
@@ -12,6 +12,7 @@ module.exports = {
     isDownloadEnabled,
     isCopyEnabled,
     isLanguageLabelVisible,
+    customControls,
     ...props
   }) => {
     return (
@@ -19,6 +20,7 @@ module.exports = {
         <pre data-testid="code-editor-content" {...props}>
           {code}
         </pre>
+        {customControls && <div data-testid="code-editor-custom-controls">{customControls}</div>}
         {onChange && (
           <textarea
             data-testid="code-editor-textarea"
@@ -30,8 +32,13 @@ module.exports = {
       </div>
     );
   },
-  CodeEditorControl: ({ onClick, icon, "aria-label": ariaLabel, ...props }) => (
-    <button onClick={onClick} aria-label={ariaLabel} {...props}>
+  CodeEditorControl: ({ onClick, icon, "aria-label": ariaLabel, tooltipProps, ...props }) => (
+    <button
+      onClick={onClick}
+      aria-label={ariaLabel}
+      data-tooltip={tooltipProps?.content}
+      {...props}
+    >
       {icon}
     </button>
   ),

--- a/changelogs/unreleased/6366-adjust-codeEditor.yml
+++ b/changelogs/unreleased/6366-adjust-codeEditor.yml
@@ -1,0 +1,4 @@
+description: Adjust the CodeEditor based on UX feedback.
+issue-nr: 6366
+change-type: patch
+destination-branches: [master, iso8]

--- a/src/Slices/CompileDetails/UI/CompileStageReportTable.tsx
+++ b/src/Slices/CompileDetails/UI/CompileStageReportTable.tsx
@@ -24,7 +24,9 @@ export const CompileStageReportTable: React.FC<Props> = ({ reports }) => {
     };
   });
 
-  return <LogViewerComponent logs={logs} />;
+  const defaultSelected = logs.find((log) => log.failed)?.id;
+
+  return <LogViewerComponent logs={logs} defaultSelected={defaultSelected} />;
 };
 
 /**

--- a/src/Slices/Diagnose/UI/Traceback.tsx
+++ b/src/Slices/Diagnose/UI/Traceback.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { CodeEditor, Language } from "@patternfly/react-code-editor";
 import { ExpandableSection } from "@patternfly/react-core";
 import { words } from "@/UI/words";
+import { CodeEditorCopyControl } from "@/UI/Components/CodeEditorControls";
 
 /**
  * A component that displays a traceback.
@@ -17,7 +18,7 @@ export const Traceback: React.FC<{ trace: string }> = ({ trace }) => {
         language={Language.python}
         isReadOnly
         isDownloadEnabled
-        isCopyEnabled
+        customControls={<CodeEditorCopyControl code={trace} />}
         height="400px"
       />
     </ExpandableSection>

--- a/src/Slices/Diagnose/UI/Traceback.tsx
+++ b/src/Slices/Diagnose/UI/Traceback.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { CodeEditor, Language } from "@patternfly/react-code-editor";
 import { ExpandableSection } from "@patternfly/react-core";
-import { words } from "@/UI/words";
 import { CodeEditorCopyControl } from "@/UI/Components/CodeEditorControls";
+import { words } from "@/UI/words";
 
 /**
  * A component that displays a traceback.

--- a/src/Slices/MarkdownPreviewer/UI/MarkdownCodeEditorControls.test.tsx
+++ b/src/Slices/MarkdownPreviewer/UI/MarkdownCodeEditorControls.test.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
+import copy from "copy-to-clipboard";
 import { words } from "@/UI/words";
 import { MarkdownCodeEditorControls, escapeNewlines } from "./MarkdownCodeEditorControls";
-import copy from "copy-to-clipboard";
 
 // Mock the PatternFly CodeEditorControl component since all we want to test is the onClick event.
 // The original component relies on the Monaco Editor which is not available in the test environment.

--- a/src/Slices/MarkdownPreviewer/UI/MarkdownCodeEditorControls.test.tsx
+++ b/src/Slices/MarkdownPreviewer/UI/MarkdownCodeEditorControls.test.tsx
@@ -1,12 +1,8 @@
 import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { words } from "@/UI/words";
-import { CodeEditorControls, escapeNewlines } from "./CodeEditorControls";
-
-// Mock the clipboard API
-const mockClipboard = {
-  writeText: jest.fn(),
-};
+import { MarkdownCodeEditorControls, escapeNewlines } from "./MarkdownCodeEditorControls";
+import copy from "copy-to-clipboard";
 
 // Mock the PatternFly CodeEditorControl component since all we want to test is the onClick event.
 // The original component relies on the Monaco Editor which is not available in the test environment.
@@ -18,11 +14,8 @@ jest.mock("@patternfly/react-code-editor", () => ({
   ),
 }));
 
-beforeAll(() => {
-  Object.assign(navigator, {
-    clipboard: mockClipboard,
-  });
-});
+// Mock copy-to-clipboard
+jest.mock("copy-to-clipboard", () => jest.fn());
 
 afterEach(() => {
   jest.clearAllMocks();
@@ -36,7 +29,7 @@ describe("CodeEditorControls", () => {
   };
 
   it("should render all control buttons", () => {
-    render(<CodeEditorControls {...defaultProps} />);
+    render(<MarkdownCodeEditorControls {...defaultProps} />);
 
     expect(screen.getByTestId("control-Copy")).toBeInTheDocument();
     expect(screen.getByTestId("control-Copy raw")).toBeInTheDocument();
@@ -46,21 +39,21 @@ describe("CodeEditorControls", () => {
   });
 
   it("should copy markdown content when copy button is clicked", () => {
-    render(<CodeEditorControls {...defaultProps} />);
+    render(<MarkdownCodeEditorControls {...defaultProps} />);
 
     const copyButton = screen.getByTestId("control-Copy");
     fireEvent.click(copyButton);
 
-    expect(mockClipboard.writeText).toHaveBeenCalledWith(defaultProps.code);
+    expect(copy).toHaveBeenCalledWith(defaultProps.code);
   });
 
   it("should copy raw markdown content with escaped newlines when raw copy button is clicked", () => {
-    render(<CodeEditorControls {...defaultProps} />);
+    render(<MarkdownCodeEditorControls {...defaultProps} />);
 
     const rawCopyButton = screen.getByTestId("control-Copy raw");
     fireEvent.click(rawCopyButton);
 
-    expect(mockClipboard.writeText).toHaveBeenCalledWith("# Test Markdown\\n\\nThis is a test");
+    expect(copy).toHaveBeenCalledWith("# Test Markdown\\n\\nThis is a test");
   });
 });
 

--- a/src/Slices/MarkdownPreviewer/UI/MarkdownCodeEditorControls.tsx
+++ b/src/Slices/MarkdownPreviewer/UI/MarkdownCodeEditorControls.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { CodeEditorControl } from "@patternfly/react-code-editor";
 import { CopyIcon, DownloadIcon, CodeIcon } from "@patternfly/react-icons";
-import { words } from "@/UI/words";
 import copy from "copy-to-clipboard";
+import { words } from "@/UI/words";
 
 interface Props {
   code: string;

--- a/src/Slices/MarkdownPreviewer/UI/MarkdownCodeEditorControls.tsx
+++ b/src/Slices/MarkdownPreviewer/UI/MarkdownCodeEditorControls.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { CodeEditorControl } from "@patternfly/react-code-editor";
 import { CopyIcon, DownloadIcon, CodeIcon } from "@patternfly/react-icons";
 import { words } from "@/UI/words";
+import copy from "copy-to-clipboard";
 
 interface Props {
   code: string;
@@ -49,7 +50,7 @@ export const escapeNewlines = (text: string): string => {
  *  @prop {string} instance - The instance name
  * @returns {React.FC<Props>} A React Component that provides the controls for the CodeEditor.
  */
-export const CodeEditorControls: React.FC<Props> = ({ code, service, instance }) => {
+export const MarkdownCodeEditorControls: React.FC<Props> = ({ code, service, instance }) => {
   return (
     <>
       <CodeEditorControl
@@ -57,7 +58,7 @@ export const CodeEditorControls: React.FC<Props> = ({ code, service, instance })
         aria-label={words("copy")}
         tooltipProps={{ content: words("copy") }}
         onClick={() => {
-          navigator.clipboard.writeText(code);
+          copy(code);
         }}
       />
       <CodeEditorControl
@@ -65,7 +66,7 @@ export const CodeEditorControls: React.FC<Props> = ({ code, service, instance })
         aria-label={words("copy.raw")}
         tooltipProps={{ content: words("copy.raw.tooltip") }}
         onClick={() => {
-          navigator.clipboard.writeText(escapeNewlines(code));
+          copy(escapeNewlines(code));
         }}
       />
       <CodeEditorControl

--- a/src/Slices/MarkdownPreviewer/UI/MarkdownPreviewer.tsx
+++ b/src/Slices/MarkdownPreviewer/UI/MarkdownPreviewer.tsx
@@ -6,7 +6,7 @@ import { MarkdownCard } from "@/Slices/ServiceInventory/UI/Tabs/MarkdownCard";
 import { PageContainer } from "@/UI/Components";
 import { getThemePreference } from "@/UI/Components/DarkmodeOption";
 import { words } from "@/UI/words";
-import { CodeEditorControls, useDocumentationContent } from ".";
+import { MarkdownCodeEditorControls, useDocumentationContent } from ".";
 
 interface Props {
   service: string;
@@ -60,7 +60,11 @@ export const MarkdownPreviewer: React.FC<Props> = ({ service, instance, instance
             height="calc(100vh - 550px)"
             onChange={setMarkdownContent}
             customControls={
-              <CodeEditorControls code={markdownContent} service={service} instance={instance} />
+              <MarkdownCodeEditorControls
+                code={markdownContent}
+                service={service}
+                instance={instance}
+              />
             }
           />
         </FlexItem>

--- a/src/Slices/MarkdownPreviewer/UI/index.ts
+++ b/src/Slices/MarkdownPreviewer/UI/index.ts
@@ -1,4 +1,4 @@
 export { Page as MarkdownPreviewerPage } from "./Page";
 export * from "./MarkdownPreviewer";
-export * from "./CodeEditorControls";
+export * from "./MarkdownCodeEditorControls";
 export * from "./DocumentationContent";

--- a/src/Slices/OrderDetails/UI/OrderDetailsRow.tsx
+++ b/src/Slices/OrderDetails/UI/OrderDetailsRow.tsx
@@ -16,6 +16,7 @@ import { TextWithCopy, Toggle } from "@/UI/Components";
 import { words } from "@/UI/words";
 import { OrderDependencies } from "./OrderDependencies";
 import { OrderStateDetails } from "./OrderStateDetails";
+import { CodeEditorCopyControl } from "@/UI/Components/CodeEditorControls";
 
 interface Props {
   row: ServiceOrderItem;
@@ -90,7 +91,9 @@ export const OrderDetailsRow: React.FC<Props> = ({
                       code={JSON.stringify(row.config, null, 2)}
                       language={Language.json}
                       isDownloadEnabled
-                      isCopyEnabled
+                      customControls={
+                        <CodeEditorCopyControl code={JSON.stringify(row.config, null, 2)} />
+                      }
                       isReadOnly
                       height="400px"
                     />
@@ -109,7 +112,12 @@ export const OrderDetailsRow: React.FC<Props> = ({
                       code={JSON.stringify(row.attributes || row.edits, null, 2)}
                       language={Language.json}
                       isDownloadEnabled
-                      isCopyEnabled
+                      customControls={
+                        <CodeEditorCopyControl
+                          code={JSON.stringify(row.attributes || row.edits, null, 2)}
+                        />
+                      }
+                      isReadOnly
                       height="400px"
                     />
                   </DescriptionListDescription>

--- a/src/Slices/OrderDetails/UI/OrderDetailsRow.tsx
+++ b/src/Slices/OrderDetails/UI/OrderDetailsRow.tsx
@@ -13,10 +13,10 @@ import styled from "styled-components";
 import { ServiceOrderItem } from "@/Slices/Orders/Core/Query";
 import { OrderStatusLabel } from "@/Slices/Orders/UI/OrderStatusLabel";
 import { TextWithCopy, Toggle } from "@/UI/Components";
+import { CodeEditorCopyControl } from "@/UI/Components/CodeEditorControls";
 import { words } from "@/UI/words";
 import { OrderDependencies } from "./OrderDependencies";
 import { OrderStateDetails } from "./OrderStateDetails";
-import { CodeEditorCopyControl } from "@/UI/Components/CodeEditorControls";
 
 interface Props {
   row: ServiceOrderItem;

--- a/src/Slices/ResourceDiscovery/UI/DiscoveredResourcesRow.tsx
+++ b/src/Slices/ResourceDiscovery/UI/DiscoveredResourcesRow.tsx
@@ -12,6 +12,7 @@ import { DiscoveredResource } from "@/Data/Managers/V2/DiscoveredResources";
 import { Toggle } from "@/UI/Components";
 import { words } from "@/UI/words";
 import { DiscoveredResourceLink } from "./Components";
+import { CodeEditorCopyControl } from "@/UI/Components/CodeEditorControls";
 
 interface Props {
   row: DiscoveredResource;
@@ -70,7 +71,9 @@ export const DiscoveredResourceRow: React.FC<Props> = ({
                       code={JSON.stringify(row.values, null, 2)}
                       language={Language.json}
                       isDownloadEnabled
-                      isCopyEnabled
+                      customControls={
+                        <CodeEditorCopyControl code={JSON.stringify(row.values, null, 2)} />
+                      }
                       isReadOnly
                       height="400px"
                     />

--- a/src/Slices/ResourceDiscovery/UI/DiscoveredResourcesRow.tsx
+++ b/src/Slices/ResourceDiscovery/UI/DiscoveredResourcesRow.tsx
@@ -10,9 +10,9 @@ import { Tbody, Tr, Td } from "@patternfly/react-table";
 import styled from "styled-components";
 import { DiscoveredResource } from "@/Data/Managers/V2/DiscoveredResources";
 import { Toggle } from "@/UI/Components";
+import { CodeEditorCopyControl } from "@/UI/Components/CodeEditorControls";
 import { words } from "@/UI/words";
 import { DiscoveredResourceLink } from "./Components";
-import { CodeEditorCopyControl } from "@/UI/Components/CodeEditorControls";
 
 interface Props {
   row: DiscoveredResource;

--- a/src/UI/Components/CodeEditorControls/CodeEditorControls.test.tsx
+++ b/src/UI/Components/CodeEditorControls/CodeEditorControls.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
-import { CodeEditorCopyControl } from "./CodeEditorControls";
 import copy from "copy-to-clipboard";
+import { CodeEditorCopyControl } from "./CodeEditorControls";
 
 // Mock copy-to-clipboard
 jest.mock("copy-to-clipboard", () => jest.fn());

--- a/src/UI/Components/CodeEditorControls/CodeEditorControls.test.tsx
+++ b/src/UI/Components/CodeEditorControls/CodeEditorControls.test.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { CodeEditorCopyControl } from "./CodeEditorControls";
+import copy from "copy-to-clipboard";
+
+// Mock copy-to-clipboard
+jest.mock("copy-to-clipboard", () => jest.fn());
+
+// Mock the PatternFly CodeEditorControl component
+jest.mock("@patternfly/react-code-editor", () => ({
+  CodeEditorControl: ({ onClick, icon, "aria-label": ariaLabel }) => (
+    <button onClick={onClick} aria-label={ariaLabel} data-testid={`control-${ariaLabel}`}>
+      {icon}
+    </button>
+  ),
+}));
+
+describe("CodeEditorCopyControl", () => {
+  const defaultProps = {
+    code: "const test = 'Hello World';",
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should render the copy button", () => {
+    render(<CodeEditorCopyControl {...defaultProps} />);
+    expect(screen.getByTestId("control-Copy")).toBeInTheDocument();
+  });
+
+  it("should copy code when copy button is clicked", () => {
+    render(<CodeEditorCopyControl {...defaultProps} />);
+
+    const copyButton = screen.getByTestId("control-Copy");
+    fireEvent.click(copyButton);
+
+    expect(copy).toHaveBeenCalledWith(defaultProps.code);
+  });
+});

--- a/src/UI/Components/CodeEditorControls/CodeEditorControls.tsx
+++ b/src/UI/Components/CodeEditorControls/CodeEditorControls.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { CodeEditorControl } from "@patternfly/react-code-editor";
+import { CopyIcon } from "@patternfly/react-icons";
+import copy from "copy-to-clipboard";
+import { words } from "@/UI/words";
+
+interface Props {
+  code: string;
+}
+
+/**
+ * The CodeEditorCopyControl Component
+ *
+ * @props {Props} props - The props of the component.
+ *  @prop {string} code - The code content
+ *
+ * @note We can't use the default copy control from the codeEditor component,
+ * because it uses navigator.clipboard which is not available on http, only on secure origins.
+ *
+ * @returns {React.FC<Props>} A React Component that provides the copy control for the CodeEditor.
+ */
+export const CodeEditorCopyControl: React.FC<Props> = ({ code }) => {
+  return (
+    <CodeEditorControl
+      icon={<CopyIcon />}
+      aria-label={words("copy")}
+      tooltipProps={{ content: words("copy") }}
+      onClick={() => {
+        copy(code);
+      }}
+    />
+  );
+};

--- a/src/UI/Components/CodeEditorControls/index.ts
+++ b/src/UI/Components/CodeEditorControls/index.ts
@@ -1,0 +1,1 @@
+export * from "./CodeEditorControls";

--- a/src/UI/Components/DesiredStateAttributes/AttributeList.test.tsx
+++ b/src/UI/Components/DesiredStateAttributes/AttributeList.test.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
 import { AttributeList, getHeightEditor } from "./AttributeList";
-import { attributes, classified } from "./Data";
 import { ClassifiedAttribute } from "./ClassifiedAttribute";
+import { attributes, classified } from "./Data";
 
 test("Given the AttributeList component When rendered with the monospace variant Then the font-family is correct", async () => {
   render(<AttributeList attributes={classified} variant="monospace" />);

--- a/src/UI/Components/DesiredStateAttributes/AttributeList.test.tsx
+++ b/src/UI/Components/DesiredStateAttributes/AttributeList.test.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
-import { AttributeList } from "./AttributeList";
+import { AttributeList, getHeightEditor } from "./AttributeList";
 import { attributes, classified } from "./Data";
+import { ClassifiedAttribute } from "./ClassifiedAttribute";
 
 test("Given the AttributeList component When rendered with the monospace variant Then the font-family is correct", async () => {
   render(<AttributeList attributes={classified} variant="monospace" />);
@@ -11,4 +12,104 @@ test("Given the AttributeList component When rendered with the monospace variant
   const multiLineValue = await screen.findByText(attributes["f"]);
 
   expect(multiLineValue).toHaveStyle("font-family:  var(--pf-t--global--font--family--mono)");
+});
+
+test("Given the getHeightEditor function When called with different attribute types Then returns correct height for each type", async () => {
+  const testCases = [
+    {
+      type: "Json",
+      description: "short JSON content",
+      attribute: {
+        kind: "Json",
+        key: "jsonShort",
+        value: '{\n  "name": "test",\n  "value": 123\n}',
+      },
+      expected: "sizeToFit",
+    },
+    {
+      type: "Json",
+      description: "long JSON content",
+      attribute: {
+        kind: "Json",
+        key: "jsonLong",
+        value: "{\n" + Array(20).fill('  "key": "value",').join("\n") + "\n}",
+      },
+      expected: "300px",
+    },
+    {
+      type: "Xml",
+      description: "short XML content",
+      attribute: {
+        kind: "Xml",
+        key: "xmlShort",
+        value: "<root>\n  <element>value</element>\n</root>",
+      },
+      expected: "sizeToFit",
+    },
+    {
+      type: "Xml",
+      description: "long XML content",
+      attribute: {
+        kind: "Xml",
+        key: "xmlLong",
+        value: "<root>\n" + Array(20).fill("  <item>value</item>").join("\n") + "\n</root>",
+      },
+      expected: "300px",
+    },
+    {
+      type: "Python",
+      description: "short Python code",
+      attribute: {
+        kind: "Python",
+        key: "pythonShort",
+        value: "def hello():\n  print('Hello, world!')\n\nhello()",
+      },
+      expected: "sizeToFit",
+    },
+    {
+      type: "Python",
+      description: "long Python code",
+      attribute: {
+        kind: "Python",
+        key: "pythonLong",
+        value: "# Long Python code\n" + Array(20).fill("print('Line of code')").join("\n"),
+      },
+      expected: "300px",
+    },
+    {
+      type: "Code",
+      description: "short generic code",
+      attribute: {
+        kind: "Code",
+        key: "codeShort",
+        value: "function test() {\n  return true;\n}",
+      },
+      expected: "sizeToFit",
+    },
+    {
+      type: "Code",
+      description: "long generic code",
+      attribute: {
+        kind: "Code",
+        key: "codeLong",
+        value: "// Long code\n" + Array(20).fill("console.log('test');").join("\n"),
+      },
+      expected: "300px",
+    },
+    {
+      type: "SingleLine",
+      description: "non-code type",
+      attribute: {
+        kind: "SingleLine",
+        key: "text",
+        value: "This is just a regular text value",
+      },
+      expected: "sizeToFit",
+    },
+  ];
+
+  testCases.forEach(({ attribute, expected }) => {
+    const height = getHeightEditor(attribute as ClassifiedAttribute);
+    expect(height).toBe(expected);
+  });
 });

--- a/src/UI/Components/DesiredStateAttributes/AttributeList.tsx
+++ b/src/UI/Components/DesiredStateAttributes/AttributeList.tsx
@@ -12,6 +12,7 @@ import styled from "styled-components";
 import { TextWithCopy } from "@/UI/Components/TextWithCopy";
 import { ClassifiedAttribute } from "./ClassifiedAttribute";
 import { FileBlock } from "./FileBlock";
+import { CodeEditorCopyControl } from "../CodeEditorControls";
 
 interface Props {
   attributes: ClassifiedAttribute[];
@@ -80,8 +81,8 @@ const AttributeValue: React.FC<{
           isLanguageLabelVisible
           language={Language.json}
           isDownloadEnabled
-          isCopyEnabled
-          height="300px"
+          customControls={<CodeEditorCopyControl code={attribute.value} />}
+          height={getHeightEditor(attribute)}
         />
       );
 
@@ -93,8 +94,8 @@ const AttributeValue: React.FC<{
           isLanguageLabelVisible
           language={Language.xml}
           isDownloadEnabled
-          isCopyEnabled
-          height="300px"
+          customControls={<CodeEditorCopyControl code={attribute.value} />}
+          height={getHeightEditor(attribute)}
         />
       );
     case "Python":
@@ -105,8 +106,8 @@ const AttributeValue: React.FC<{
           isLanguageLabelVisible
           language={Language.python}
           isDownloadEnabled
-          isCopyEnabled
-          height="300px"
+          customControls={<CodeEditorCopyControl code={attribute.value} />}
+          height={getHeightEditor(attribute)}
         />
       );
     case "Code":
@@ -126,3 +127,21 @@ const TextContainer = styled.span<{ $variant?: AttributeTextVariant }>`
       ? "font-family: var(--pf-t--global--font--family--mono)"
       : "inherit"};
 `;
+
+/**
+ * Determines the height for code editors based on content length
+ * @param attribute The attribute to determine height for
+ * @returns "300px" if lines > 15, otherwise "sizeToFit"
+ */
+export const getHeightEditor = (attribute: ClassifiedAttribute): string => {
+  if (
+    attribute.kind === "Json" ||
+    attribute.kind === "Xml" ||
+    attribute.kind === "Python" ||
+    attribute.kind === "Code"
+  ) {
+    const lineCount = attribute.value.split("\n").length;
+    return lineCount > 15 ? "300px" : "sizeToFit";
+  }
+  return "sizeToFit";
+};

--- a/src/UI/Components/DesiredStateAttributes/AttributeList.tsx
+++ b/src/UI/Components/DesiredStateAttributes/AttributeList.tsx
@@ -10,9 +10,9 @@ import {
 import { OutlinedQuestionCircleIcon } from "@patternfly/react-icons";
 import styled from "styled-components";
 import { TextWithCopy } from "@/UI/Components/TextWithCopy";
+import { CodeEditorCopyControl } from "../CodeEditorControls";
 import { ClassifiedAttribute } from "./ClassifiedAttribute";
 import { FileBlock } from "./FileBlock";
-import { CodeEditorCopyControl } from "../CodeEditorControls";
 
 interface Props {
   attributes: ClassifiedAttribute[];

--- a/src/UI/Components/LogViewer/LogViewer.test.tsx
+++ b/src/UI/Components/LogViewer/LogViewer.test.tsx
@@ -31,47 +31,49 @@ describe("LogViewerComponent", () => {
     render(<LogViewerComponent logs={mockLogs} />);
 
     // Check if first log name is displayed in select
-    expect(screen.getByRole("button", { name: /Log 1/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Failed Log/i })).toBeInTheDocument();
 
     // Check if log content is displayed
     const logViewer = screen.getByTestId("log-viewer");
-    expect(logViewer).toHaveTextContent("Line 1");
-    expect(logViewer).toHaveTextContent("Line 2");
-    expect(logViewer).toHaveTextContent("Line 3");
+    expect(logViewer).toHaveTextContent("Error line 1");
+    expect(logViewer).toHaveTextContent("Error line 2");
 
     // Check if duration is displayed
-    expect(screen.getByText(/Duration: 1 s/)).toBeInTheDocument();
+    expect(screen.getByText(/Duration: 20 s/)).toBeInTheDocument();
   });
 
   it("switches between logs when selecting from dropdown", async () => {
     render(<LogViewerComponent logs={mockLogs} />);
 
     // Open dropdown
-    const toggle = screen.getByRole("button", { name: /Log 1/i });
+    const toggle = screen.getByRole("button", { name: /Failed Log/i });
     await userEvent.click(toggle);
 
     // Select second log
-    const option = screen.getByRole("option", { name: /Failed Log/i });
+    const option = screen.getByRole("option", { name: /Log 1/i });
     await userEvent.click(option);
 
     // Check if new log content is displayed
     const logViewer = screen.getByTestId("log-viewer");
-    expect(logViewer).toHaveTextContent("Error line 1");
-    expect(logViewer).toHaveTextContent("Error line 2");
-    expect(screen.getByText(/Duration: 20 s/)).toBeInTheDocument();
+    expect(logViewer).toHaveTextContent("Line 1");
+    expect(logViewer).toHaveTextContent("Line 2");
+    expect(logViewer).toHaveTextContent("Line 3");
+    expect(screen.getByText(/Duration: 1 s/)).toBeInTheDocument();
   });
 
   it("shows error icon for failed logs", async () => {
     render(<LogViewerComponent logs={mockLogs} />);
 
-    // Open dropdown
-    const toggle = screen.getByRole("button", { name: /Log 1/i });
-    await userEvent.click(toggle);
-
-    // Find the failed log option and check for icon
-    const failedLogOption = screen.getByRole("option", { name: /Failed Log/i });
-    const icon = failedLogOption.querySelector(".pf-v6-c-icon__content.pf-m-danger");
+    // Check for error icon in toggle button
+    const toggle = screen.getByRole("button", { name: /Failed Log/i });
+    const icon = toggle.querySelector(".pf-v6-c-icon__content.pf-m-danger");
     expect(icon).toBeInTheDocument();
+
+    // Open dropdown and check icon in option
+    await userEvent.click(toggle);
+    const failedLogOption = screen.getByRole("option", { name: /Failed Log/i });
+    const optionIcon = failedLogOption.querySelector(".pf-v6-c-icon__content.pf-m-danger");
+    expect(optionIcon).toBeInTheDocument();
   });
 
   it("toggles auto-scroll when pause/resume button is clicked", async () => {

--- a/src/UI/Components/LogViewer/LogViewer.tsx
+++ b/src/UI/Components/LogViewer/LogViewer.tsx
@@ -29,15 +29,24 @@ export interface LogViewerData {
 
 interface LogViewerProps {
   logs: LogViewerData[];
+  defaultSelected?: string;
 }
 
 /**
  * LogViewer component displays logs with a dropdown to select log parts and a download button.
  * Uses PatternFly's LogViewer for rendering logs.
- * @param logs Array of log objects, each with data, id, name, duration, and failed status.
+ *
+ * @prop {LogViewerData[]} logs - Array of log objects, each with data, id, name, duration, and failed status.
+ * @prop {string} defaultSelected - The id of the log to select by default.
+ *
+ * @note If the defaultSelected log is not found in the logs array, the last log will be selected.
+ *
+ * @returns {React.FC<LogViewerProps>} LogViewer component
  */
-export const LogViewerComponent: React.FC<LogViewerProps> = ({ logs }) => {
-  const [selectedLogId, setSelectedLogId] = useState(logs[0]?.id || "");
+export const LogViewerComponent: React.FC<LogViewerProps> = ({ logs, defaultSelected }) => {
+  const [selectedLogId, setSelectedLogId] = useState(
+    defaultSelected || logs[logs.length - 1]?.id || ""
+  );
   const [selectOpen, setSelectOpen] = useState(false);
   const [isPaused, setIsPaused] = useState(false);
   const logViewerRef = useRef<HTMLDivElement>(null);
@@ -72,6 +81,11 @@ export const LogViewerComponent: React.FC<LogViewerProps> = ({ logs }) => {
       onClick={() => setSelectOpen((open) => !open)}
       isExpanded={selectOpen}
     >
+      {selectedLog?.failed && (
+        <Icon status="danger">
+          <ExclamationCircleIcon />
+        </Icon>
+      )}
       {selectedLog?.name || words("logViewer.selectLog")}
     </MenuToggle>
   );

--- a/src/UI/Styles/Global.ts
+++ b/src/UI/Styles/Global.ts
@@ -70,7 +70,12 @@ export const GlobalStyles = createGlobalStyle`
     min-width: 180px;
   }
 
-
+  .pf-v6-c-code-editor__main,
+  .pf-v6-c-code-editor__main .monaco-editor,
+  .monaco-editor .margin {
+    --vscode-editor-background: var(--pf-t--global--background--color--primary--default) !important;
+    background-color: var(--pf-t--global--background--color--primary--default) !important;
+  }
 
   ${MarkdownStyles}
 `;


### PR DESCRIPTION
# Description

- Replaced the copy button provided by default for the  codeEditor with a customControl that uses a copy method that is supported by both http and https.
- Update the default stage on the compile reports to be the failed one or the last one.
- Update the background color of all codeEditors to be the same as the app background.

closes #6366 