### PR TITLE
ISO 7 - Dryrun change : update e2e

### DIFF
--- a/changelogs/unreleased/update-dryrun-result-e2e.yml
+++ b/changelogs/unreleased/update-dryrun-result-e2e.yml
@@ -1,3 +1,3 @@
 description: Update the dryrun result e2e test to use the new log viewer. 
 change-type: patch
-destination-branches: [master, iso8, iso7]
+destination-branches: [iso7]

--- a/changelogs/unreleased/update-dryrun-result-e2e.yml
+++ b/changelogs/unreleased/update-dryrun-result-e2e.yml
@@ -1,0 +1,3 @@
+description: Update the dryrun result e2e test to use the new log viewer. 
+change-type: patch
+destination-branches: [master, iso8, iso7]

--- a/cypress/e2e/scenario-4-desired-state.cy.js
+++ b/cypress/e2e/scenario-4-desired-state.cy.js
@@ -485,16 +485,6 @@ describe("Scenario 4 Desired State", () => {
       }
     });
 
-    // await the end of the dry-run and expect to find two rows with expandable content.
-    cy.get(".pf-v6-c-card__expandable-content", { timeout: 20000 }).should(
-      ($expandableRow) => {
-        expect($expandableRow).to.have.length(isIso ? 2 : 5);
-        expect($expandableRow.eq(0), "first-row").to.have.text(
-          "This resource has not been modified.",
-        );
-      },
-    );
-
     // click on filter by status dropdown
     cy.get('[aria-label="StatusFilter"]').click();
 

--- a/cypress/e2e/scenario-4-desired-state.cy.js
+++ b/cypress/e2e/scenario-4-desired-state.cy.js
@@ -485,6 +485,16 @@ describe("Scenario 4 Desired State", () => {
       }
     });
 
+    // await the end of the dry-run and expect to find two rows with expandable content.
+    cy.get(".pf-v5-c-card__expandable-content", { timeout: 20000 }).should(
+      ($expandableRow) => {
+        expect($expandableRow).to.have.length(isIso ? 2 : 5);
+        expect($expandableRow.eq(0), "first-row").to.have.text(
+          "This resource has not been modified.",
+        );
+      },
+    );
+
     // click on filter by status dropdown
     cy.get('[aria-label="StatusFilter"]').click();
 

--- a/cypress/e2e/scenario-4-desired-state.cy.js
+++ b/cypress/e2e/scenario-4-desired-state.cy.js
@@ -426,14 +426,15 @@ describe("Scenario 4 Desired State", () => {
       ($expandableRow) => {
         expect($expandableRow).to.have.length(isIso ? 2 : 5);
 
-      expect($expandableRow.eq(0), "first-row").to.have.text(
-        "This resource has not been modified."
-      );
+        expect($expandableRow.eq(0), "first-row").to.have.text(
+          "This resource has not been modified.",
+        );
 
-      expect($expandableRow.eq(1), "second-row").to.have.text(
-        "This resource has not been modified."
-      );
-    });
+        expect($expandableRow.eq(1), "second-row").to.have.text(
+          "This resource has not been modified.",
+        );
+      },
+    );
 
     // go back to desired state page
     cy.get(".pf-v5-c-nav__link").contains("Desired State").click();
@@ -485,12 +486,14 @@ describe("Scenario 4 Desired State", () => {
     });
 
     // await the end of the dry-run and expect to find two rows with expandable content.
-    cy.get(".pf-v6-c-card__expandable-content", { timeout: 20000 }).should(($expandableRow) => {
-      expect($expandableRow).to.have.length(isIso ? 2 : 5);
-      expect($expandableRow.eq(0), "first-row").to.have.text(
-        "This resource has not been modified."
-      );
-    });
+    cy.get(".pf-v6-c-card__expandable-content", { timeout: 20000 }).should(
+      ($expandableRow) => {
+        expect($expandableRow).to.have.length(isIso ? 2 : 5);
+        expect($expandableRow.eq(0), "first-row").to.have.text(
+          "This resource has not been modified.",
+        );
+      },
+    );
 
     // click on filter by status dropdown
     cy.get('[aria-label="StatusFilter"]').click();
@@ -525,12 +528,14 @@ describe("Scenario 4 Desired State", () => {
       }
     });
     // expect the view to still contain the diff of the last dry-run comparison
-    cy.get(".pf-v6-c-card__expandable-content", { timeout: 20000 }).should(($expandableRow) => {
-      expect($expandableRow).to.have.length(isIso ? 2 : 5);
-      expect($expandableRow.eq(0), "first-row").to.have.text(
-        "This resource has not been modified."
-      );
-    });
+    cy.get(".pf-v6-c-card__expandable-content", { timeout: 20000 }).should(
+      ($expandableRow) => {
+        expect($expandableRow).to.have.length(isIso ? 2 : 5);
+        expect($expandableRow.eq(0), "first-row").to.have.text(
+          "This resource has not been modified.",
+        );
+      },
+    );
 
     // click on Perform dry run
     cy.get(".pf-v5-c-button").contains("Perform dry run").click();

--- a/cypress/e2e/scenario-4-desired-state.cy.js
+++ b/cypress/e2e/scenario-4-desired-state.cy.js
@@ -426,20 +426,14 @@ describe("Scenario 4 Desired State", () => {
       ($expandableRow) => {
         expect($expandableRow).to.have.length(isIso ? 2 : 5);
 
-        expect($expandableRow.eq(0), "first-row").to.have.text(
-          "This resource has not been modified.",
-        );
-        if (isIso) {
-          expect($expandableRow.eq(1), "second-row").to.contain(
-            "next_version-3+4",
-          );
-        } else {
-          expect($expandableRow.eq(1), "second-row").to.have.text(
-            "This resource has not been modified.",
-          );
-        }
-      },
-    );
+      expect($expandableRow.eq(0), "first-row").to.have.text(
+        "This resource has not been modified."
+      );
+
+      expect($expandableRow.eq(1), "second-row").to.have.text(
+        "This resource has not been modified."
+      );
+    });
 
     // go back to desired state page
     cy.get(".pf-v5-c-nav__link").contains("Desired State").click();
@@ -491,20 +485,12 @@ describe("Scenario 4 Desired State", () => {
     });
 
     // await the end of the dry-run and expect to find two rows with expandable content.
-    cy.get(".pf-v5-c-card__expandable-content", { timeout: 20000 }).should(
-      ($expandableRow) => {
-        expect($expandableRow).to.have.length(isIso ? 2 : 5);
-        expect($expandableRow.eq(0), "first-row").to.have.text(
-          "This resource has not been modified.",
-        );
-
-        if (isIso) {
-          expect($expandableRow.eq(1), "second-row").to.contain(
-            "next_version-3+4",
-          );
-        }
-      },
-    );
+    cy.get(".pf-v6-c-card__expandable-content", { timeout: 20000 }).should(($expandableRow) => {
+      expect($expandableRow).to.have.length(isIso ? 2 : 5);
+      expect($expandableRow.eq(0), "first-row").to.have.text(
+        "This resource has not been modified."
+      );
+    });
 
     // click on filter by status dropdown
     cy.get('[aria-label="StatusFilter"]').click();
@@ -512,21 +498,6 @@ describe("Scenario 4 Desired State", () => {
     // uncheck unmodified option
     cy.get('[role="option"]').contains("unmodified").click();
     cy.get('[aria-label="StatusFilter"]').click();
-
-    // expect diff-module to only show the modified file.Only for ISO, the table would be empty on OSS.
-    if (isIso) {
-      cy.get(".pf-v5-c-card__expandable-content", { timeout: 20000 }).should(
-        ($expandableRow) => {
-          expect($expandableRow).to.have.length(1);
-
-          if (isIso) {
-            expect($expandableRow.eq(0), "first-row").to.contain(
-              "next_version-3+4",
-            );
-          }
-        },
-      );
-    }
 
     // go back to desired state
     cy.get(".pf-v5-c-nav__link").contains("Desired State").click();
@@ -554,20 +525,12 @@ describe("Scenario 4 Desired State", () => {
       }
     });
     // expect the view to still contain the diff of the last dry-run comparison
-    cy.get(".pf-v5-c-card__expandable-content", { timeout: 20000 }).should(
-      ($expandableRow) => {
-        expect($expandableRow).to.have.length(isIso ? 2 : 5);
-        expect($expandableRow.eq(0), "first-row").to.have.text(
-          "This resource has not been modified.",
-        );
-
-        if (isIso) {
-          expect($expandableRow.eq(1), "second-row").to.contain(
-            "next_version-3+4",
-          );
-        }
-      },
-    );
+    cy.get(".pf-v6-c-card__expandable-content", { timeout: 20000 }).should(($expandableRow) => {
+      expect($expandableRow).to.have.length(isIso ? 2 : 5);
+      expect($expandableRow.eq(0), "first-row").to.have.text(
+        "This resource has not been modified."
+      );
+    });
 
     // click on Perform dry run
     cy.get(".pf-v5-c-button").contains("Perform dry run").click();

--- a/cypress/e2e/scenario-4-desired-state.cy.js
+++ b/cypress/e2e/scenario-4-desired-state.cy.js
@@ -518,7 +518,7 @@ describe("Scenario 4 Desired State", () => {
       }
     });
     // expect the view to still contain the diff of the last dry-run comparison
-    cy.get(".pf-v6-c-card__expandable-content", { timeout: 20000 }).should(
+    cy.get(".pf-v5-c-card__expandable-content", { timeout: 20000 }).should(
       ($expandableRow) => {
         expect($expandableRow).to.have.length(isIso ? 2 : 5);
         expect($expandableRow.eq(0), "first-row").to.have.text(


### PR DESCRIPTION
# Description

This is the iso 7 PR for https://github.com/inmanta/web-console/pull/6471

From now on, the LifecycleTransfer resource never reports a change in the dryrun. Thus, the lines related to asserting the next_version would be bumped, can be removed.