### PR TITLE
UI improvements

### DIFF
--- a/changelogs/unreleased/increase-contrast.yml
+++ b/changelogs/unreleased/increase-contrast.yml
@@ -1,0 +1,8 @@
+change-type: patch
+description: | 
+  Increase the contrast of the blue label color to be darker than the default blue used for labels.
+  Adjust the teal color in the progress bar to contrast better with the success color.
+  Update the order of the stream outputs displayed in the compile reports page.
+  Align the position of the loading dot in the repair and deploy buttons.
+destination-branches: [master, iso8]
+sections: {}

--- a/src/Slices/CompileDetails/UI/CompileStageReportTable.tsx
+++ b/src/Slices/CompileDetails/UI/CompileStageReportTable.tsx
@@ -15,7 +15,7 @@ interface Props {
 export const CompileStageReportTable: React.FC<Props> = ({ reports }) => {
   const logs: LogViewerData[] = reports.map((report) => {
     return {
-      data: [report.command, report.errstream, report.outstream],
+      data: [report.command, report.outstream, report.errstream],
       name: report.name,
       id: report.id,
       duration: getDuration(report.started, report.completed),

--- a/src/Slices/Resource/UI/ResourcesPage/Components/ActionButton.tsx
+++ b/src/Slices/Resource/UI/ResourcesPage/Components/ActionButton.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useEffect, useState } from "react";
-import { Button, Tooltip } from "@patternfly/react-core";
+import { Button, Flex, FlexItem, Tooltip } from "@patternfly/react-core";
 import { DeployAgentsAction, useDeployAgents } from "@/Data/Queries";
 import { ActionDisabledTooltip } from "@/UI/Components";
 import { DependencyContext } from "@/UI/Dependency";
@@ -62,8 +62,14 @@ export const ResourcePageActionButton: React.FC<Props> = ({ method, tooltip, tex
   ) : (
     <Tooltip content={tooltip} entryDelay={400}>
       <Button variant="secondary" isDisabled={showSpinner} onClick={() => handleClick()}>
-        {textContent}
-        {showSpinner && <CompileReportsIndication data-testid="dot-indication" />}
+        <Flex>
+          <FlexItem>{textContent}</FlexItem>
+          {showSpinner && (
+            <FlexItem>
+              <CompileReportsIndication data-testid="dot-indication" />
+            </FlexItem>
+          )}
+        </Flex>
       </Button>
     </Tooltip>
   );

--- a/src/Slices/Resource/UI/ResourcesPage/Components/CompileReportsIndication.tsx
+++ b/src/Slices/Resource/UI/ResourcesPage/Components/CompileReportsIndication.tsx
@@ -8,13 +8,12 @@ const pendingAnimation = keyframes`
 `;
 
 export const CompileReportsIndication = styled.span`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   width: 10px;
   height: 10px;
-  margin-left: 10px;
-  position: relative;
   &::before {
-    position: absolute;
-    top: 1px;
     content: "";
     background-color: var(--pf-t--global--color--nonstatus--blue--default);
     width: 8px;

--- a/src/UI/Components/ResourceStatus/ColorConfig.ts
+++ b/src/UI/Components/ResourceStatus/ColorConfig.ts
@@ -21,13 +21,13 @@ export const labelColorConfig: Record<
 // Color config that will match the Resource.Status to a valid Patternfly color. This is used in the Progress bar.
 export const colorConfig: Record<Resource.Status, string> = {
   [Resource.Status.deployed]: "var(--pf-t--global--color--status--success--default)",
-  [Resource.Status.skipped]: "var(--pf-t--global--color--status--custom--default)",
-  [Resource.Status.skipped_for_undefined]: "var(--pf-t--global--color--status--custom--default)",
-  [Resource.Status.cancelled]: "var(--pf-t--global--color--status--custom--default)",
+  [Resource.Status.skipped]: "var(--pf-t--color--teal--50)",
+  [Resource.Status.skipped_for_undefined]: "var(--pf-t--color--teal--50)",
+  [Resource.Status.cancelled]: "var(--pf-t--color--teal--50)",
   [Resource.Status.failed]: "var(--pf-t--global--color--status--danger--default)",
   [Resource.Status.unavailable]: "var(--pf-t--global--color--status--warning--default)",
   [Resource.Status.undefined]: "var(--pf-t--global--color--status--warning--default)",
-  [Resource.Status.deploying]: "var(--pf-t--global--color--nonstatus--blue--default)",
+  [Resource.Status.deploying]: "var(--pf-t--color--blue--50)",
   [Resource.Status.available]: "var(--pf-t--global--color--nonstatus--gray--default)",
   [Resource.Status.dry]: "var(--pf-t--global--color--status--info--default)",
   [Resource.Status.orphaned]: "var(--pf-t--global--color--status--info--default)",

--- a/src/UI/Components/ResourceStatus/ResourceStatusLabel.tsx
+++ b/src/UI/Components/ResourceStatus/ResourceStatusLabel.tsx
@@ -31,7 +31,7 @@ export const ResourceStatusLabel: React.FC<Props> = ({ status, label }) => {
   }
 
   return (
-    <Label color={status} data-testid={`Status-${label}`}>
+    <Label variant="outline" color={status} data-testid={`Status-${label}`}>
       {label}
     </Label>
   );

--- a/src/UI/Styles/Global.ts
+++ b/src/UI/Styles/Global.ts
@@ -88,5 +88,15 @@ export const GlobalStyles = createGlobalStyle`
     text-transform: capitalize;
   }
 
+  /** 
+   * We are overriding the blue label color to be darker than the default blue used for labels. 
+   * The default blue is not contrasting enough with the teal label color that is used for the skipped status.
+   * in PF 5 we'd use the info status label for "deploying", but moving to PF 6, they changed their info color to purple.
+   * And that was a change we didn't want for our UI.
+  */
+  .pf-v6-c-label.pf-m-outline.pf-m-blue {
+     --pf-v6-c-label--BorderColor: var(--pf-t--color--blue--50);
+  }
+
   ${MarkdownStyles}
 `;


### PR DESCRIPTION
# Description

- Update the order of the stream outputs displayed in the compile reports page.
- Align the position of the loading dot to be properly centered in the repair and deploy buttons.
- Increase the contrast of the blue label color to be darker than the default blue used for labels.
<img width="255" height="883" alt="image" src="https://github.com/user-attachments/assets/55b80269-fe99-4e31-a568-3427a2c86993" />

- Adjust the teal color in the progress bar to contrast better with the success color.
<img width="601" height="105" alt="image" src="https://github.com/user-attachments/assets/7bb17f73-44d5-4ebb-8daf-d5a836dfdcdc" />



closes:
- #6575
- #6574
