### PR TITLE
Bugfix resource links

### DIFF
--- a/changelogs/unreleased/6371-regex-resourceID-link.yml
+++ b/changelogs/unreleased/6371-regex-resourceID-link.yml
@@ -1,0 +1,6 @@
+description: Generate links for resource IDs using regex, regardless of the version suffix being present or not.
+issue-nr: 6371
+change-type: patch
+destination-branches: [master, iso8, iso7]
+sections:
+  bugfix: "{{description}}"

--- a/src/Slices/ServiceInstanceDetails/Test/Page.test.tsx
+++ b/src/Slices/ServiceInstanceDetails/Test/Page.test.tsx
@@ -446,7 +446,7 @@ describe("ServiceInstanceDetailsPage", () => {
 
     expect(screen.getByTestId("Status-deployed")).toBeVisible();
 
-    expect(screen.getByText("test_resource[]")).toBeVisible();
+    expect(screen.getByText("hello[world,v=42]")).toBeVisible();
 
     // Change Version to older
     await userEvent.click(screen.getAllByLabelText("History-Row")[1]);
@@ -456,7 +456,7 @@ describe("ServiceInstanceDetailsPage", () => {
 
     expect(screen.getByTestId("Status-deployed")).not.toBeVisible();
 
-    expect(screen.getByText("test_resource[]")).not.toBeVisible();
+    expect(screen.getByText("hello[world,v=42]")).not.toBeVisible();
 
     // Change Version to latest
     await userEvent.click(screen.getAllByLabelText("History-Row")[0]);

--- a/src/Slices/ServiceInstanceDetails/Test/mockServer.ts
+++ b/src/Slices/ServiceInstanceDetails/Test/mockServer.ts
@@ -98,7 +98,7 @@ const getJSONSchema = http.get("/lsm/v1/service_catalog/mobileCore/schema", () =
 
 const getResources = http.get("/lsm/v1/service_inventory/mobileCore/1d96a1ab/resources", () => {
   return HttpResponse.json({
-    data: [{ resource_id: "test_resource[],", resource_state: "deployed" }],
+    data: [{ resource_id: "hello[world,v=42]", resource_state: "deployed" }],
   });
 });
 

--- a/src/UI/Utils/ResourceId.test.ts
+++ b/src/UI/Utils/ResourceId.test.ts
@@ -1,9 +1,39 @@
 import { getResourceIdFromResourceVersionId } from "./ResourceId";
 
-test("Version is correctly left out of resource id", () => {
-  expect(
-    getResourceIdFromResourceVersionId(
-      "unittest::Resource[internal,name=0a5ec450-5f3e-4dab-81cd-60c158ffb66f],v=2"
-    )
-  ).toEqual("unittest::Resource[internal,name=0a5ec450-5f3e-4dab-81cd-60c158ffb66f]");
+describe("getResourceIdFromResourceVersionId", () => {
+  it("should remove version suffix from resource version ID", () => {
+    const resourceVersionId = "resource::test[name],v=123";
+    const result = getResourceIdFromResourceVersionId(resourceVersionId);
+    expect(result).toBe("resource::test[name]");
+  });
+
+  it("should handle complex resource IDs with commas", () => {
+    const resourceVersionId = "resource::namespace::type[name,with,commas],v=456";
+    const result = getResourceIdFromResourceVersionId(resourceVersionId);
+    expect(result).toBe("resource::namespace::type[name,with,commas]");
+  });
+
+  it('should handle resource IDs with "v=" in the name', () => {
+    const resourceVersionId = "hello[world,v=42],v=123";
+    const result = getResourceIdFromResourceVersionId(resourceVersionId);
+    expect(result).toBe("hello[world,v=42]");
+  });
+
+  it("should return the original string if no version suffix is present", () => {
+    const resourceId = "resource::test[name]";
+    const result = getResourceIdFromResourceVersionId(resourceId);
+    expect(result).toBe(resourceId);
+  });
+
+  it("should handle empty strings", () => {
+    const result = getResourceIdFromResourceVersionId("");
+    expect(result).toBe("");
+  });
+
+  it("should handle long UUIDs in resource names", () => {
+    const resourceVersionId =
+      "unittest::Resource[internal,name=0a5ec450-5f3e-4dab-81cd-60c158ffb66f],v=2";
+    const result = getResourceIdFromResourceVersionId(resourceVersionId);
+    expect(result).toBe("unittest::Resource[internal,name=0a5ec450-5f3e-4dab-81cd-60c158ffb66f]");
+  });
 });

--- a/src/UI/Utils/ResourceId.ts
+++ b/src/UI/Utils/ResourceId.ts
@@ -1,5 +1,9 @@
+/**
+ * Extracts the base resource ID from a resource version ID by removing the version suffix.
+ *
+ * @param resourceVersionId - The full resource version ID with format "resourceId,v=number"
+ * @returns The base resource ID without the version suffix
+ */
 export function getResourceIdFromResourceVersionId(resourceVersionId: string): string {
-  const indexOfVersionSeparator = resourceVersionId.lastIndexOf("],");
-
-  return resourceVersionId.substring(0, indexOfVersionSeparator + 1);
+  return resourceVersionId.replace(/,v=[0-9]+$/, "");
 }


### PR DESCRIPTION
# Description

Update the method to extract the resourceId to handle the case where we deal with a resourceId without version. 
Covered more cases with the tests.

closes #6371 
