### PR TITLE
6488 protected settings

### DIFF
--- a/changelogs/unreleased/6488-protected-settings.yml
+++ b/changelogs/unreleased/6488-protected-settings.yml
@@ -3,4 +3,5 @@ description: Add support for protected settings in the Environment Settings page
 issue-nr: 6488
 destination-branches:
 - master
-sections: {}
+sections: 
+  minor-improvement: "{{description}}"

--- a/changelogs/unreleased/6488-protected-settings.yml
+++ b/changelogs/unreleased/6488-protected-settings.yml
@@ -1,0 +1,6 @@
+change-type: patch
+description: Add support for protected settings in the Environment Settings page
+issue-nr: 6488
+destination-branches:
+- master
+sections: {}

--- a/src/Core/Domain/EnvironmentSettings.ts
+++ b/src/Core/Domain/EnvironmentSettings.ts
@@ -29,6 +29,8 @@ interface BaseDefinition {
   update_model: boolean;
   agent_restart: boolean;
   section: string;
+  protected: boolean;
+  protected_by: string | null;
 }
 
 export interface UnknownDefinition extends BaseDefinition {

--- a/src/Slices/Settings/UI/Tabs/Configuration/Components/BooleanInput.tsx
+++ b/src/Slices/Settings/UI/Tabs/Configuration/Components/BooleanInput.tsx
@@ -11,6 +11,7 @@ export const BooleanInput: React.FC<Props> = ({ info }) => (
   <Flex direction={{ default: "row" }}>
     <FlexItem>
       <Switch
+        isDisabled={info.protected}
         isChecked={info.value}
         onChange={(_event, value) => info.set(value)}
         aria-label={`Toggle-${info.name}`}

--- a/src/Slices/Settings/UI/Tabs/Configuration/Components/DictInput.tsx
+++ b/src/Slices/Settings/UI/Tabs/Configuration/Components/DictInput.tsx
@@ -39,6 +39,7 @@ export const DictInputWithRow: React.FC<Props> = ({ info }) => {
             newEntry={newEntry}
             setNewEntry={setNewEntry}
             isDeleteEntryAllowed={isDeleteEntryAllowed}
+            isDisabled={info.protected}
           />
         </FlexItem>
 

--- a/src/Slices/Settings/UI/Tabs/Configuration/Components/EnumInput.tsx
+++ b/src/Slices/Settings/UI/Tabs/Configuration/Components/EnumInput.tsx
@@ -18,6 +18,7 @@ export const EnumInput: React.FC<Props> = ({ info }) => {
     <Flex direction={{ default: "row" }}>
       <FlexItem grow={{ default: "grow" }}>
         <SingleTextSelect
+          isDisabled={info.protected}
           selected={info.value}
           setSelected={setSelected}
           options={options}

--- a/src/Slices/Settings/UI/Tabs/Configuration/Components/InputActions.tsx
+++ b/src/Slices/Settings/UI/Tabs/Configuration/Components/InputActions.tsx
@@ -19,7 +19,6 @@ export const InputActions: React.FC<Props> = ({ info }) => (
   </ActionList>
 );
 
-
 const InputUpdateAction: React.FC<{
   info: EnvironmentSettings.InputInfo;
 }> = ({ info }) => (

--- a/src/Slices/Settings/UI/Tabs/Configuration/Components/InputActions.tsx
+++ b/src/Slices/Settings/UI/Tabs/Configuration/Components/InputActions.tsx
@@ -2,14 +2,10 @@ import React from "react";
 import { ActionList, ActionListItem, Button } from "@patternfly/react-core";
 import { SaveIcon, UndoIcon } from "@patternfly/react-icons";
 import { EnvironmentSettings } from "@/Core";
-
-type Info<Properties extends keyof EnvironmentSettings.InputInfo> = Pick<
-  EnvironmentSettings.InputInfo,
-  Properties
->;
+import { words } from "@/UI";
 
 interface Props {
-  info: Info<"value" | "initial" | "update" | "reset" | "default">;
+  info: EnvironmentSettings.InputInfo;
 }
 
 export const InputActions: React.FC<Props> = ({ info }) => (
@@ -23,28 +19,31 @@ export const InputActions: React.FC<Props> = ({ info }) => (
   </ActionList>
 );
 
+
 const InputUpdateAction: React.FC<{
-  info: Info<"value" | "initial" | "update">;
+  info: EnvironmentSettings.InputInfo;
 }> = ({ info }) => (
   <Button
     variant="secondary"
+    isDisabled={info.protected}
     aria-label="SaveAction"
     onClick={() => info.update(info.value as never)}
     icon={<SaveIcon />}
   >
-    Save
+    {words("save")}
   </Button>
 );
 
 const InputResetAction: React.FC<{
-  info: Info<"reset">;
+  info: EnvironmentSettings.InputInfo;
 }> = ({ info }) => (
   <Button
+    isDisabled={info.protected}
     icon={<UndoIcon />}
     variant="tertiary"
     aria-label="ResetAction"
     onClick={() => info.reset()}
   >
-    Reset
+    {words("reset")}
   </Button>
 );

--- a/src/Slices/Settings/UI/Tabs/Configuration/Components/InputRow.tsx
+++ b/src/Slices/Settings/UI/Tabs/Configuration/Components/InputRow.tsx
@@ -13,7 +13,6 @@ interface Props {
 }
 
 export const InputRow: React.FC<Props> = ({ info }) => {
-  console.log("info", info);
   switch (info.type) {
     case "bool":
       return (

--- a/src/Slices/Settings/UI/Tabs/Configuration/Components/InputRow.tsx
+++ b/src/Slices/Settings/UI/Tabs/Configuration/Components/InputRow.tsx
@@ -17,7 +17,7 @@ export const InputRow: React.FC<Props> = ({ info }) => {
     case "bool":
       return (
         <Row info={info}>
-          <BooleanInput info={info}/>
+          <BooleanInput info={info} />
         </Row>
       );
     case "int":

--- a/src/Slices/Settings/UI/Tabs/Configuration/Components/InputRow.tsx
+++ b/src/Slices/Settings/UI/Tabs/Configuration/Components/InputRow.tsx
@@ -13,11 +13,12 @@ interface Props {
 }
 
 export const InputRow: React.FC<Props> = ({ info }) => {
+  console.log("info", info);
   switch (info.type) {
     case "bool":
       return (
         <Row info={info}>
-          <BooleanInput info={info} />
+          <BooleanInput info={info}/>
         </Row>
       );
     case "int":

--- a/src/Slices/Settings/UI/Tabs/Configuration/Components/IntInput.tsx
+++ b/src/Slices/Settings/UI/Tabs/Configuration/Components/IntInput.tsx
@@ -27,6 +27,7 @@ export const IntInput: React.FC<Props> = ({ info }) => {
           minusBtnAriaLabel="minus"
           plusBtnAriaLabel="plus"
           widthChars={10}
+          isDisabled={info.protected}
         />
       </FlexItem>
 

--- a/src/Slices/Settings/UI/Tabs/Configuration/Components/PositiveFloatInput.tsx
+++ b/src/Slices/Settings/UI/Tabs/Configuration/Components/PositiveFloatInput.tsx
@@ -31,6 +31,7 @@ export const PositiveFloatInput: React.FC<Props> = ({ info }) => {
           minusBtnAriaLabel="minus"
           plusBtnAriaLabel="plus"
           widthChars={10}
+          isDisabled={info.protected}
         />
       </FlexItem>
 

--- a/src/Slices/Settings/UI/Tabs/Configuration/Components/ProtectedMessage.test.tsx
+++ b/src/Slices/Settings/UI/Tabs/Configuration/Components/ProtectedMessage.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from "@testing-library/react";
+import { EnvironmentSettings } from "@/Core";
+import { words } from "@/UI";
+import { ProtectedMessage } from "./ProtectedMessage";
+
+// Helper function to create mock InputInfo
+const createMockInputInfo = (
+  overrides: Partial<EnvironmentSettings.InputInfo> = {}
+): EnvironmentSettings.InputInfo =>
+  ({
+    name: "test_setting",
+    type: "bool",
+    default: false,
+    doc: "Test setting",
+    recompile: false,
+    update_model: false,
+    agent_restart: false,
+    section: "test",
+    protected: false,
+    protected_by: null,
+    initial: false,
+    value: false,
+    set: vi.fn(),
+    update: vi.fn(),
+    reset: vi.fn(),
+    isUpdateable: vi.fn(),
+    ...overrides,
+  }) as EnvironmentSettings.BooleanInputInfo;
+
+describe("ProtectedMessage", () => {
+  it("GIVEN protected input with protected_by THEN shows protected message with protected_by", () => {
+    const mockInfo = createMockInputInfo({
+      protected: true,
+      protected_by: "environment variable",
+    });
+
+    render(<ProtectedMessage info={mockInfo} />);
+
+    const expectedMessage = words("settings.protected.message")("environment variable");
+    expect(screen.getByText(expectedMessage)).toBeVisible();
+  });
+
+  it("GIVEN protected input without protected_by THEN shows default protected message", () => {
+    const mockInfo = createMockInputInfo({
+      protected: true,
+      protected_by: null,
+    });
+
+    render(<ProtectedMessage info={mockInfo} />);
+
+    const expectedMessage = words("settings.protected.message.default");
+    expect(screen.getByText(expectedMessage)).toBeVisible();
+  });
+
+  it("GIVEN non-protected input THEN does not render", () => {
+    const mockInfo = createMockInputInfo({
+      protected: false,
+      protected_by: null,
+    });
+
+    const { container } = render(<ProtectedMessage info={mockInfo} />);
+
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/src/Slices/Settings/UI/Tabs/Configuration/Components/ProtectedMessage.tsx
+++ b/src/Slices/Settings/UI/Tabs/Configuration/Components/ProtectedMessage.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { EnvironmentSettings } from "@/Core";
+import { HelperText, HelperTextItem } from '@patternfly/react-core';
+import { words } from "@/UI";
+
+interface Props {
+    info: EnvironmentSettings.InputInfo;
+}
+
+/**
+ * ProtectedMessage is a component that displays a warning message if the input is protected.
+ * @param info - The info of the input.
+ * @returns A React component.
+ */
+export const ProtectedMessage: React.FC<Props> = ({ info }) => {
+    return info.protected && (
+        <HelperText>
+            <HelperTextItem variant="warning">
+                {info.protected_by && words("settings.protected.message")(info.protected_by)}
+                {!info.protected_by && words("settings.protected.message.default")}
+            </HelperTextItem>
+        </HelperText>
+    )
+}

--- a/src/Slices/Settings/UI/Tabs/Configuration/Components/ProtectedMessage.tsx
+++ b/src/Slices/Settings/UI/Tabs/Configuration/Components/ProtectedMessage.tsx
@@ -1,10 +1,10 @@
 import React from "react";
+import { HelperText, HelperTextItem } from "@patternfly/react-core";
 import { EnvironmentSettings } from "@/Core";
-import { HelperText, HelperTextItem } from '@patternfly/react-core';
 import { words } from "@/UI";
 
 interface Props {
-    info: EnvironmentSettings.InputInfo;
+  info: EnvironmentSettings.InputInfo;
 }
 
 /**
@@ -13,12 +13,14 @@ interface Props {
  * @returns A React component.
  */
 export const ProtectedMessage: React.FC<Props> = ({ info }) => {
-    return info.protected && (
-        <HelperText>
-            <HelperTextItem variant="warning">
-                {info.protected_by && words("settings.protected.message")(info.protected_by)}
-                {!info.protected_by && words("settings.protected.message.default")}
-            </HelperTextItem>
-        </HelperText>
+  return (
+    info.protected && (
+      <HelperText>
+        <HelperTextItem variant="warning">
+          {info.protected_by && words("settings.protected.message")(info.protected_by)}
+          {!info.protected_by && words("settings.protected.message.default")}
+        </HelperTextItem>
+      </HelperText>
     )
-}
+  );
+};

--- a/src/Slices/Settings/UI/Tabs/Configuration/Components/Row.tsx
+++ b/src/Slices/Settings/UI/Tabs/Configuration/Components/Row.tsx
@@ -4,6 +4,7 @@ import { OutlinedQuestionCircleIcon } from "@patternfly/react-icons";
 import { Td, Tr } from "@patternfly/react-table";
 import { EnvironmentSettings } from "@/Core";
 import { InputActions } from "./InputActions";
+import { ProtectedMessage } from "./ProtectedMessage";
 
 interface Props {
   info: EnvironmentSettings.InputInfo;
@@ -16,6 +17,7 @@ export const Row: React.FC<React.PropsWithChildren<Props>> = ({ info, children }
       <Tooltip content={getDescription(info)}>
         <OutlinedQuestionCircleIcon />
       </Tooltip>
+      <ProtectedMessage info={info} />
     </Td>
     <Td>{children}</Td>
     <Td>

--- a/src/Slices/Settings/UI/Tabs/Configuration/Components/StringInput.tsx
+++ b/src/Slices/Settings/UI/Tabs/Configuration/Components/StringInput.tsx
@@ -16,6 +16,7 @@ export const StringInput: React.FC<Props> = ({ info }) => {
           onChange={(_event, value) => info.set(value)}
           aria-label="string input"
           type="text"
+          isDisabled={info.protected}
         />
       </FlexItem>
 

--- a/src/Slices/Settings/UI/Tabs/Configuration/Tab.test.tsx
+++ b/src/Slices/Settings/UI/Tabs/Configuration/Tab.test.tsx
@@ -281,6 +281,400 @@ describe("ConfigurationTab", () => {
     });
   });
 
+  test("GIVEN ConfigurationTab WITH protected dict setting THEN disables editing", async () => {
+    const overridenDefinition = {
+      ...EnvironmentSettings.base.definition,
+      autostart_agent_map: {
+        ...EnvironmentSettings.base.definition.autostart_agent_map,
+        protected: true,
+        protected_by: "project.yml",
+      },
+    };
+
+    server.use(
+      http.get("/api/v2/environment_settings", () => {
+        return HttpResponse.json({
+          data: {
+            settings: EnvironmentSettings.base.settings,
+            definition: overridenDefinition,
+          },
+        });
+      })
+    );
+
+    const { component } = setup();
+
+    render(component);
+
+    const row = await screen.findByRole("row", {
+      name: "Row-autostart_agent_map",
+    });
+
+    // Wait for the protected message to appear, indicating the component is properly loaded
+    await screen.findByText("This setting is protected by project.yml, and cannot be changed.");
+
+    const newEntryRow = within(row).getByRole("row", { name: "Row-newEntry" });
+    const newKeyInput = within(newEntryRow).getByRole("textbox", {
+      name: "editEntryKey",
+    });
+    const newValueInput = within(newEntryRow).getByRole("textbox", {
+      name: /editentryvalue/i,
+    });
+
+    expect(newKeyInput).toBeDisabled();
+    expect(newValueInput).toBeDisabled();
+
+    await act(async () => {
+      const results = await axe(document.body);
+
+      expect(results).toHaveNoViolations();
+    });
+  });
+
+  test("GIVEN ConfigurationTab WITH protected enum field THEN disables editing", async () => {
+    const overridenDefinition = {
+      ...EnvironmentSettings.base.definition,
+      agent_trigger_method_on_auto_deploy: {
+        ...EnvironmentSettings.base.definition.agent_trigger_method_on_auto_deploy,
+        protected: true,
+        protected_by: "project.yml",
+      },
+    };
+    server.use(
+      http.get("/api/v2/environment_settings", () => {
+        return HttpResponse.json({
+          data: {
+            settings: EnvironmentSettings.base.settings,
+            definition: overridenDefinition,
+          },
+        });
+      })
+    );
+
+    const { component } = setup();
+
+    render(component);
+
+    const row = await screen.findByRole("row", {
+      name: "Row-agent_trigger_method_on_auto_deploy",
+    });
+
+    await userEvent.click(
+      within(row).getByRole("combobox", {
+        name: "EnumInput-agent_trigger_method_on_auto_deployFilterInput",
+      })
+    );
+
+    // Check that the toggle button (which contains the combobox) is disabled by CSS class
+    const toggle = within(row).getByTestId("EnumInput-agent_trigger_method_on_auto_deploy-toggle");
+    expect(toggle).toHaveClass("pf-m-disabled");
+
+    await act(async () => {
+      const results = await axe(document.body);
+
+      expect(results).toHaveNoViolations();
+    });
+  });
+
+  test("GIVEN ConfigurationTab WITH protected boolean field THEN disables editing", async () => {
+    const overridenDefinition = {
+      ...EnvironmentSettings.base.definition,
+      auto_deploy: {
+        ...EnvironmentSettings.base.definition.auto_deploy,
+        protected: true,
+        protected_by: "config.yml",
+      },
+    };
+
+    server.use(
+      http.get("/api/v2/environment_settings", () => {
+        return HttpResponse.json({
+          data: {
+            settings: EnvironmentSettings.base.settings,
+            definition: overridenDefinition,
+          },
+        });
+      })
+    );
+
+    const { component } = setup();
+
+    render(component);
+
+    const row = await screen.findByRole("row", {
+      name: "Row-auto_deploy",
+    });
+
+    // Wait for the protected message to appear
+    await screen.findByText("This setting is protected by config.yml, and cannot be changed.");
+
+    const toggle = within(row).getByRole("switch", {
+      name: "Toggle-auto_deploy",
+    });
+
+    expect(toggle).toBeDisabled();
+
+    await act(async () => {
+      const results = await axe(document.body);
+      expect(results).toHaveNoViolations();
+    });
+  });
+
+  test("GIVEN ConfigurationTab WITH protected integer field THEN disables editing", async () => {
+    const overridenDefinition = {
+      ...EnvironmentSettings.base.definition,
+      autostart_agent_interval: {
+        ...EnvironmentSettings.base.definition.autostart_agent_interval,
+        protected: true,
+        protected_by: "environment.yml",
+      },
+    };
+
+    server.use(
+      http.get("/api/v2/environment_settings", () => {
+        return HttpResponse.json({
+          data: {
+            settings: EnvironmentSettings.base.settings,
+            definition: overridenDefinition,
+          },
+        });
+      })
+    );
+
+    const { component } = setup();
+
+    render(component);
+
+    const row = await screen.findByRole("row", {
+      name: "Row-autostart_agent_interval",
+    });
+
+    // Wait for the protected message to appear
+    await screen.findByText("This setting is protected by environment.yml, and cannot be changed.");
+
+    const numberInput = within(row).getByRole("spinbutton", {
+      name: "number input",
+    });
+    const minusButton = within(row).getByRole("button", { name: "minus" });
+    const plusButton = within(row).getByRole("button", { name: "plus" });
+
+    expect(numberInput).toBeDisabled();
+    expect(minusButton).toBeDisabled();
+    expect(plusButton).toBeDisabled();
+
+    await act(async () => {
+      const results = await axe(document.body);
+      expect(results).toHaveNoViolations();
+    });
+  });
+
+  test("GIVEN ConfigurationTab WITH protected positive float field THEN disables editing", async () => {
+    const overridenDefinition = {
+      ...EnvironmentSettings.base.definition,
+      recompile_backoff: {
+        ...EnvironmentSettings.base.definition.recompile_backoff,
+        protected: true,
+        protected_by: "project.yml",
+      },
+    };
+
+    server.use(
+      http.get("/api/v2/environment_settings", () => {
+        return HttpResponse.json({
+          data: {
+            settings: EnvironmentSettings.base.settings,
+            definition: overridenDefinition,
+          },
+        });
+      })
+    );
+
+    const { component } = setup();
+
+    render(component);
+
+    const row = await screen.findByRole("row", {
+      name: "Row-recompile_backoff",
+    });
+
+    // Wait for the protected message to appear
+    await screen.findByText("This setting is protected by project.yml, and cannot be changed.");
+
+    const numberInput = within(row).getByRole("spinbutton", {
+      name: "number input",
+    });
+    const minusButton = within(row).getByRole("button", { name: "minus" });
+    const plusButton = within(row).getByRole("button", { name: "plus" });
+
+    expect(numberInput).toBeDisabled();
+    expect(minusButton).toBeDisabled();
+    expect(plusButton).toBeDisabled();
+
+    await act(async () => {
+      const results = await axe(document.body);
+      expect(results).toHaveNoViolations();
+    });
+  });
+
+  test("GIVEN ConfigurationTab WITH protected string field THEN disables editing", async () => {
+    const overridenDefinition = {
+      ...EnvironmentSettings.base.definition,
+      auto_full_compile: {
+        ...EnvironmentSettings.base.definition.auto_full_compile,
+        protected: true,
+        protected_by: "server.conf",
+      },
+    };
+
+    server.use(
+      http.get("/api/v2/environment_settings", () => {
+        return HttpResponse.json({
+          data: {
+            settings: EnvironmentSettings.base.settings,
+            definition: overridenDefinition,
+          },
+        });
+      })
+    );
+
+    const { component } = setup();
+
+    render(component);
+
+    const row = await screen.findByRole("row", {
+      name: "Row-auto_full_compile",
+    });
+
+    // Wait for the protected message to appear
+    await screen.findByText("This setting is protected by server.conf, and cannot be changed.");
+
+    const textInput = within(row).getByRole("textbox", {
+      name: "string input",
+    });
+
+    expect(textInput).toBeDisabled();
+
+    await act(async () => {
+      const results = await axe(document.body);
+      expect(results).toHaveNoViolations();
+    });
+  });
+
+  test("GIVEN ConfigurationTab WHEN editing a boolean field THEN shows warning icon", async () => {
+    server.use(
+      http.get("/api/v2/environment_settings", () => {
+        return HttpResponse.json({ data: EnvironmentSettings.base });
+      })
+    );
+
+    const { component } = setup();
+
+    render(component);
+
+    const row = await screen.findByRole("row", {
+      name: "Row-auto_deploy",
+    });
+
+    expect(within(row).queryByRole("generic", { name: "Warning" })).not.toBeInTheDocument();
+
+    await userEvent.click(
+      within(row).getByRole<HTMLInputElement>("switch", {
+        name: "Toggle-auto_deploy",
+      })
+    );
+
+    expect(within(row).getByTestId("Warning")).toBeInTheDocument();
+
+    await act(async () => {
+      const results = await axe(document.body);
+      expect(results).toHaveNoViolations();
+    });
+  });
+
+  test("GIVEN ConfigurationTab WHEN editing an integer field THEN shows warning icon", async () => {
+    server.use(
+      http.get("/api/v2/environment_settings", () => {
+        return HttpResponse.json({ data: EnvironmentSettings.base });
+      })
+    );
+
+    const { component } = setup();
+
+    render(component);
+
+    const row = await screen.findByRole("row", {
+      name: "Row-autostart_agent_interval",
+    });
+
+    expect(within(row).queryByRole("generic", { name: "Warning" })).not.toBeInTheDocument();
+
+    await userEvent.click(within(row).getByRole("button", { name: "plus" }));
+
+    expect(within(row).getByTestId("Warning")).toBeInTheDocument();
+
+    await act(async () => {
+      const results = await axe(document.body);
+      expect(results).toHaveNoViolations();
+    });
+  });
+
+  test("GIVEN ConfigurationTab WHEN editing a positive float field THEN shows warning icon", async () => {
+    server.use(
+      http.get("/api/v2/environment_settings", () => {
+        return HttpResponse.json({ data: EnvironmentSettings.base });
+      })
+    );
+
+    const { component } = setup();
+
+    render(component);
+
+    const row = await screen.findByRole("row", {
+      name: "Row-recompile_backoff",
+    });
+
+    expect(within(row).queryByRole("generic", { name: "Warning" })).not.toBeInTheDocument();
+
+    await userEvent.click(within(row).getByRole("button", { name: "plus" }));
+
+    expect(within(row).getByTestId("Warning")).toBeInTheDocument();
+
+    await act(async () => {
+      const results = await axe(document.body);
+      expect(results).toHaveNoViolations();
+    });
+  });
+
+  test("GIVEN ConfigurationTab WHEN editing a string field THEN shows warning icon", async () => {
+    server.use(
+      http.get("/api/v2/environment_settings", () => {
+        return HttpResponse.json({ data: EnvironmentSettings.base });
+      })
+    );
+
+    const { component } = setup();
+
+    render(component);
+
+    const row = await screen.findByRole("row", {
+      name: "Row-auto_full_compile",
+    });
+    const textbox = within(row).getByRole("textbox", {
+      name: "string input",
+    });
+
+    expect(within(row).queryByRole("generic", { name: "Warning" })).not.toBeInTheDocument();
+
+    await userEvent.type(textbox, "testString");
+
+    expect(within(row).getByTestId("Warning")).toBeInTheDocument();
+
+    await act(async () => {
+      const results = await axe(document.body);
+      expect(results).toHaveNoViolations();
+    });
+  });
+
   test("ConfigurationTab can display unknown setting types as strings", async () => {
     server.use(
       http.get("/api/v2/environment_settings", () => {

--- a/src/Test/Data/EnvironmentSettings.ts
+++ b/src/Test/Data/EnvironmentSettings.ts
@@ -9,6 +9,8 @@ export const definition: EnvironmentSettings.DefinitionMap = {
     recompile: false,
     update_model: false,
     agent_restart: false,
+    protected: false,
+    protected_by: null,
     section: "deployment",
   },
   push_on_auto_deploy: {
@@ -19,6 +21,8 @@ export const definition: EnvironmentSettings.DefinitionMap = {
     recompile: false,
     update_model: false,
     agent_restart: false,
+    protected: false,
+    protected_by: null,
     section: "deployment",
   },
   agent_trigger_method_on_auto_deploy: {
@@ -30,6 +34,8 @@ export const definition: EnvironmentSettings.DefinitionMap = {
     update_model: false,
     agent_restart: false,
     allowed_values: ["push_incremental_deploy", "push_full_deploy"],
+    protected: false,
+    protected_by: null,
     section: "deployment",
   },
   environment_agent_trigger_method: {
@@ -41,6 +47,8 @@ export const definition: EnvironmentSettings.DefinitionMap = {
     update_model: false,
     agent_restart: false,
     allowed_values: ["push_incremental_deploy", "push_full_deploy"],
+    protected: false,
+    protected_by: null,
     section: "deployment",
   },
   autostart_splay: {
@@ -51,6 +59,8 @@ export const definition: EnvironmentSettings.DefinitionMap = {
     recompile: false,
     update_model: false,
     agent_restart: false,
+    protected: false,
+    protected_by: null,
     section: "agents",
   },
   autostart_agent_deploy_interval: {
@@ -61,6 +71,8 @@ export const definition: EnvironmentSettings.DefinitionMap = {
     recompile: false,
     update_model: false,
     agent_restart: true,
+    protected: false,
+    protected_by: null,
     section: "agents",
   },
   autostart_agent_deploy_splay_time: {
@@ -71,6 +83,8 @@ export const definition: EnvironmentSettings.DefinitionMap = {
     recompile: false,
     update_model: false,
     agent_restart: true,
+    protected: false,
+    protected_by: null,
     section: "agents",
   },
   autostart_agent_repair_interval: {
@@ -81,6 +95,8 @@ export const definition: EnvironmentSettings.DefinitionMap = {
     recompile: false,
     update_model: false,
     agent_restart: true,
+    protected: false,
+    protected_by: null,
     section: "agents",
   },
   autostart_agent_repair_splay_time: {
@@ -91,6 +107,8 @@ export const definition: EnvironmentSettings.DefinitionMap = {
     recompile: false,
     update_model: false,
     agent_restart: true,
+    protected: false,
+    protected_by: null,
     section: "agents",
   },
   autostart_on_start: {
@@ -101,6 +119,8 @@ export const definition: EnvironmentSettings.DefinitionMap = {
     recompile: false,
     update_model: false,
     agent_restart: false,
+    protected: false,
+    protected_by: null,
     section: "agents",
   },
   auto_full_compile: {
@@ -111,6 +131,8 @@ export const definition: EnvironmentSettings.DefinitionMap = {
     recompile: false,
     update_model: false,
     agent_restart: false,
+    protected: false,
+    protected_by: null,
     section: "compilation",
   },
   autostart_agent_map: {
@@ -123,6 +145,8 @@ export const definition: EnvironmentSettings.DefinitionMap = {
     recompile: false,
     update_model: false,
     agent_restart: true,
+    protected: false,
+    protected_by: null,
     section: "agents",
   },
   autostart_agent_interval: {
@@ -133,6 +157,8 @@ export const definition: EnvironmentSettings.DefinitionMap = {
     recompile: false,
     update_model: false,
     agent_restart: true,
+    protected: false,
+    protected_by: null,
     section: "agents",
   },
   server_compile: {
@@ -143,6 +169,8 @@ export const definition: EnvironmentSettings.DefinitionMap = {
     recompile: false,
     update_model: false,
     agent_restart: false,
+    protected: false,
+    protected_by: null,
     section: "compilation",
   },
   resource_action_logs_retention: {
@@ -153,6 +181,8 @@ export const definition: EnvironmentSettings.DefinitionMap = {
     recompile: false,
     update_model: false,
     agent_restart: false,
+    protected: false,
+    protected_by: null,
     section: "maintenance",
   },
   purge_on_delete: {
@@ -163,6 +193,8 @@ export const definition: EnvironmentSettings.DefinitionMap = {
     recompile: false,
     update_model: false,
     agent_restart: false,
+    protected: false,
+    protected_by: null,
     section: "resources",
   },
   protected_environment: {
@@ -173,6 +205,8 @@ export const definition: EnvironmentSettings.DefinitionMap = {
     recompile: false,
     update_model: false,
     agent_restart: false,
+    protected: false,
+    protected_by: null,
     section: "security",
   },
   recompile_backoff: {
@@ -183,6 +217,8 @@ export const definition: EnvironmentSettings.DefinitionMap = {
     recompile: false,
     update_model: false,
     agent_restart: false,
+    protected: false,
+    protected_by: null,
     section: "compilation",
   },
   an_unknown_setting_type: {
@@ -193,6 +229,8 @@ export const definition: EnvironmentSettings.DefinitionMap = {
     recompile: false,
     update_model: false,
     agent_restart: false,
+    protected: false,
+    protected_by: null,
     section: "unknown",
   },
 };

--- a/src/UI/Components/DictEditor/DictEditor.tsx
+++ b/src/UI/Components/DictEditor/DictEditor.tsx
@@ -124,7 +124,7 @@ const Row: React.FC<RowProps> = ({
           size="sm"
           isDisabled={isDisabled || !isDeleteable}
           aria-label="DeleteEntryAction"
-          ></Button>
+        ></Button>
       </Td>
     </Tr>
   );
@@ -138,4 +138,3 @@ const StyledTextInput = styled(TextInput)`
     }
   }
 `;
-

--- a/src/UI/Components/DictEditor/DictEditor.tsx
+++ b/src/UI/Components/DictEditor/DictEditor.tsx
@@ -15,6 +15,7 @@ interface Props {
   newEntry: Entry;
   setNewEntry: (entry: Entry) => void;
   isDeleteEntryAllowed: (value: Dict, key: string) => boolean;
+  isDisabled?: boolean;
 }
 
 export const DictEditor: React.FC<Props> = ({
@@ -23,6 +24,7 @@ export const DictEditor: React.FC<Props> = ({
   newEntry,
   setNewEntry,
   isDeleteEntryAllowed,
+  isDisabled = false,
 }) => {
   const updateEntry =
     (key: string) =>
@@ -44,6 +46,7 @@ export const DictEditor: React.FC<Props> = ({
             clear={clearEntry}
             isDeleteable={isDeleteEntryAllowed(value, entry[0])}
             aria-label={`Row-${entry[0]}`}
+            isDisabled={isDisabled}
           />
         ))}
         <Row
@@ -54,6 +57,7 @@ export const DictEditor: React.FC<Props> = ({
           isKeyEditable
           isDeleteable={newEntry[0].length > 0 || newEntry[1].length > 0}
           aria-label="Row-newEntry"
+          isDisabled={isDisabled}
         />
       </Tbody>
     </Table>
@@ -72,6 +76,7 @@ interface RowProps {
   clear: (key: string) => void;
   isDeleteable?: boolean;
   isKeyEditable?: boolean;
+  isDisabled?: boolean;
 }
 
 const Row: React.FC<RowProps> = ({
@@ -80,6 +85,7 @@ const Row: React.FC<RowProps> = ({
   clear,
   isKeyEditable,
   isDeleteable,
+  isDisabled,
   ...props
 }) => {
   const onKeyChange = (newKey) => {
@@ -90,34 +96,36 @@ const Row: React.FC<RowProps> = ({
 
   return (
     <Tr {...props}>
-      <SlimTd>
+      <Td>
         <StyledTextInput
           value={key}
           onChange={(_event, value) => onKeyChange(value)}
           type="text"
           aria-label="editEntryKey"
           readOnly={!isKeyEditable}
+          isDisabled={isDisabled}
         />
-      </SlimTd>
-      <SlimTd>
+      </Td>
+      <Td>
         <StyledTextInput
           value={value}
           onChange={(_event, value) => onValueChange(value)}
           type="text"
           aria-label="editEntryValue"
+          isDisabled={isDisabled}
         />
-      </SlimTd>
-      <SlimTd>
+      </Td>
+      <Td>
         <Button
           icon={<TrashAltIcon />}
           onClick={onClear}
           variant={isDeleteable ? "link" : "plain"}
           isDanger
           size="sm"
-          isDisabled={!isDeleteable}
+          isDisabled={isDisabled || !isDeleteable}
           aria-label="DeleteEntryAction"
-        ></Button>
-      </SlimTd>
+          ></Button>
+      </Td>
     </Tr>
   );
 };
@@ -131,8 +139,3 @@ const StyledTextInput = styled(TextInput)`
   }
 `;
 
-const SlimTd = styled(Td)`
-  &&& {
-    padding: 0;
-  }
-`;

--- a/src/UI/words.tsx
+++ b/src/UI/words.tsx
@@ -25,6 +25,7 @@ const dict = {
   deploy: "Deploy",
   expand: "Expand",
   save: "Save",
+  reset: "Reset",
   yes: "Yes",
   no: "No",
   null: "null",
@@ -688,7 +689,8 @@ const dict = {
   "settings.tabs.token.generate": "Generate",
   "settings.update": "Setting Changed",
   "settings.warning.update": "Changed value has not been saved",
-
+  "settings.protected.message": (protected_by: string) => `This setting is protected by ${protected_by}, and cannot be changed.`,
+  "settings.protected.message.default": "This setting is protected, and cannot be changed.",
   /**
    * Status
    */

--- a/src/UI/words.tsx
+++ b/src/UI/words.tsx
@@ -689,8 +689,10 @@ const dict = {
   "settings.tabs.token.generate": "Generate",
   "settings.update": "Setting Changed",
   "settings.warning.update": "Changed value has not been saved",
-  "settings.protected.message": (protected_by: string) => `This setting is protected by ${protected_by}, and cannot be changed.`,
+  "settings.protected.message": (protected_by: string) =>
+    `This setting is protected by ${protected_by}, and cannot be changed.`,
   "settings.protected.message.default": "This setting is protected, and cannot be changed.",
+
   /**
    * Status
    */


### PR DESCRIPTION
# Description

The web-console now supports protected environment settings. Fields will be disabled, and if there is a protected_by value, it will be added in the warning message.

closes : 
- #6488 

<img width="794" height="247" alt="image" src="https://github.com/user-attachments/assets/9af3176b-9690-4bd4-8d5c-0c96a3e8d72a" />

