### PR TITLE
6628 markdown diff support - ISO8

### DIFF
--- a/changelogs/unreleased/6628-diff-rendering-markdown.yml
+++ b/changelogs/unreleased/6628-diff-rendering-markdown.yml
@@ -1,0 +1,7 @@
+change-type: patch
+description: The markdown preview now supports diff fenced code blocks.
+issue-nr: "6628"
+destination-branches:
+- iso8
+sections: 
+  minor-improvement: "{{description}}"

--- a/src/UI/Styles/MarkdownStyles.ts
+++ b/src/UI/Styles/MarkdownStyles.ts
@@ -209,8 +209,58 @@ export const MarkdownStyles = `
   padding: 0;
 }
 
+.markdown-body details {
+  margin: 16px 0;
+  border: 1px solid var(--pf-t--global--border--color--default);
+  border-radius: var(--pf-t--global--border--radius--small);
+  background-color: var(--pf-t--global--background--color--secondary--default);
+}
+
 .markdown-body details summary {
+  display: flex;
+  align-items: center;
   cursor: pointer;
+  padding: var(--pf-t--global--spacer--sm) var(--pf-t--global--spacer--md);
+  list-style: none;
+  font-weight: var(--pf-t--global--font--weight--body);
+  color: var(--pf-t--global--text--color--regular);
+}
+
+.markdown-body details summary::before {
+  content: "";
+  display: inline-block;
+  flex-shrink: 0;
+  width: 0.45rem;
+  height: 0.45rem;
+  margin-right: var(--pf-t--global--spacer--sm);
+  margin-top: 0;
+  border-style: solid;
+  border-width: 0 2px 2px 0;
+  border-color: var(--pf-t--global--icon--color--regular);
+  transform-origin: center;
+  /* 45deg gives a chevron similar to fa-angle-right instead of a 90deg L-shape.
+     A slight vertical translation keeps it visually centered with the text line. */
+  transform: translateY(-2px) rotate(45deg);
+  transition: transform var(--pf-t--global--motion-duration--fast) ease-in-out;
+}
+
+.markdown-body details[open] summary::before {
+  /* Rotate further to point down when expanded, preserving vertical alignment */
+  transform: translateY(1px) rotate(135deg);
+}
+
+.markdown-body details summary::-webkit-details-marker,
+.markdown-body details summary::marker {
+  display: none;
+}
+
+.markdown-body details[open] summary {
+  border-bottom: 1px solid var(--pf-t--global--border--color--default);
+}
+
+.markdown-body details>*:not(summary) {
+  padding: var(--pf-t--global--spacer--sm) var(--pf-t--global--spacer--md)
+    var(--pf-t--global--spacer--md);
 }
 
 .markdown-body details:not([open])>*:not(summary) {
@@ -746,11 +796,12 @@ export const MarkdownStyles = `
 .markdown-body .highlight pre,
 .markdown-body pre {
   padding: 16px;
+  margin: var(--pf-t--global--spacer--sm);
   overflow: auto;
   font-size: 85%;
   line-height: 1.45;
   color: var(--pf-t--global--text--color--regular);
-  background-color: var(--pf-t--global--background--color--secondary--default);
+  background-color: var(--pf-t--global--background--color--primary--default);
   border-radius: var(--pf-t--global--border--radius--small);
 }
 
@@ -758,7 +809,7 @@ export const MarkdownStyles = `
 .markdown-body pre tt {
   display: inline;
   max-width: auto;
-  padding: 0;
+  padding: 0 var(--pf-t--global--spacer--xs);
   margin: 0;
   overflow: visible;
   line-height: inherit;
@@ -925,17 +976,17 @@ export const MarkdownStyles = `
 }
 
 .markdown-body .pl-md {
-  color: var(--pf-t--global--text--color--status--danger--default);
+  color: var(--pf-t--color--red--60);
   background-color: var(--pf-t--global--color--nonstatus--red--default);
 }
 
 .markdown-body .pl-mi1 {
-  color: var(--pf-t--global--text--color--status--success--default);
+  color: var(--pf-t--color--green--60);
   background-color: var(--pf-t--global--color--nonstatus--green--default);
 }
 
 .markdown-body .pl-mc {
-  color: var(--pf-t--global--text--color--status--danger--default);
+  color: var(--pf-t--color--red--60);
   background-color: var(--pf-t--global--color--nonstatus--red--default);
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1688,6 +1688,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@isaacs/balanced-match@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "@isaacs/balanced-match@npm:4.0.1"
+  checksum: 10/102fbc6d2c0d5edf8f6dbf2b3feb21695a21bc850f11bc47c4f06aa83bd8884fde3fe9d6d797d619901d96865fdcb4569ac2a54c937992c48885c5e3d9967fe8
+  languageName: node
+  linkType: hard
+
+"@isaacs/brace-expansion@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "@isaacs/brace-expansion@npm:5.0.0"
+  dependencies:
+    "@isaacs/balanced-match": "npm:^4.0.1"
+  checksum: 10/cf3b7f206aff12128214a1df764ac8cdbc517c110db85249b945282407e3dfc5c6e66286383a7c9391a059fc8e6e6a8ca82262fc9d2590bd615376141fbebd2d
+  languageName: node
+  linkType: hard
+
 "@isaacs/cliui@npm:^8.0.2":
   version: 8.0.2
   resolution: "@isaacs/cliui@npm:8.0.2"
@@ -2353,13 +2369,6 @@ __metadata:
   version: 6.2.2
   resolution: "@patternfly/react-tokens@npm:6.2.2"
   checksum: 10/1066728401f6a51e65342881e46ac6b2ead11cf1d59d94b205ccf81defff9c8e5dc770d119deeab7e6f7ff6418787ae887f59039f89f2746df4c4b7ebca06ebb
-  languageName: node
-  linkType: hard
-
-"@pkgjs/parseargs@npm:^0.11.0":
-  version: 0.11.0
-  resolution: "@pkgjs/parseargs@npm:0.11.0"
-  checksum: 10/115e8ceeec6bc69dff2048b35c0ab4f8bbee12d8bb6c1f4af758604586d802b6e669dcb02dda61d078de42c2b4ddce41b3d9e726d7daa6b4b850f4adbf7333ff
   languageName: node
   linkType: hard
 
@@ -8905,13 +8914,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"foreground-child@npm:^3.1.0":
-  version: 3.1.1
-  resolution: "foreground-child@npm:3.1.1"
+"foreground-child@npm:^3.3.1":
+  version: 3.3.1
+  resolution: "foreground-child@npm:3.3.1"
   dependencies:
-    cross-spawn: "npm:^7.0.0"
+    cross-spawn: "npm:^7.0.6"
     signal-exit: "npm:^4.0.1"
-  checksum: 10/087edd44857d258c4f73ad84cb8df980826569656f2550c341b27adf5335354393eec24ea2fabd43a253233fb27cee177ebe46bd0b7ea129c77e87cb1e9936fb
+  checksum: 10/427b33f997a98073c0424e5c07169264a62cda806d8d2ded159b5b903fdfc8f0a1457e06b5fc35506497acb3f1e353f025edee796300209ac6231e80edece835
   languageName: node
   linkType: hard
 
@@ -9298,18 +9307,18 @@ __metadata:
   linkType: hard
 
 "glob@npm:^11.0.0":
-  version: 11.0.0
-  resolution: "glob@npm:11.0.0"
+  version: 11.1.0
+  resolution: "glob@npm:11.1.0"
   dependencies:
-    foreground-child: "npm:^3.1.0"
-    jackspeak: "npm:^4.0.1"
-    minimatch: "npm:^10.0.0"
+    foreground-child: "npm:^3.3.1"
+    jackspeak: "npm:^4.1.1"
+    minimatch: "npm:^10.1.1"
     minipass: "npm:^7.1.2"
     package-json-from-dist: "npm:^1.0.0"
     path-scurry: "npm:^2.0.0"
   bin:
     glob: dist/esm/bin.mjs
-  checksum: 10/e66939201d11ae30fe97e3364ac2be5c59d6c9bfce18ac633edfad473eb6b46a7553f6f73658f67caaf6cccc1df1ae336298a45e9021fa5695fd78754cc1603e
+  checksum: 10/da4501819633daff8822c007bb3f93d5c4d2cbc7b15a8e886660f4497dd251a1fb4f53a85fba1e760b31704eff7164aeb2c7a82db10f9f2c362d12c02fe52cf3
   languageName: node
   linkType: hard
 
@@ -10746,16 +10755,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jackspeak@npm:^4.0.1":
-  version: 4.0.1
-  resolution: "jackspeak@npm:4.0.1"
+"jackspeak@npm:^4.1.1":
+  version: 4.1.1
+  resolution: "jackspeak@npm:4.1.1"
   dependencies:
     "@isaacs/cliui": "npm:^8.0.2"
-    "@pkgjs/parseargs": "npm:^0.11.0"
-  dependenciesMeta:
-    "@pkgjs/parseargs":
-      optional: true
-  checksum: 10/b20dc0df0dbb2903e4d540ae68308ec7d1dd60944b130e867e218c98b5d77481d65ea734b6c81c812d481500076e8b3fdfccfb38fc81cb1acf165e853da3e26c
+  checksum: 10/ffceb270ec286841f48413bfb4a50b188662dfd599378ce142b6540f3f0a66821dc9dcb1e9ebc55c6c3b24dc2226c96e5819ba9bd7a241bd29031b61911718c7
   languageName: node
   linkType: hard
 
@@ -11908,9 +11913,9 @@ __metadata:
   linkType: hard
 
 "lru-cache@npm:^11.0.0":
-  version: 11.0.0
-  resolution: "lru-cache@npm:11.0.0"
-  checksum: 10/41f36fbff8b6f199cce3e9cb2b625714f97a535dfd7f16d0988c2627f9ed4c38b6dc8f9ea7fdba19262a7c917ba41c89cad15ca3e3791fc9a2068af472b5bc8d
+  version: 11.2.4
+  resolution: "lru-cache@npm:11.2.4"
+  checksum: 10/3b2da74c0b6653767f8164c38c4c4f4d7f0cc10c62bfa512663d94a830191ae6a5af742a8d88a8b30d5f9974652d3adae53931f32069139ad24fa2a18a199aca
   languageName: node
   linkType: hard
 
@@ -12285,12 +12290,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^10.0.0":
-  version: 10.0.1
-  resolution: "minimatch@npm:10.0.1"
+"minimatch@npm:^10.1.1":
+  version: 10.1.1
+  resolution: "minimatch@npm:10.1.1"
   dependencies:
-    brace-expansion: "npm:^2.0.1"
-  checksum: 10/082e7ccbc090d5f8c4e4e029255d5a1d1e3af37bda837da2b8b0085b1503a1210c91ac90d9ebfe741d8a5f286ece820a1abb4f61dc1f82ce602a055d461d93f3
+    "@isaacs/brace-expansion": "npm:^5.0.0"
+  checksum: 10/110f38921ea527022e90f7a5f43721838ac740d0a0c26881c03b57c261354fb9a0430e40b2c56dfcea2ef3c773768f27210d1106f1f2be19cde3eea93f26f45e
   languageName: node
   linkType: hard
 
@@ -13407,12 +13412,12 @@ __metadata:
   linkType: hard
 
 "path-scurry@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "path-scurry@npm:2.0.0"
+  version: 2.0.1
+  resolution: "path-scurry@npm:2.0.1"
   dependencies:
     lru-cache: "npm:^11.0.0"
     minipass: "npm:^7.1.2"
-  checksum: 10/285ae0c2d6c34ae91dc1d5378ede21981c9a2f6de1ea9ca5a88b5a270ce9763b83dbadc7a324d512211d8d36b0c540427d3d0817030849d97a60fa840a2c59ec
+  checksum: 10/1e9c74e9ccf94d7c16056a5cb2dba9fa23eec1bc221ab15c44765486b9b9975b4cd9a4d55da15b96eadf67d5202e9a2f1cec9023fbb35fe7d9ccd0ff1891f88b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Description

This is the PR for ISO8
- Since we're still using Jest on ISO8, the tests couldn't be ported. It would have required me to mock the entire Markdown-it library, which I do not have the time for atm. I ran a test orchestrator and tested it manually to see if it was working as intended. 
