### PR TITLE
disable the e2e tests on jenkins for ISO-7

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -46,34 +46,11 @@ pipeline {
                         }
                     }
                 }
-                stage('Testing with cypress') {
-                    steps {
-                        timeout(time: 20, unit: 'MINUTES') {
-                            dir('web-console') {
-                                sh '''yarn run build;
-                                sudo systemctl restart docker && sudo docker network prune -f;
-                                yarn run install:orchestrator:ci;
-                                yarn run cypress-test:iso;'''
-                            }
-                        }
-                    }
-                    post {
-                        always {
-                            dir('web-console') {
-                                sh'yarn run kill-server'
-                            }
-                        }
-                    }
-                }
             }
             post {
                 always {
-                    dir('web-console') {
-                        sh '''npx junit-merge -d cypress/reports/junit -o cypress/reports/cypress-report.xml'''
-                    }
                     junit 'web-console/junit.xml'
                     recordCoverage(tools: [[parser: 'COBERTURA']], sourceCodeRetention: 'NEVER')
-                    archiveArtifacts artifacts: 'web-console/cypress/reports/cypress-report.xml, web-console/cypress/screenshots/**, web-console/cypress/videos/**', allowEmptyArchive: true, onlyIfSuccessful: false
                     deleteDir()
                 }
             }

--- a/changelogs/unreleased/disable-e2e.yml
+++ b/changelogs/unreleased/disable-e2e.yml
@@ -1,0 +1,3 @@
+description: Disable e2e tests on jenkins for ISO-7
+change-type: patch
+destination-branches: [iso7]


### PR DESCRIPTION
# Description

Maintaining the backward compatibility for the local-setup is starting to get complicated. Solutions-team doesn't have time right now to help setup a lab for our automated tests, and Bart agreed it was acceptable to disable the iso7 e2e tests. The unit tests remain.
