### PR TITLE
Prevent stalling when environment is missing or invalid.

### DIFF
--- a/changelogs/unreleased/prevent-stalling-env-missing.yml
+++ b/changelogs/unreleased/prevent-stalling-env-missing.yml
@@ -1,0 +1,6 @@
+change-type: patch
+description: Prevent stalling when environment is missing or invalid.
+destination-branches:
+- master
+- iso8
+sections: {}

--- a/src/Slices/Notification/UI/Badge/Badge.tsx
+++ b/src/Slices/Notification/UI/Badge/Badge.tsx
@@ -23,13 +23,14 @@ export const Badge: React.FC<{ onClick(): void }> = ({ onClick }) => {
   const [errorMessage, setErrorMessage] = useState("");
 
   useEffect(() => {
-    if (isError) {
+    // We add the check for envID to prevent blocking the UI when an environment id is not valid or missing.
+    if (isError && envID) {
       setErrorMessage(error.message);
     }
-    if (isSuccess && data.errors && data.errors.length > 0) {
+    if (isSuccess && data.errors && data.errors.length > 0 && envID) {
       setErrorMessage(data.errors.join(", "));
     }
-  }, [data, isError, isSuccess, error]);
+  }, [data, isError, isSuccess, error, envID]);
 
   if (errorMessage) {
     return (

--- a/src/UI/Dependency/EnvironmentHandler.ts
+++ b/src/UI/Dependency/EnvironmentHandler.ts
@@ -41,7 +41,7 @@ export function EnvironmentHandlerImpl(
     const environment = useSelected();
 
     if (typeof environment === "undefined") {
-      throw new Error("environment required but missing");
+      return "";
     }
 
     return environment.id;
@@ -51,7 +51,7 @@ export function EnvironmentHandlerImpl(
     const environment = useSelected();
 
     if (typeof environment === "undefined") {
-      throw new Error("environment required but missing");
+      return "";
     }
 
     return environment.name;

--- a/src/UI/Root/Components/Sidebar/EnvironmentControls/EnvironmentControls.tsx
+++ b/src/UI/Root/Components/Sidebar/EnvironmentControls/EnvironmentControls.tsx
@@ -23,10 +23,10 @@ export const EnvironmentControls: React.FC = () => {
     if (isSuccess) {
       document.dispatchEvent(new CustomEvent("status-up"));
     }
-    if (isError) {
+    if (isError && id) {
       document.dispatchEvent(new CustomEvent("status-down"));
     }
-  }, [isError, isSuccess]);
+  }, [isError, isSuccess, id]);
 
   if (isSuccess) {
     return (


### PR DESCRIPTION
# Description

## Issue
The app crashed whenever the url contained an invalid environment id, or if the id was missing anywhere in the query-hooks.

The error was being thrown during React's rendering phase from within a custom hook (environmentHandler.useId() or environmentHandler.useName()). While Error Boundaries should catch rendering errors, there are specific cases where they might not:
- Context hook errors - Errors thrown from within context hooks during the initial render might bypass error boundaries in certain scenarios
- Hook execution timing - The error occurs during hook execution which might happen before the Error Boundary is fully set up

## Solution
I removed the throws and handled the case where the id was required and would block the UI. The app now redirects to the home page whenever it cannot find the environment id. 
I also had the behavior setting the status-down, a missing environment would result in showing the icon red, but the statuspage doesn't provide information about missing environments, so it wasn't relevant.


https://github.com/user-attachments/assets/f9b8bb3e-71b6-4906-b4fc-57a6ba145708

