### PR TITLE
Fix missing logout button when using Keycloak authentication

### DIFF
--- a/changelogs/unreleased/keycloak-missing-logout.yml
+++ b/changelogs/unreleased/keycloak-missing-logout.yml
@@ -1,0 +1,5 @@
+change-type: patch
+description: Fix missing logout button when using Keycloak authentication
+destination-branches:
+- master
+sections: {}

--- a/src/UI/Root/Components/Header/EnvSelector/EnvSelector.tsx
+++ b/src/UI/Root/Components/Header/EnvSelector/EnvSelector.tsx
@@ -42,6 +42,7 @@ export const EnvSelector: React.FC<Props> = ({
   // Only show the user management link if the auth method is database. Other auth methods have external user and role management.
   const authConfig = globalThis && globalThis.auth;
   const showUserManagement = !authHelper.isDisabled() && authConfig?.method === "database";
+  const showLogout = !authHelper.isDisabled();
 
   return (
     <Dropdown
@@ -86,18 +87,20 @@ export const EnvSelector: React.FC<Props> = ({
               {words("home.navigation.button")}
             </DropdownItem>
           </Tooltip>
-          {showUserManagement && (
-            <>
+          <>
+            {showUserManagement && (
               <DropdownItem
                 onClick={() => navigate(routeManager.getUrl("UserManagement", undefined))}
               >
                 {words("userManagement.title")}
               </DropdownItem>
+            )}
+            {showLogout && (
               <DropdownItem onClick={() => authHelper.logout()}>
                 {words("dashboard.logout")}
               </DropdownItem>
-            </>
-          )}
+            )}
+          </>
         </div>
         <DarkmodeOption />
       </DropdownList>


### PR DESCRIPTION
# Description

With adding the role management, and the conditional to only show the userManagement menu option, I by mistake included the logout button in that check. I've split it up now.
This fixes the Keycloak pipeline.
