### PR TITLE
fix: removed whitespaces from markdownpreview codeblocks

### DIFF
--- a/changelogs/unreleased/6646-whitespace-codeblocks.yml
+++ b/changelogs/unreleased/6646-whitespace-codeblocks.yml
@@ -1,0 +1,4 @@
+description: Removed whitespaces from the markdownpreview codeblocks.
+issue-nr: 6646
+change-type: patch
+destination-branches: [master, iso9]

--- a/src/UI/Styles/MarkdownStyles.ts
+++ b/src/UI/Styles/MarkdownStyles.ts
@@ -811,7 +811,6 @@ export const MarkdownStyles = `
 .markdown-body pre tt {
   display: inline;
   max-width: auto;
-  padding: 0 var(--pf-t--global--spacer--xs);
   margin: 0;
   overflow: visible;
   line-height: inherit;


### PR DESCRIPTION
# Description

- Removed the whitespaces from markdownpreview codeblocks

https://github.com/inmanta/web-console/issues/6646

<img width="862" height="782" alt="Screenshot 2026-03-12 at 10 18 26" src="https://github.com/user-attachments/assets/0fba8b23-accb-4f6e-9a69-4eb8a6b5860a" />

