### PR TITLE
Remove the send_event field from the desired state e2e test.

### DIFF
--- a/changelogs/unreleased/update-e2e-desiredState.yml
+++ b/changelogs/unreleased/update-e2e-desiredState.yml
@@ -1,0 +1,3 @@
+description: Remove the send_event field from the desired state e2e test.
+change-type: patch
+destination-branches: [master, iso8, iso7]

--- a/cypress/e2e/scenario-4-desired-state.cy.js
+++ b/cypress/e2e/scenario-4-desired-state.cy.js
@@ -242,12 +242,6 @@ describe("Scenario 4 Desired State", () => {
           .should("include.text", '"frontend_model::TestResource[internal,name=default-0001]"');
 
         cy.get(".pf-v6-c-description-list__term")
-          .contains("send_event")
-          .closest(".pf-v6-c-description-list__group")
-          .find(".pf-v6-c-description-list__description")
-          .should("have.text", "false");
-
-        cy.get(".pf-v6-c-description-list__term")
           .contains("service_entity")
           .closest(".pf-v6-c-description-list__group")
           .find(".pf-v6-c-description-list__description")


### PR DESCRIPTION
# Description

 removed the send_event assertion from the test case, it's not hard requirement to assert this specific value.
