### PR TITLE
Show unknown code languages in Code Editor instead of plain codeblocks.

### DIFF
--- a/changelogs/unreleased/Traceback-formatting-codeEditor.yml
+++ b/changelogs/unreleased/Traceback-formatting-codeEditor.yml
@@ -1,0 +1,3 @@
+description: Format traceback and unknown Code language in code editor instead of plain codeBlocks
+change-type: patch
+destination-branches: [master, iso8]

--- a/src/UI/Components/DesiredStateAttributes/AttributeList.tsx
+++ b/src/UI/Components/DesiredStateAttributes/AttributeList.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { CodeEditor, Language } from "@patternfly/react-code-editor";
 import {
-  CodeBlock,
   DescriptionList,
   DescriptionListDescription,
   DescriptionListGroup,
@@ -111,7 +110,15 @@ const AttributeValue: React.FC<{
         />
       );
     case "Code":
-      return <CodeBlock>{attribute.value}</CodeBlock>;
+      return (
+        <CodeEditor
+          isReadOnly
+          code={attribute.value}
+          isDownloadEnabled
+          customControls={<CodeEditorCopyControl code={attribute.value} />}
+          height={getHeightEditor(attribute)}
+        />
+      );
   }
 };
 


### PR DESCRIPTION
# Description

When we don't know the language of a certain piece of text/code, we now display the code in a codeEditor instead of a plain codeBlock. This has the advantage of auto-formatting the code. 

![image](https://github.com/user-attachments/assets/61ea4501-e2a3-4755-ae79-40deb6d5d1b0)

