### PR TITLE
Fixed code block rendering in markdown preview.

### DIFF
--- a/changelogs/unreleased/6628-codeblock-rendering.yml
+++ b/changelogs/unreleased/6628-codeblock-rendering.yml
@@ -1,0 +1,6 @@
+description: Fixed code block rendering in markdown preview.
+change-type: patch
+destination-branches:
+- master
+- iso8
+sections: {}

--- a/src/UI/Components/MarkdownContainer/MarkdownContainer.test.tsx
+++ b/src/UI/Components/MarkdownContainer/MarkdownContainer.test.tsx
@@ -47,6 +47,28 @@ describe("MarkdownContainer", () => {
     expect(addedLine).toHaveTextContent("+ new line");
   });
 
+  it("renders code blocks without language specified correctly", () => {
+    const markdownContent =
+      "```\nsome code here\nmore code\n```\n\nThis is normal text after the code block.";
+    const webTitle = "Container_id";
+
+    render(<MarkdownContainer text={markdownContent} web_title={webTitle} />);
+
+    const container = document.querySelector(".markdown-body");
+    expect(container).not.toBeNull();
+
+    // Verify the code block is rendered
+    const codeBlock = container!.querySelector("pre > code");
+    expect(codeBlock).not.toBeNull();
+    // Check that the code block contains both lines (whitespace may be normalized in textContent)
+    const codeText = codeBlock!.textContent || "";
+    expect(codeText).toContain("some code here");
+    expect(codeText).toContain("more code");
+
+    // Verify that text after the code block is rendered normally (not as part of the code block)
+    expect(screen.getByText("This is normal text after the code block.")).toBeInTheDocument();
+  });
+
   it("renders the Markdown content with Mermaid diagrams correctly", async () => {
     const markdownContent = "```mermaid\ngraph LR\n    A --> B\n    B --> C\n```";
     const webTitle = "Container_id";

--- a/src/UI/Components/MarkdownContainer/MarkdownContainer.tsx
+++ b/src/UI/Components/MarkdownContainer/MarkdownContainer.tsx
@@ -41,6 +41,9 @@ export const MarkdownContainer: React.FC<Props> = ({ text, web_title }) => {
 
     // Enable GitHub-style diff fences (```diff) with basic line coloring
     // without pulling in an additional highlighting library.
+    // Store reference to the original fence renderer before replacing it
+    const defaultFenceRenderer = markdownInstance.renderer.rules.fence;
+
     markdownInstance.renderer.rules.fence = (tokens, idx, options, env, self) => {
       const token = tokens[idx];
       const info = token.info ? token.info.trim() : "";
@@ -75,8 +78,15 @@ export const MarkdownContainer: React.FC<Props> = ({ text, web_title }) => {
         return code;
       }
 
-      // Fallback to default fence renderer for all other languages
-      return self.renderToken(tokens, idx, options);
+      // Fallback to default fence renderer for all other languages (including empty language)
+      if (defaultFenceRenderer) {
+        return defaultFenceRenderer(tokens, idx, options, env, self);
+      }
+
+      // If no default renderer exists, use markdown-it's built-in fence rendering
+      const content = markdownInstance.utils.escapeHtml(token.content);
+      const langClass = langName ? ` class="language-${langName}"` : "";
+      return `<pre><code${langClass}>${content}</code></pre>`;
     };
 
     markdownInstance.use(full);

--- a/src/UI/Components/MarkdownContainer/styles.css
+++ b/src/UI/Components/MarkdownContainer/styles.css
@@ -37,14 +37,8 @@
   /* Position relative to the main content area */
   left: calc(var(--pf-c-page__sidebar--Width, 300px) + var(--left-margin));
   top: calc(var(--pf-c-page__header--MinHeight, 76px) + var(--diagram-margin));
-  width: calc(
-    100vw - var(--pf-c-page__sidebar--Width, 300px) - var(--left-margin) - var(--diagram-margin) -
-      (var(--page-padding) * 2) - var(--extra-space)
-  );
-  height: calc(
-    100vh - var(--pf-c-page__header--MinHeight, 76px) - (var(--diagram-margin) * 2) -
-      var(--page-padding) - var(--extra-space)
-  );
+  width: calc(100vw - var(--pf-c-page__sidebar--Width, 300px) - var(--left-margin) - var(--diagram-margin) - (var(--page-padding) * 2) - var(--extra-space));
+  height: calc(100vh - var(--pf-c-page__header--MinHeight, 76px) - (var(--diagram-margin) * 2) - var(--page-padding) - var(--extra-space));
   transform: none !important;
   cursor: zoom-out;
   background: var(--pf-global--BackgroundColor--100, white);
@@ -56,19 +50,13 @@
 }
 
 /* When sidebar is collapsed */
-.pf-m-collapsed ~ * .mermaid-diagram.zoomed {
+.pf-m-collapsed~* .mermaid-diagram.zoomed {
   left: calc(var(--pf-c-page__sidebar--Width--collapsed, 75px) + var(--left-margin));
-  width: calc(
-    100vw - var(--pf-c-page__sidebar--Width--collapsed, 75px) - var(--left-margin) -
-      var(--diagram-margin) - (var(--page-padding) * 2) - var(--extra-space)
-  );
+  width: calc(100vw - var(--pf-c-page__sidebar--Width--collapsed, 75px) - var(--left-margin) - var(--diagram-margin) - (var(--page-padding) * 2) - var(--extra-space));
 }
 
 /* When sidebar is hidden */
-.pf-m-hidden ~ * .mermaid-diagram.zoomed {
+.pf-m-hidden~* .mermaid-diagram.zoomed {
   left: var(--left-margin);
-  width: calc(
-    100vw - var(--left-margin) - var(--diagram-margin) - (var(--page-padding) * 2) -
-      var(--extra-space)
-  );
+  width: calc(100vw - var(--left-margin) - var(--diagram-margin) - (var(--page-padding) * 2) - var(--extra-space));
 }

--- a/src/UI/Styles/MarkdownStyles.ts
+++ b/src/UI/Styles/MarkdownStyles.ts
@@ -796,13 +796,17 @@ export const MarkdownStyles = `
 .markdown-body .highlight pre,
 .markdown-body pre {
   padding: 16px;
-  margin: var(--pf-t--global--spacer--sm);
   overflow: auto;
   font-size: 85%;
   line-height: 1.45;
   color: var(--pf-t--global--text--color--regular);
   background-color: var(--pf-t--global--background--color--primary--default);
+  border: var(--pf-t--global--border--width--regular) solid var(--pf-t--global--border--color--nonstatus--gray--default);
   border-radius: var(--pf-t--global--border--radius--small);
+}
+
+.markdown-body details pre {
+  margin: var(--pf-t--global--spacer--sm);
 }
 
 .markdown-body pre code,


### PR DESCRIPTION
# Description

With the addition of a rule for the -diff blocks, it didn't fall back to the default fence rules for other sorts of codeblocks.
