### PR TITLE
6440 user role management

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,5 @@
+We use vite and vitest for bundling and testing our application.
+
+We use React 19.
+
+Comments and docstrings are important.

--- a/changelogs/unreleased/6440-role-management.yml
+++ b/changelogs/unreleased/6440-role-management.yml
@@ -1,0 +1,14 @@
+description: |
+  Add support for role management to user management page.
+  
+  This feature allows to assign and manage user roles directly from the web console.
+  
+  Note: Role management is only supported when using the database authentication method in combination with the policy-engine authorization provider.
+  
+  See the [Inmanta documentation](https://docs.inmanta.com/inmanta-service-orchestrator-dev/9/administrators/authorization.html#integration-with-database-authentication) for details on configuring roles and permissions.
+
+issue-nr: "6440"
+change-type: patch
+destination-branches: [master]
+sections:
+  feature: "{{description}}"

--- a/cypress/e2e/scenario-7.3-user-management.cy.js
+++ b/cypress/e2e/scenario-7.3-user-management.cy.js
@@ -1,4 +1,120 @@
 if (Cypress.env("local-auth")) {
+  it.only("should display the roles for a user, and allow them to be added and removed", () => {
+    cy.visit("/console/");
+
+    cy.get('[id="pf-login-username-id"]').type("admin");
+    cy.get('[id="pf-login-password-id"]').type("adminadmin{enter}");
+
+    cy.get("h1").contains("Home").should("be.visible");
+
+    cy.get("[id=toggle-button]", { timeout: 20000 }).should("contain", "admin");
+    cy.get("[id=toggle-button]").click();
+
+    cy.get('[role="menuitem"]').contains("User Management").click();
+
+    // For Admin Assert "None" in Roles column and expand
+    cy.get('tr[aria-label="row-admin"]').within(() => {
+      // Check that the first cell contains an SVG icon before the username
+      cy.get("td")
+        .first()
+        .within(() => {
+          cy.get("svg").should("exist");
+          cy.contains("admin");
+        });
+      // Assert the Roles column contains a button with text "None"
+      cy.get('td[data-label="Roles"] button').should("contain", "None");
+      // Click the "None" button
+      cy.get('td[data-label="Roles"] button').click();
+    });
+
+    cy.get('tr[aria-label="expanded-row-admin"]')
+      .should("be.visible")
+      .within(() => {
+        // Assert the nested table exists
+        cy.get('table[aria-label="Nested-Roles-Table"]')
+          .should("exist")
+          .within(() => {
+            // Assert there is exactly one environment row (tbody > tr)
+            cy.get("tbody tr").should("have.length", 1);
+            // Assert the first cell contains "env"
+            cy.get("tbody tr").first().find("td").first().should("contain", "env");
+            // Assert the select button exists and is clickable
+            cy.get('button[aria-label="role-selector"]')
+              .should("exist")
+              .and("contain", "Edit roles")
+              .click();
+          });
+      });
+
+    cy.get("div#role-selector")
+      .should("be.visible")
+      .within(() => {
+        cy.get('ul[role="listbox"]').within(() => {
+          cy.contains("li", "environment-admin").should("exist");
+          cy.contains("li", "environment-expert-admin").should("exist");
+          cy.contains("li", "noc").should("exist");
+          cy.contains("li", "operator").should("exist");
+          cy.contains("li", "read-only").should("exist");
+          // Click the first three roles
+          cy.contains("li", "environment-admin")
+            .find('input[type="checkbox"]')
+            .click({ force: true });
+          cy.contains("li", "environment-expert-admin")
+            .find('input[type="checkbox"]')
+            .click({ force: true });
+          cy.contains("li", "noc").find('input[type="checkbox"]').click({ force: true });
+        });
+      });
+
+    // Click outside to close the dropdown
+    cy.get("body").click(0, 0);
+
+    // Assert the labels are present in the row
+    cy.get(
+      'tr[aria-label="expanded-row-admin"] table[aria-label="Nested-Roles-Table"] tbody tr'
+    ).within(() => {
+      cy.get('[data-testid="role-label-environment-admin"]')
+        .should("exist")
+        .and("contain", "environment-admin");
+      cy.get('[data-testid="role-label-environment-expert-admin"]')
+        .should("exist")
+        .and("contain", "environment-expert-admin");
+      cy.get('[data-testid="role-label-noc"]').should("exist").and("contain", "noc");
+    });
+
+    // Open the dropdown again to remove a role
+    cy.get(
+      'tr[aria-label="expanded-row-admin"] table[aria-label="Nested-Roles-Table"] tbody tr'
+    ).within(() => {
+      cy.get('button[aria-label="role-selector"]').click();
+    });
+    cy.get("div#role-selector")
+      .should("be.visible")
+      .within(() => {
+        cy.get('ul[role="listbox"]').within(() => {
+          cy.contains("li", "environment-expert-admin")
+            .find('input[type="checkbox"]')
+            .click({ force: true });
+        });
+      });
+    // Assert the label for 'environment-expert-admin' is removed, others remain
+    cy.get(
+      'tr[aria-label="expanded-row-admin"] table[aria-label="Nested-Roles-Table"] tbody tr'
+    ).within(() => {
+      cy.get('[data-testid="role-label-environment-admin"]')
+        .should("exist")
+        .and("contain", "environment-admin");
+      cy.get('[data-testid="role-label-noc"]').should("exist").and("contain", "noc");
+      cy.get('[data-testid="role-label-environment-expert-admin"]').should("not.exist");
+    });
+
+    // Assert the Roles column for admin now displays '2 roles' instead of 'None'
+    cy.get('tr[aria-label="row-admin"]').within(() => {
+      cy.get('td[data-label="Roles"] button').should("contain", "environment-admin, noc");
+      cy.get('td[data-label="Roles"] button').should("not.contain", "None");
+    });
+  });
+
   it("should be able to add user", () => {
     cy.visit("/console/");
 
@@ -58,6 +174,7 @@ if (Cypress.env("local-auth")) {
 
     cy.get('[data-testid="user-row"]', { timeout: 20000 }).should("have.length", 6);
   });
+
   it("should be able to change user password", () => {
     cy.visit("/console/");
 

--- a/cypress/e2e/scenario-7.3-user-management.cy.js
+++ b/cypress/e2e/scenario-7.3-user-management.cy.js
@@ -1,5 +1,5 @@
 if (Cypress.env("local-auth")) {
-  it.only("should display the roles for a user, and allow them to be added and removed", () => {
+  it("should display the roles for a user, and allow them to be added and removed", () => {
     cy.visit("/console/");
 
     cy.get('[id="pf-login-username-id"]').type("admin");

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/x-icon" href="./images/favicon.ico" />
     <title>Web Console</title>
 </head>
 

--- a/src/Data/Queries/Helpers/useFetchHelpers.ts
+++ b/src/Data/Queries/Helpers/useFetchHelpers.ts
@@ -27,20 +27,18 @@ export const useFetchHelpers = () => {
 
     if (!response.ok) {
       let message = customErrorMessage;
+      let bodyText: string | undefined;
       try {
-        const data = await response.clone().json();
-        if (data && data.message) message = data.message;
-      } catch {
-        // ignore JSON parse errors
-      }
-      if (!message) {
+        bodyText = await response.text();
         try {
-          // Try to get text if JSON failed
-          const text = await response.clone().text();
-          if (text) message = text;
+          const data = JSON.parse(bodyText);
+          if (data && data.message) message = data.message;
         } catch {
-          // ignore
+          // If not JSON, use the text as message
+          if (bodyText && !message) message = bodyText;
         }
+      } catch {
+        // ignore body read errors
       }
       if (!message) message = response.statusText || "An unknown error occurred";
       const error: CustomError = new Error(message);

--- a/src/Data/Queries/Slices/Auth/AddRole/index.ts
+++ b/src/Data/Queries/Slices/Auth/AddRole/index.ts
@@ -1,0 +1,1 @@
+export * from "./useAddRole";

--- a/src/Data/Queries/Slices/Auth/AddRole/useAddRole.ts
+++ b/src/Data/Queries/Slices/Auth/AddRole/useAddRole.ts
@@ -4,7 +4,7 @@ import { usePostWithoutEnv } from "@/Data/Queries";
 /**
  * Represents the roles for a given environment.
  */
-export type EvironmentRoles = Record<string, string[]>;
+export type EnvironmentRoles = Record<string, string[]>;
 
 /**
  * Adds a role to a user, for a specific environment.

--- a/src/Data/Queries/Slices/Auth/AddRole/useAddRole.ts
+++ b/src/Data/Queries/Slices/Auth/AddRole/useAddRole.ts
@@ -1,0 +1,26 @@
+import { useMutation, UseMutationOptions } from "@tanstack/react-query";
+import { usePostWithoutEnv } from "@/Data/Queries";
+
+/**
+ * Represents the roles for a given environment.
+ */
+export type EvironmentRoles = Record<string, string[]>;
+
+/**
+ * Adds a role to a user, for a specific environment.
+ * @param username - The username of the user.
+ * @param options - The options for the mutation.
+ * @returns The mutation result.
+ */
+export const useAddRole = (
+  username: string,
+  options?: UseMutationOptions<void, Error, { role: string; environment: string }, unknown>
+) => {
+  const post = usePostWithoutEnv()<{ role: string; environment: string }>;
+
+  return useMutation<void, Error, { role: string; environment: string }>({
+    mutationFn: (body) => post(`/api/v2/role_assignment/${username}`, body),
+    mutationKey: ["update-roles"],
+    ...options,
+  });
+};

--- a/src/Data/Queries/Slices/Auth/DeleteRole/index.ts
+++ b/src/Data/Queries/Slices/Auth/DeleteRole/index.ts
@@ -1,0 +1,1 @@
+export * from "./useDeleteRole";

--- a/src/Data/Queries/Slices/Auth/DeleteRole/useDeleteRole.ts
+++ b/src/Data/Queries/Slices/Auth/DeleteRole/useDeleteRole.ts
@@ -1,0 +1,24 @@
+import { UseMutationResult, UseMutationOptions, useMutation } from "@tanstack/react-query";
+import { useDeleteWithoutEnv } from "@/Data/Queries";
+
+/**
+ * Deletes a role from a user, for a specific environment.
+ * @param username - The username of the user.
+ * @param options - The options for the mutation.
+ * @returns The mutation result.
+ */
+export const useDeleteRole = (
+  username: string,
+  options?: UseMutationOptions<void, Error, { role: string; environment: string }, unknown>
+): UseMutationResult<void, Error, { role: string; environment: string }, unknown> => {
+  const deleteFn = useDeleteWithoutEnv();
+
+  return useMutation<void, Error, { role: string; environment: string }>({
+    mutationFn: ({ role, environment }) =>
+      deleteFn(
+        `/api/v2/role_assignment/${encodeURIComponent(username)}?role=${encodeURIComponent(role)}&environment=${encodeURIComponent(environment)}`
+      ),
+    mutationKey: ["delete-role"],
+    ...options,
+  });
+};

--- a/src/Data/Queries/Slices/Auth/GetRoles/index.ts
+++ b/src/Data/Queries/Slices/Auth/GetRoles/index.ts
@@ -1,0 +1,1 @@
+export * from "./useGetRoles";

--- a/src/Data/Queries/Slices/Auth/GetRoles/useGetRoles.ts
+++ b/src/Data/Queries/Slices/Auth/GetRoles/useGetRoles.ts
@@ -1,0 +1,23 @@
+import { useQuery } from "@tanstack/react-query";
+import { useGetWithoutEnv } from "@/Data/Queries";
+import { KeyFactory, SliceKeys } from "@/Data/Queries/Helpers/KeyFactory";
+
+/**
+ * React Query hook to fetch the roles for a given environment.
+ * @param environmentId - The ID of the environment to fetch the roles for.
+ * @returns An object containing a custom hook to fetch the roles for a given environment.
+ */
+export const useGetRoles = (environmentId: string) => {
+  const get = useGetWithoutEnv()<{ data: string[] }>;
+
+  return {
+    useOneTime: () =>
+      useQuery({
+        queryKey: getRolesKey.list([environmentId]),
+        queryFn: () => get("/api/v2/role"),
+        select: (data) => data.data,
+      }),
+  };
+};
+
+export const getRolesKey = new KeyFactory(SliceKeys.auth, "get_roles");

--- a/src/Data/Queries/Slices/Auth/GetUsers/useGetUsers.ts
+++ b/src/Data/Queries/Slices/Auth/GetUsers/useGetUsers.ts
@@ -5,7 +5,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { useGetWithoutEnv } from "@/Data/Queries";
 import { KeyFactory, SliceKeys } from "@/Data/Queries/Helpers/KeyFactory";
-import { EvironmentRoles } from "../AddRole/useAddRole";
+import { EnvironmentRoles } from "../AddRole/useAddRole";
 
 /**
  * Represents the user information.
@@ -14,7 +14,7 @@ export interface UserInfo {
   username: string;
   auth_method: "oidc" | "database";
   is_admin: boolean;
-  roles: EvironmentRoles;
+  roles: EnvironmentRoles;
 }
 
 /**

--- a/src/Data/Queries/Slices/Auth/GetUsers/useGetUsers.ts
+++ b/src/Data/Queries/Slices/Auth/GetUsers/useGetUsers.ts
@@ -5,6 +5,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { useGetWithoutEnv } from "@/Data/Queries";
 import { KeyFactory, SliceKeys } from "@/Data/Queries/Helpers/KeyFactory";
+import { EvironmentRoles } from "../AddRole/useAddRole";
 
 /**
  * Represents the user information.
@@ -13,7 +14,7 @@ export interface UserInfo {
   username: string;
   auth_method: "oidc" | "database";
   is_admin: boolean;
-  roles: string[];
+  roles: EvironmentRoles;
 }
 
 /**

--- a/src/Data/Queries/Slices/Auth/GetUsers/useGetUsers.ts
+++ b/src/Data/Queries/Slices/Auth/GetUsers/useGetUsers.ts
@@ -12,6 +12,8 @@ import { KeyFactory, SliceKeys } from "@/Data/Queries/Helpers/KeyFactory";
 export interface UserInfo {
   username: string;
   auth_method: "oidc" | "database";
+  is_admin: boolean;
+  roles: string[];
 }
 
 /**

--- a/src/Data/Queries/Slices/Auth/index.ts
+++ b/src/Data/Queries/Slices/Auth/index.ts
@@ -4,3 +4,6 @@ export * from "./Login";
 export * from "./GetUsers";
 export * from "./RemoveUser";
 export * from "./ChangeUserPassword";
+export * from "./GetRoles";
+export * from "./AddRole";
+export * from "./DeleteRole";

--- a/src/Slices/Notification/UI/Drawer/Drawer.test.tsx
+++ b/src/Slices/Notification/UI/Drawer/Drawer.test.tsx
@@ -39,7 +39,7 @@ function setup() {
         <MockedDependencyProvider>
           <Page
             notificationDrawer={
-              <Drawer onClose={closeCallback} isDrawerOpen drawerRef={{ current: undefined }} />
+              <Drawer onClose={closeCallback} isDrawerOpen drawerRef={{ current: null }} />
             }
             isNotificationDrawerExpanded={true}
             masthead={

--- a/src/Slices/Notification/UI/Drawer/Drawer.tsx
+++ b/src/Slices/Notification/UI/Drawer/Drawer.tsx
@@ -104,9 +104,9 @@ const View: React.FC<ViewProps> = ({ response, onClose, mutate, drawerRef }) => 
 
   const getOnUpdate =
     (ids: string[]): OnUpdate =>
-      (body) => {
-        mutate({ body, ids });
-      };
+    (body) => {
+      mutate({ body, ids });
+    };
 
   const onClearAll = () => {
     if (!response.isSuccess) return;
@@ -136,13 +136,13 @@ const View: React.FC<ViewProps> = ({ response, onClose, mutate, drawerRef }) => 
         <NotificationDrawerList>
           {response.isSuccess
             ? response.data.data.map((notification) => (
-              <Item
-                data-testid="menuitem"
-                {...{ notification }}
-                key={notification.id}
-                onUpdate={getOnUpdate([notification.id])}
-              />
-            ))
+                <Item
+                  data-testid="menuitem"
+                  {...{ notification }}
+                  key={notification.id}
+                  onUpdate={getOnUpdate([notification.id])}
+                />
+              ))
             : null}
         </NotificationDrawerList>
       </NotificationDrawerBody>

--- a/src/Slices/Notification/UI/Drawer/Drawer.tsx
+++ b/src/Slices/Notification/UI/Drawer/Drawer.tsx
@@ -1,4 +1,4 @@
-import React, { MutableRefObject, useEffect, useState } from "react";
+import React, { RefObject, useEffect, useState } from "react";
 import {
   Dropdown,
   DropdownItem,
@@ -28,12 +28,12 @@ import { Item, OnUpdate } from "./Item";
  *
  * @property {(event?: MouseEvent) => void} onClose - Function to handle drawer closing
  * @property {boolean} isDrawerOpen - Whether the drawer is currently open
- * @property {MutableRefObject<HTMLDivElement | undefined>} drawerRef - Ref to the drawer DOM element
+ * @property {RefObject<HTMLDivElement | null>} drawerRef - Ref to the drawer DOM element
  */
 interface Props {
   onClose(event?: MouseEvent): void;
   isDrawerOpen: boolean;
-  drawerRef: MutableRefObject<HTMLDivElement | undefined>;
+  drawerRef: RefObject<HTMLDivElement | null>;
 }
 
 /**
@@ -55,18 +55,26 @@ export const Drawer: React.FC<Props> = ({ onClose, isDrawerOpen, drawerRef }) =>
   });
 
   useEffect(() => {
-    const close = (event) => {
+    if (!isDrawerOpen) {
+      return;
+    }
+
+    const close = (event: MouseEvent) => {
       const target = event.target as Node;
       const wasTargetOutsideSidebar = !drawerRef.current?.contains(target);
 
-      if (isDrawerOpen && wasTargetOutsideSidebar) {
+      if (wasTargetOutsideSidebar) {
         onClose();
       }
     };
 
-    document.addEventListener("click", close);
+    // Defer event listener attachment to prevent race condition with opening click
+    const timeoutId = setTimeout(() => {
+      document.addEventListener("click", close);
+    }, 0);
 
     return () => {
+      clearTimeout(timeoutId);
       document.removeEventListener("click", close);
     };
   }, [drawerRef, isDrawerOpen, onClose]);
@@ -96,9 +104,9 @@ const View: React.FC<ViewProps> = ({ response, onClose, mutate, drawerRef }) => 
 
   const getOnUpdate =
     (ids: string[]): OnUpdate =>
-    (body) => {
-      mutate({ body, ids });
-    };
+      (body) => {
+        mutate({ body, ids });
+      };
 
   const onClearAll = () => {
     if (!response.isSuccess) return;
@@ -128,13 +136,13 @@ const View: React.FC<ViewProps> = ({ response, onClose, mutate, drawerRef }) => 
         <NotificationDrawerList>
           {response.isSuccess
             ? response.data.data.map((notification) => (
-                <Item
-                  data-testid="menuitem"
-                  {...{ notification }}
-                  key={notification.id}
-                  onUpdate={getOnUpdate([notification.id])}
-                />
-              ))
+              <Item
+                data-testid="menuitem"
+                {...{ notification }}
+                key={notification.id}
+                onUpdate={getOnUpdate([notification.id])}
+              />
+            ))
             : null}
         </NotificationDrawerList>
       </NotificationDrawerBody>

--- a/src/Slices/Notification/UI/Drawer/UseDrawer.tsx
+++ b/src/Slices/Notification/UI/Drawer/UseDrawer.tsx
@@ -10,7 +10,7 @@ type UseDrawer = (env: boolean) => {
 
 export const useDrawer: UseDrawer = (env) => {
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
-  const drawerRef = useRef<HTMLDivElement | undefined>(undefined);
+  const drawerRef = useRef<HTMLDivElement>(null);
   const onDrawerClose = () => setIsDrawerOpen(false);
 
   const onDrawerOpen = () => {
@@ -29,7 +29,7 @@ export const useDrawer: UseDrawer = (env) => {
     isNotificationDrawerExpanded,
     onNotificationsToggle,
   ] = env
-    ? [
+      ? [
         <Drawer
           onClose={onDrawerClose}
           isDrawerOpen={isDrawerOpen}
@@ -40,7 +40,7 @@ export const useDrawer: UseDrawer = (env) => {
         isDrawerOpen,
         () => setIsDrawerOpen(!isDrawerOpen),
       ]
-    : [undefined, undefined, false, () => undefined];
+      : [undefined, undefined, false, () => undefined];
 
   useEffect(() => {
     if (!env) setIsDrawerOpen(false);

--- a/src/Slices/Notification/UI/Drawer/UseDrawer.tsx
+++ b/src/Slices/Notification/UI/Drawer/UseDrawer.tsx
@@ -29,7 +29,7 @@ export const useDrawer: UseDrawer = (env) => {
     isNotificationDrawerExpanded,
     onNotificationsToggle,
   ] = env
-      ? [
+    ? [
         <Drawer
           onClose={onDrawerClose}
           isDrawerOpen={isDrawerOpen}
@@ -40,7 +40,7 @@ export const useDrawer: UseDrawer = (env) => {
         isDrawerOpen,
         () => setIsDrawerOpen(!isDrawerOpen),
       ]
-      : [undefined, undefined, false, () => undefined];
+    : [undefined, undefined, false, () => undefined];
 
   useEffect(() => {
     if (!env) setIsDrawerOpen(false);

--- a/src/Slices/UserManagement/UI/Components/AddUserForm/UserCredentialsForm.tsx
+++ b/src/Slices/UserManagement/UI/Components/AddUserForm/UserCredentialsForm.tsx
@@ -142,11 +142,7 @@ export const UserCredentialsForm: React.FC<UserCredentialsFormProps> = ({
       </FormGroup>
       <Flex justifyContent={{ default: "justifyContentFlexEnd" }}>
         <ActionGroup>
-          <Button
-            variant="secondary"
-            onClick={closeModal}
-            aria-label="cancel-button"
-          >
+          <Button variant="secondary" onClick={closeModal} aria-label="cancel-button">
             {words("cancel")}
           </Button>
           <Button

--- a/src/Slices/UserManagement/UI/Components/AddUserForm/UserCredentialsForm.tsx
+++ b/src/Slices/UserManagement/UI/Components/AddUserForm/UserCredentialsForm.tsx
@@ -12,6 +12,7 @@ import {
   ActionGroup,
   ValidatedOptions,
   Spinner,
+  Flex,
 } from "@patternfly/react-core";
 import { ExclamationCircleIcon, EyeIcon, EyeSlashIcon } from "@patternfly/react-icons";
 import { useAddUser } from "@/Data/Queries";
@@ -86,7 +87,7 @@ export const UserCredentialsForm: React.FC<UserCredentialsFormProps> = ({
   }, [isSuccess, closeModal]);
 
   return (
-    <Form className="loginForm" onSubmit={handleSubmit}>
+    <Form className="loginForm" onSubmit={handleSubmit} autoComplete="off">
       {isError && error && (
         <FormHelperText>
           <HelperText>
@@ -110,6 +111,7 @@ export const UserCredentialsForm: React.FC<UserCredentialsFormProps> = ({
           aria-label="input-username"
           value={username}
           onChange={handleUsernameChange}
+          autoComplete="off"
         />
       </FormGroup>
       <FormGroup label={words("password")} isRequired fieldId="pf-login-password-id">
@@ -124,6 +126,7 @@ export const UserCredentialsForm: React.FC<UserCredentialsFormProps> = ({
               validated={ValidatedOptions.default}
               value={password}
               onChange={handlePasswordChange}
+              autoComplete="off"
             />
           </InputGroupItem>
           <InputGroupItem>
@@ -137,18 +140,26 @@ export const UserCredentialsForm: React.FC<UserCredentialsFormProps> = ({
           </InputGroupItem>
         </InputGroup>
       </FormGroup>
-      <ActionGroup>
-        <Button
-          aria-label={submitButtonLabel}
-          variant="primary"
-          type="submit"
-          onClick={handleSubmit}
-          isBlock
-          isDisabled={isPending}
-        >
-          {isPending ? <Spinner size="md" /> : submitButtonText}
-        </Button>
-      </ActionGroup>
+      <Flex justifyContent={{ default: "justifyContentFlexEnd" }}>
+        <ActionGroup>
+          <Button
+            variant="secondary"
+            onClick={closeModal}
+            aria-label="cancel-button"
+          >
+            {words("cancel")}
+          </Button>
+          <Button
+            aria-label={submitButtonLabel}
+            variant="primary"
+            type="submit"
+            onClick={handleSubmit}
+            isDisabled={isPending}
+          >
+            {isPending ? <Spinner size="md" /> : submitButtonText}
+          </Button>
+        </ActionGroup>
+      </Flex>
     </Form>
   );
 };

--- a/src/Slices/UserManagement/UI/Components/NestedUserRoleTable.test.tsx
+++ b/src/Slices/UserManagement/UI/Components/NestedUserRoleTable.test.tsx
@@ -1,0 +1,219 @@
+import React from "react";
+import { Page } from "@patternfly/react-core";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { within } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import { UserInfo } from "@/Data/Queries";
+import { NestedUserRoleTable } from "./NestedUserRoleTable";
+
+const mockEnvironments = [
+  { id: "env1", name: "Production" },
+  { id: "env2", name: "Staging" },
+];
+const mockRoles = ["admin", "observer", "deployer"];
+
+const mockUser: UserInfo = {
+  username: "alice",
+  auth_method: "database",
+  is_admin: false,
+  roles: {
+    env1: ["admin"],
+  },
+};
+
+function renderWithClient(ui: React.ReactElement) {
+  const queryClient = new QueryClient();
+  return render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
+}
+
+// Test wrapper to simulate parent state update
+function TestWrapper({ initialUser }: { initialUser: UserInfo }) {
+  const [user, setUser] = React.useState(initialUser);
+  return (
+    <Page>
+      <QueryClientProvider client={new QueryClient()}>
+        <NestedUserRoleTable {...user} />
+        {/* Expose a way to update user state for the test */}
+        <button
+          data-testid="simulate-parent-update"
+          onClick={() => {
+            setUser((prev) => ({
+              ...prev,
+              roles: {
+                ...prev.roles,
+                env1: prev.roles.env1.includes("admin")
+                  ? prev.roles.env1.filter((role) => role !== "admin")
+                  : [...prev.roles.env1, "admin"],
+              },
+            }));
+          }}
+        />
+      </QueryClientProvider>
+    </Page>
+  );
+}
+
+describe("NestedUserRoleTable (with MSW)", () => {
+  let server: ReturnType<typeof setupServer>;
+
+  afterEach(() => {
+    if (server) server.close();
+  });
+
+  it("renders environments and roles", async () => {
+    server = setupServer(
+      http.get("/api/v2/environment", () => HttpResponse.json({ data: mockEnvironments })),
+      http.get("/api/v2/role", () => HttpResponse.json({ data: mockRoles }))
+    );
+    server.listen();
+
+    renderWithClient(<NestedUserRoleTable {...mockUser} />);
+
+    expect(await screen.findByText("Production")).toBeInTheDocument();
+    expect(screen.getByText("Staging")).toBeInTheDocument();
+    expect(screen.getByText("admin")).toBeInTheDocument();
+    expect(screen.getByText(/none/i)).toBeInTheDocument();
+  });
+
+  it("shows 'roles unavailable' if no roles and not loading", async () => {
+    server = setupServer(
+      http.get("/api/v2/environment", () => HttpResponse.json({ data: mockEnvironments })),
+      http.get("/api/v2/role", () => HttpResponse.json({ data: undefined }))
+    );
+    server.listen();
+    renderWithClient(<NestedUserRoleTable {...mockUser} />);
+    expect(await screen.findByText(/no roles available/i)).toBeInTheDocument();
+  });
+
+  it("If a role is not yet assigned, it should be added", async () => {
+    server = setupServer(
+      http.get("/api/v2/environment", () => HttpResponse.json({ data: mockEnvironments })),
+      http.get("/api/v2/role", () => HttpResponse.json({ data: mockRoles })),
+      http.post("/api/v2/role_assignment/:username", async () => {
+        return HttpResponse.json({}, { status: 204 });
+      })
+    );
+    server.listen();
+    render(<TestWrapper initialUser={{ ...mockUser, roles: { env1: [] } }} />);
+    const editDropdowns = await screen.findAllByLabelText("role-selector");
+    fireEvent.click(editDropdowns[0]);
+
+    // Find the menuitem for 'admin' in the dropdown
+    const menuItems = await screen.findAllByRole("menuitem");
+    const adminMenuItem = menuItems.find((item) => item.textContent?.includes("admin"));
+    expect(adminMenuItem).toBeDefined();
+
+    // Find the checkbox inside the menuitem and click it
+    const checkbox = within(adminMenuItem!).getByRole("checkbox");
+    fireEvent.click(checkbox);
+
+    // Simulate parent update after mutation
+    fireEvent.click(screen.getByTestId("simulate-parent-update"));
+
+    // there should now be a label with the role besides the dropdown
+    expect(screen.getByTestId("role-label-admin")).toBeInTheDocument();
+  });
+
+  it("If a role is already assigned, it should be removed", async () => {
+    server = setupServer(
+      http.get("/api/v2/environment", () => HttpResponse.json({ data: mockEnvironments })),
+      http.get("/api/v2/role", () => HttpResponse.json({ data: mockRoles })),
+      http.delete("/api/v2/role_assignment/:username", () => {
+        return HttpResponse.json({}, { status: 204 });
+      })
+    );
+    server.listen();
+    render(<TestWrapper initialUser={mockUser} />);
+    const editButtons = await screen.findAllByLabelText("role-selector");
+    fireEvent.click(editButtons[0]); // env1
+
+    // Find the menuitem for 'admin' in the dropdown
+    const menuItems = await screen.findAllByRole("menuitem");
+    const adminMenuItem = menuItems.find((item) => item.textContent?.includes("admin"));
+    expect(adminMenuItem).toBeDefined();
+
+    // Find the checkbox inside the menuitem and click it
+    const checkbox = within(adminMenuItem!).getByRole("checkbox");
+    fireEvent.click(checkbox);
+
+    // Simulate parent update after mutation
+    fireEvent.click(screen.getByTestId("simulate-parent-update"));
+    // Wait for the parent state to update and the label to disappear
+    await waitFor(() => expect(screen.queryByTestId("role-label-admin")).not.toBeInTheDocument());
+  });
+
+  it("shows error alert if addRole fails", async () => {
+    server = setupServer(
+      http.get("/api/v2/environment", () => HttpResponse.json({ data: mockEnvironments })),
+      http.get("/api/v2/role", () => HttpResponse.json({ data: mockRoles })),
+      http.post("/api/v2/role_assignment/:username", async () => {
+        return HttpResponse.json({ message: "Invalid request" }, { status: 400 });
+      })
+    );
+
+    server.listen();
+    renderWithClient(<TestWrapper initialUser={{ ...mockUser, roles: { env1: [] } }} />);
+    const editDropdowns = await screen.findAllByLabelText("role-selector");
+    fireEvent.click(editDropdowns[1]); // env2
+    // Find the menuitem for 'admin' in the dropdown
+    const adminMenuItem = await screen.findByRole("menuitem", { name: /admin/i });
+    expect(adminMenuItem).toBeDefined();
+    // Find the checkbox inside the menuitem and click it
+    const checkbox = within(adminMenuItem).getByRole("checkbox");
+    fireEvent.click(checkbox);
+
+    const errorMessage = await screen.findByLabelText("error-message");
+
+    expect(errorMessage).toBeInTheDocument();
+    expect(errorMessage).toHaveTextContent("Invalid request");
+  });
+
+  it("shows error alert if deleteRole fails", async () => {
+    server = setupServer(
+      http.get("/api/v2/environment", () => HttpResponse.json({ data: mockEnvironments })),
+      http.get("/api/v2/role", () => HttpResponse.json({ data: mockRoles })),
+      http.delete("/api/v2/role_assignment/:username", () => {
+        return HttpResponse.json({ message: "Delete failed" }, { status: 500 });
+      })
+    );
+    server.listen();
+    renderWithClient(<NestedUserRoleTable {...mockUser} />);
+    const editDropdowns = await screen.findAllByLabelText("role-selector");
+    fireEvent.click(editDropdowns[0]); // env1
+    // Find the menuitem for 'admin' in the dropdown
+    const menuItems = await screen.findAllByRole("menuitem");
+    const adminMenuItem = menuItems.find((item) => item.textContent?.includes("admin"));
+    expect(adminMenuItem).toBeDefined();
+
+    // Find the checkbox inside the menuitem and click it
+    const checkbox = within(adminMenuItem!).getByRole("checkbox");
+    fireEvent.click(checkbox);
+
+    await waitFor(() => expect(screen.getByText(/delete failed/i)).toBeInTheDocument());
+  });
+
+  it("renders multiple roles as labels", async () => {
+    const multiRoleUser: UserInfo = {
+      ...mockUser,
+      roles: { env1: ["admin", "observer"], env2: [] },
+    };
+    server = setupServer(
+      http.get("/api/v2/environment", () => HttpResponse.json({ data: mockEnvironments })),
+      http.get("/api/v2/role", () => HttpResponse.json({ data: mockRoles }))
+    );
+    server.listen();
+    renderWithClient(<NestedUserRoleTable {...multiRoleUser} />);
+    expect(await screen.findByText("admin")).toBeInTheDocument();
+    expect(screen.getByText("observer")).toBeInTheDocument();
+  });
+
+  it("renders no rows if no environments", async () => {
+    server = setupServer(http.get("/api/v2/environment", () => HttpResponse.json({ data: [] })));
+    server.listen();
+    renderWithClient(<NestedUserRoleTable {...mockUser} />);
+    expect(screen.queryByText("Production")).not.toBeInTheDocument();
+    expect(screen.queryByText("Staging")).not.toBeInTheDocument();
+  });
+});

--- a/src/Slices/UserManagement/UI/Components/NestedUserRoleTable.tsx
+++ b/src/Slices/UserManagement/UI/Components/NestedUserRoleTable.tsx
@@ -108,7 +108,7 @@ const RoleSelector: React.FC<{
       client.invalidateQueries({ queryKey: getUserKey.list() });
     },
     onError: (error) => {
-      setErrors([...errors, error.message]);
+      setErrors((prev) => [...prev, error.message]);
     },
   });
   const { mutate: deleteRole } = useDeleteRole(username, {
@@ -116,7 +116,7 @@ const RoleSelector: React.FC<{
       client.invalidateQueries({ queryKey: getUserKey.list() });
     },
     onError: (error) => {
-      setErrors([...errors, error.message]);
+      setErrors((prev) => [...prev, error.message]);
     },
   });
 

--- a/src/Slices/UserManagement/UI/Components/NestedUserRoleTable.tsx
+++ b/src/Slices/UserManagement/UI/Components/NestedUserRoleTable.tsx
@@ -1,0 +1,190 @@
+import { useState } from "react";
+import {
+  Alert,
+  AlertGroup,
+  Label,
+  MenuToggle,
+  MenuToggleElement,
+  Select,
+  SelectList,
+  SelectOption,
+} from "@patternfly/react-core";
+import { Flex, FlexItem } from "@patternfly/react-core";
+import { Table, Tbody, Tr, Td, Thead, Th } from "@patternfly/react-table";
+import { useQueryClient } from "@tanstack/react-query";
+import { uniqueId } from "lodash";
+import { Environment } from "@/Core/Domain/ProjectModel";
+import {
+  UserInfo,
+  useGetEnvironments,
+  useGetRoles,
+  useAddRole,
+  useDeleteRole,
+  getUserKey,
+} from "@/Data/Queries";
+import { words } from "@/UI";
+
+/**
+ * A table that displays the roles of a user, for all environments.
+ * @param user - The user to display the roles for.
+ * @returns The table.
+ */
+export const NestedUserRoleTable: React.FC<UserInfo> = (user: UserInfo) => {
+  // get all environments from api
+  const { data: environments } = useGetEnvironments().useOneTime();
+
+  // we need to map the environments to the roles, and display the names of the environments instead of the ids
+  // we use a Map to avoid duplicates, since multiple environments can have the same set of roles for a specific user.
+  const mappedEnvironments = environments?.map((environment: Environment) => ({
+    id: environment.id,
+    name: environment.name,
+  }));
+
+  return (
+    <Table variant="compact" aria-label="Nested-Roles-Table">
+      <Thead>
+        <Tr>
+          <Th width={40}>{words("userManagement.environment")}</Th>
+          <Th width={60}>{words("userManagement.role")}</Th>
+        </Tr>
+      </Thead>
+      <Tbody>
+        {mappedEnvironments?.map((environment: { id: string; name: string }) => (
+          <Tr key={environment.id}>
+            <Td width={40}>{environment.name}</Td>
+            <Td width={60}>
+              <Flex
+                alignItems={{ default: "alignItemsCenter" }}
+                spaceItems={{ default: "spaceItemsSm" }}
+              >
+                <FlexItem>
+                  <RoleSelector
+                    selectedRoles={user.roles[environment.id]}
+                    environmentId={environment.id}
+                    username={user.username}
+                  />
+                </FlexItem>
+                {user.roles[environment.id]?.length > 0 ? (
+                  user.roles[environment.id].map((role) => (
+                    <FlexItem key={role}>
+                      <Label data-testid={`role-label-${role}`} color="blue">
+                        {role}
+                      </Label>
+                    </FlexItem>
+                  ))
+                ) : (
+                  <FlexItem>{words("userManagement.roles.none")}</FlexItem>
+                )}
+              </Flex>
+            </Td>
+          </Tr>
+        ))}
+      </Tbody>
+    </Table>
+  );
+};
+
+/**
+ * A dropdown menu for the roles, multiselect and mutation hooks to update the roles.
+ * @param selectedRoles - The roles that are currently selected.
+ * @param environmentId - The id of the environment.
+ * @param username - The username of the user.
+ * @returns The dropdown menu.
+ */
+const RoleSelector: React.FC<{
+  selectedRoles: string[];
+  environmentId: string;
+  username: string;
+}> = ({ selectedRoles, environmentId, username }) => {
+  const client = useQueryClient();
+  const { data: availableRoles, isLoading: isLoadingAvailableRoles } =
+    useGetRoles(environmentId).useOneTime();
+  const [errors, setErrors] = useState<string[]>([]);
+
+  const [isOpen, setIsOpen] = useState(false);
+
+  const { mutate: addRole } = useAddRole(username, {
+    onSuccess: () => {
+      client.invalidateQueries({ queryKey: getUserKey.list() });
+    },
+    onError: (error) => {
+      setErrors([...errors, error.message]);
+    },
+  });
+  const { mutate: deleteRole } = useDeleteRole(username, {
+    onSuccess: () => {
+      client.invalidateQueries({ queryKey: getUserKey.list() });
+    },
+    onError: (error) => {
+      setErrors([...errors, error.message]);
+    },
+  });
+
+  // no roles available from the api
+  if (!isLoadingAvailableRoles && !availableRoles) {
+    return <>{words("userManagement.roles.unavailable")}</>;
+  }
+
+  const onSelect = (
+    _event: React.MouseEvent<Element, MouseEvent> | undefined,
+    value: string | number | undefined
+  ) => {
+    // if the value is in the selectedRoles, remove it
+    if (selectedRoles?.includes(value as string)) {
+      deleteRole({ role: value as string, environment: environmentId });
+    } else {
+      addRole({ role: value as string, environment: environmentId });
+    }
+  };
+
+  const menuToggle = (toggleRef: React.Ref<MenuToggleElement>) => (
+    <MenuToggle
+      ref={toggleRef}
+      aria-label="role-selector"
+      onClick={() => setIsOpen(!isOpen)}
+      isExpanded={isOpen}
+    >
+      {words("userManagement.roles.edit")}
+    </MenuToggle>
+  );
+
+  return (
+    <>
+      {errors.length > 0 && (
+        <AlertGroup isLiveRegion aria-live="polite" isToast>
+          {errors.map((error) => (
+            <Alert
+              variant="danger"
+              title="Error"
+              key={"error-" + uniqueId()}
+              timeout={5000}
+              aria-label="error-message"
+            >
+              {error}
+            </Alert>
+          ))}
+        </AlertGroup>
+      )}
+      <Select
+        id="role-selector"
+        isOpen={isOpen}
+        toggle={menuToggle}
+        onSelect={onSelect}
+        onOpenChange={(nextOpen: boolean) => setIsOpen(nextOpen)}
+      >
+        <SelectList>
+          {availableRoles?.map((role: string) => (
+            <SelectOption
+              key={role}
+              value={role}
+              hasCheckbox
+              isSelected={selectedRoles?.includes(role) ?? false}
+            >
+              {role}
+            </SelectOption>
+          ))}
+        </SelectList>
+      </Select>
+    </>
+  );
+};

--- a/src/Slices/UserManagement/UI/Components/UserInfoRow.tsx
+++ b/src/Slices/UserManagement/UI/Components/UserInfoRow.tsx
@@ -73,46 +73,48 @@ export const UserInfoRow: React.FC<Props> = ({ user, setAlertMessage }) => {
     });
   };
 
-  return [
-    <Tr aria-label={`row-${user.username}`} data-testid="user-row">
-      <Td dataLabel={user.username}>
-        {user.is_admin && (
-          <>
-            <UserShieldIcon />{" "}
-          </>
-        )}
-        {user.username}
-      </Td>
-      {showRoles && (
-        <Td dataLabel={words("userManagement.roles")}>
-          <Button variant="link" onClick={() => setIsExpanded(!isExpanded)} isInline>
-            {Object.keys(user.roles).length > 0
-              ? [...new Set(Object.values(user.roles).flat())].join(", ")
-              : words("userManagement.roles.none")}
-          </Button>
+  return (
+    <>
+      <Tr aria-label={`row-${user.username}`} data-testid="user-row">
+        <Td dataLabel={user.username}>
+          {user.is_admin && (
+            <>
+              <UserShieldIcon />{" "}
+            </>
+          )}
+          {user.username}
         </Td>
-      )}
-      <Td id={`${user.username}-actions`} dataLabel={words("userManagement.actions")}>
-        <Flex justifyContent={{ default: "justifyContentFlexEnd" }}>
-          <FlexItem>
-            <Button variant="primary" onClick={openChangePasswordModal} size="sm">
-              {words("userManagement.changePassword")}
+        {showRoles && (
+          <Td dataLabel={words("userManagement.roles")}>
+            <Button variant="link" onClick={() => setIsExpanded(!isExpanded)} isInline>
+              {Object.keys(user.roles).length > 0
+                ? [...new Set(Object.values(user.roles).flat())].join(", ")
+                : words("userManagement.roles.none")}
             </Button>
-          </FlexItem>
-          <FlexItem>
-            <Button variant="danger" onClick={openDeleteModal} size="sm">
-              {words("delete")}
-            </Button>
-          </FlexItem>
-        </Flex>
-      </Td>
-    </Tr>,
-    showRoles && isExpanded && (
-      <Tr aria-label={`expanded-row-${user.username}`} isStriped>
-        <Td colSpan={3}>
-          <NestedUserRoleTable {...user} />
+          </Td>
+        )}
+        <Td id={`${user.username}-actions`} dataLabel={words("userManagement.actions")}>
+          <Flex justifyContent={{ default: "justifyContentFlexEnd" }}>
+            <FlexItem>
+              <Button variant="primary" onClick={openChangePasswordModal} size="sm">
+                {words("userManagement.changePassword")}
+              </Button>
+            </FlexItem>
+            <FlexItem>
+              <Button variant="danger" onClick={openDeleteModal} size="sm">
+                {words("delete")}
+              </Button>
+            </FlexItem>
+          </Flex>
         </Td>
       </Tr>
-    ),
-  ];
+      {showRoles && isExpanded && (
+        <Tr aria-label={`expanded-row-${user.username}`} isStriped>
+          <Td colSpan={3}>
+            <NestedUserRoleTable {...user} />
+          </Td>
+        </Tr>
+      )}
+    </>
+  );
 };

--- a/src/Slices/UserManagement/UI/Components/UserInfoRow.tsx
+++ b/src/Slices/UserManagement/UI/Components/UserInfoRow.tsx
@@ -1,11 +1,12 @@
 import React, { useContext } from "react";
 import { Button, Flex, FlexItem } from "@patternfly/react-core";
-import { Td, Tr } from "@patternfly/react-table";
+import { Td, Tr, ExpandableRowContent } from "@patternfly/react-table";
 import { useRemoveUser, UserInfo } from "@/Data/Queries";
 import { words } from "@/UI";
 import { ConfirmUserActionForm } from "@/UI/Components";
 import { ModalContext } from "@/UI/Root/Components/ModalProvider";
 import { ChangePasswordForm } from "./ChangePasswordForm";
+import { UserShieldIcon } from "@patternfly/react-icons";
 
 interface Props {
   user: UserInfo;
@@ -21,6 +22,7 @@ interface Props {
  */
 export const UserInfoRow: React.FC<Props> = ({ user, setAlertMessage }) => {
   const { triggerModal, closeModal } = useContext(ModalContext);
+  console.log("UserInfoRow", user);
 
   const { mutate } = useRemoveUser();
 
@@ -70,7 +72,15 @@ export const UserInfoRow: React.FC<Props> = ({ user, setAlertMessage }) => {
 
   return (
     <Tr aria-label={`row-${user.username}`} data-testid="user-row">
-      <Td dataLabel={user.username}>{user.username}</Td>
+      <Td dataLabel={user.username}>
+        {user.is_admin && (
+          <>
+            <UserShieldIcon />
+            {" "}
+          </>
+        )}
+        {user.username}
+      </Td>
       <Td id={`${user.username}-actions`} dataLabel={words("userManagement.actions")}>
         <Flex justifyContent={{ default: "justifyContentFlexEnd" }}>
           <FlexItem>

--- a/src/Slices/UserManagement/UI/Page.test.tsx
+++ b/src/Slices/UserManagement/UI/Page.test.tsx
@@ -162,8 +162,8 @@ describe("UserManagementPage", () => {
 
   it("should sent request to add user to the list", async () => {
     const data: UserInfo[] = [
-      { username: "test_user", auth_method: "database" },
-      { username: "test_user2", auth_method: "oidc" },
+      { username: "test_user", auth_method: "database", is_admin: false, roles: {} },
+      { username: "test_user2", auth_method: "oidc", is_admin: false, roles: {} },
     ];
     const server = setupServer(
       http.get("/api/v2/user", async () => {
@@ -196,7 +196,12 @@ describe("UserManagementPage", () => {
           );
         }
 
-        data.push({ username: reqBody?.username, auth_method: "database" });
+        data.push({
+          username: reqBody?.username,
+          auth_method: "database",
+          is_admin: false,
+          roles: {},
+        });
 
         return HttpResponse.json({
           username: "new_user",
@@ -331,8 +336,8 @@ describe("UserManagementPage", () => {
 
   it("should sent request to remove user from the list", async () => {
     const data: UserInfo[] = [
-      { username: "test_user", auth_method: "database" },
-      { username: "test_user2", auth_method: "oidc" },
+      { username: "test_user", auth_method: "database", is_admin: false, roles: {} },
+      { username: "test_user2", auth_method: "oidc", is_admin: false, roles: {} },
     ];
     const server = setupServer(
       http.get("/api/v2/user", async (): Promise<HttpResponse> => {

--- a/src/Slices/UserManagement/UI/Page.tsx
+++ b/src/Slices/UserManagement/UI/Page.tsx
@@ -8,10 +8,21 @@ import { EmptyView, ErrorView, LoadingView, PageContainer, ToastAlert } from "@/
 import { ModalContext } from "@/UI/Root/Components/ModalProvider";
 import { UserInfoRow } from "./Components/UserInfoRow";
 
+/**
+ * User Management Page
+ *
+ * This page displays a list of users and allows for user management.
+ * It should only be visible when the auth method is database.
+ *
+ * @returns {React.FC}
+ */
 export const UserManagementPage: React.FC = () => {
   const { triggerModal } = useContext(ModalContext);
   const [alertMessage, setAlertMessage] = useState<string | null>(null);
   const { data, isSuccess, isError, error, refetch } = useGetUsers().useOneTime();
+
+  const authConfig = globalThis && globalThis.auth;
+  const showRoles = authConfig?.provider === "policy-engine" && authConfig?.method === "database";
 
   /**
    * Opens a modal with a form for user credentials.
@@ -67,7 +78,8 @@ export const UserManagementPage: React.FC = () => {
           <Table aria-label="users-table">
             <Thead>
               <Tr>
-                <Th width={80}>{words("userManagement.name")}</Th>
+                <Th width={40}>{words("userManagement.name")}</Th>
+                {showRoles && <Th width={40}>{words("userManagement.roles")}</Th>}
                 <Th
                   isStickyColumn
                   stickyMinWidth="340px"

--- a/src/UI/Root/Components/Header/EnvSelector/EnvSelector.tsx
+++ b/src/UI/Root/Components/Header/EnvSelector/EnvSelector.tsx
@@ -39,6 +39,10 @@ export const EnvSelector: React.FC<Props> = ({
     setIsOpen(!isOpen);
   };
 
+  // Only show the user management link if the auth method is database. Other auth methods have external user and role management.
+  const authConfig = globalThis && globalThis.auth;
+  const showUserManagement = !authHelper.isDisabled() && authConfig?.method === "database";
+
   return (
     <Dropdown
       isOpen={isOpen}
@@ -82,7 +86,7 @@ export const EnvSelector: React.FC<Props> = ({
               {words("home.navigation.button")}
             </DropdownItem>
           </Tooltip>
-          {!authHelper.isDisabled() && (
+          {showUserManagement && (
             <>
               <DropdownItem
                 onClick={() => navigate(routeManager.getUrl("UserManagement", undefined))}

--- a/src/UI/Root/Components/PageFrame/PageFrame.tsx
+++ b/src/UI/Root/Components/PageFrame/PageFrame.tsx
@@ -16,7 +16,6 @@ export const PageFrame: React.FC<React.PropsWithChildren<Props>> = ({
   children,
   environmentId,
 }) => {
-
   const {
     onNotificationsToggle,
     notificationDrawer,

--- a/src/UI/Root/Components/PageFrame/PageFrame.tsx
+++ b/src/UI/Root/Components/PageFrame/PageFrame.tsx
@@ -16,6 +16,7 @@ export const PageFrame: React.FC<React.PropsWithChildren<Props>> = ({
   children,
   environmentId,
 }) => {
+
   const {
     onNotificationsToggle,
     notificationDrawer,

--- a/src/UI/words.tsx
+++ b/src/UI/words.tsx
@@ -852,6 +852,13 @@ const dict = {
   "userManagement.deleteUserMessage": (username: string) =>
     `Are you sure you want to delete user ${username}?`,
   "userManagement.empty.message": "No users found",
+  "userManagement.roles": "Roles",
+  "userManagement.roles.placeholder": "Select roles...",
+  "userManagement.roles.none": "None",
+  "userManagement.roles.unavailable": "No roles available",
+  "userManagement.roles.edit": "Edit roles",
+  "userManagement.environment": "Environment",
+  "userManagement.role": "Role",
 
   /**
    * Markdown Previewer related text

--- a/src/config.js
+++ b/src/config.js
@@ -7,9 +7,9 @@
  */
 
 // local auth
-window.auth = {
-  method: "database",
-  provider: "policy-engine",
-};
+// window.auth = {
+//   method: "database",
+//   provider: "policy-engine",
+// };
 
 export const features = [];

--- a/src/config.js
+++ b/src/config.js
@@ -9,6 +9,7 @@
 // local auth
 window.auth = {
   method: "database",
+  provider: "policy-engine",
 };
 
 export const features = [];

--- a/src/config.js
+++ b/src/config.js
@@ -6,4 +6,9 @@
 };
  */
 
+// local auth
+window.auth = {
+  method: "database",
+};
+
 export const features = [];

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -89,25 +89,31 @@ function copyConfigPlugin() {
       const configSource = resolve(__dirname, "src/config.js");
       const configDest = resolve(distDir, "config.js");
       const htmlFile = resolve(distDir, "index.html");
-
+      // Copy favicon.ico from public/images/ to dist/
+      const faviconSource = resolve(__dirname, "public/images/favicon.ico");
+      const faviconDest = resolve(distDir, "favicon.ico");
       try {
         // Copy config.js to dist root
         writeFileSync(configDest, readFileSync(configSource, "utf-8"));
         console.log("config.js copied to build output");
-
+        // Copy favicon.ico to dist root
+        if (statSync(faviconSource, { throwIfNoEntry: false })) {
+          writeFileSync(faviconDest, readFileSync(faviconSource));
+          console.log("favicon.ico copied to build output root");
+        }
         // Update HTML to include config.js script before the main script in the head section
         if (statSync(htmlFile, { throwIfNoEntry: false })) {
           let htmlContent = readFileSync(htmlFile, "utf-8");
           // Insert config.js script before the main script in the head section
           htmlContent = htmlContent.replace(
-            /(<script type="module" crossorigin src="\.\/[^"]+\.js"><\/script>)/,
+            /(<script type="module" crossorigin src="\.\/[^\"]+\.js"><\/script>)/,
             '  <script type="module" src="./config.js"></script>\n$1'
           );
           writeFileSync(htmlFile, htmlContent, "utf-8");
           console.log("HTML updated to include config.js script");
         }
       } catch (error) {
-        console.error("Failed to copy config.js or update HTML:", error);
+        console.error("Failed to copy config.js, favicon.ico, or update HTML:", error);
       }
     },
   };


### PR DESCRIPTION
# Description

  Add support for role management to user management page.
  
  This feature allows to assign and manage user roles directly from the web console.
  
  Note: Role management is only supported when using the database authentication method in combination with the policy-engine authorization provider.
  
  See the [Inmanta documentation](https://docs.inmanta.com/inmanta-service-orchestrator-dev/9/administrators/authorization.html#integration-with-database-authentication) for details on configuring roles and permissions.

closes #6440

E2E test suit results for Local auth:
<img width="365" height="116" alt="image" src="https://github.com/user-attachments/assets/9f5af388-3795-4621-b9c5-e5ab966bc728" />

Visuals:
<img width="1274" height="669" alt="image" src="https://github.com/user-attachments/assets/34af2858-8d3c-4868-b5ba-500bfbcf8fcd" />

