### PR TITLE
fix: notifications now clear properly

### DIFF
--- a/changelogs/unreleased/6660-clear-notifications.yml
+++ b/changelogs/unreleased/6660-clear-notifications.yml
@@ -1,0 +1,6 @@
+description: Notifications on export failure of compiles now clear properly
+issue-nr: "6660"
+change-type: "patch"
+destination-branches: [master, iso9]
+sections:
+  bugfix: "{{description}}"

--- a/src/Slices/Notification/UI/Drawer/Drawer.tsx
+++ b/src/Slices/Notification/UI/Drawer/Drawer.tsx
@@ -45,6 +45,9 @@ export const Drawer: React.FC<Props> = ({ onClose, isDrawerOpen, drawerRef }) =>
     pageSize: PageSize.from("50"),
     origin: "drawer",
     currentPage: { kind: "CurrentPage", value: "" },
+    filter: {
+      cleared: false,
+    },
   }).useContinuous();
 
   const { mutate } = useUpdateNotification({


### PR DESCRIPTION
# Description

Notifications on export failure of compiles now clear properly.
Was looking for why the test cases were passing while they should fail but couldn't really find anything wrong with it in the end, they were fine so the only issue was the filtering on the main query in the end...

https://github.com/inmanta/web-console/issues/6660
