### PR TITLE
Fix/6576

### DIFF
--- a/changelogs/unreleased/6576-encodedBreadCrumbs.yml
+++ b/changelogs/unreleased/6576-encodedBreadCrumbs.yml
@@ -2,5 +2,3 @@ description: Breadcrumbs now show decoded characters instead of encoded ones.
 issue-nr: 6576
 change-type: patch
 destination-branches: [master, iso9]
-sections:
-  bugfix: "{{description}}"

--- a/src/UI/Root/Components/PageBreadcrumbs/PageBreadcrumbs.test.tsx
+++ b/src/UI/Root/Components/PageBreadcrumbs/PageBreadcrumbs.test.tsx
@@ -118,7 +118,7 @@ test("GIVEN Breadcrumbs on Add Instance WHEN user clicks inventory breadcrumb li
 });
 
 test("GIVEN Breadcrumbs WHEN service name is encoded THEN decoded label is shown", () => {
-  const url = "/lsm/catalog/basic%2520service/inventory";
+  const url = "/lsm/catalog/basic%20service/inventory";
   const { component } = setup([url]);
   render(component);
 

--- a/src/UI/Root/Components/PageBreadcrumbs/PageBreadcrumbs.tsx
+++ b/src/UI/Root/Components/PageBreadcrumbs/PageBreadcrumbs.tsx
@@ -4,22 +4,6 @@ import { Breadcrumb, BreadcrumbItem } from "@patternfly/react-core";
 import { DependencyContext } from "@/UI/Dependency";
 import { SearchSanitizer } from "@/UI/Routing";
 
-const decodeUrlLabel = (label: string) => {
-  try {
-    let decoded = label;
-    let prev;
-
-    do {
-      prev = decoded;
-      decoded = decodeURIComponent(decoded);
-    } while (decoded !== prev);
-
-    return decoded;
-  } catch {
-    return label;
-  }
-};
-
 export const PageBreadcrumbs: React.FC = () => {
   const { routeManager } = useContext(DependencyContext);
   const { pathname, search } = useLocation();
@@ -31,7 +15,7 @@ export const PageBreadcrumbs: React.FC = () => {
       {crumbs.map((crumb) => (
         <BreadcrumbItem key={crumb.kind} isActive={crumb.active} aria-label={"BreadcrumbItem"}>
           {crumb.active ? (
-            decodeUrlLabel(crumb.label)
+            decodeURIComponent(crumb.label)
           ) : (
             <NavLink
               to={{
@@ -39,7 +23,7 @@ export const PageBreadcrumbs: React.FC = () => {
                 search: sanitizer.sanitize(crumb.kind, search),
               }}
             >
-              {decodeUrlLabel(crumb.label)}
+              {decodeURIComponent(crumb.label)}
             </NavLink>
           )}
         </BreadcrumbItem>


### PR DESCRIPTION
# Description

So the issue where breadcrumbs show with encoded characters now is fixed and should shown with decoded characters

https://github.com/inmanta/web-console/issues/6576