### PR TITLE
fix: copy button is now centered

### DIFF
--- a/changelogs/unreleased/6618-offcentered-copy.yml
+++ b/changelogs/unreleased/6618-offcentered-copy.yml
@@ -1,0 +1,4 @@
+description: Copy button on settings, tokens tab is now centered.
+issue-nr: 6618
+change-type: patch
+destination-branches: [master, iso9]

--- a/src/Slices/Settings/UI/Tabs/Token/TokenForm.tsx
+++ b/src/Slices/Settings/UI/Tabs/Token/TokenForm.tsx
@@ -86,6 +86,7 @@ export const TokenForm: React.FC<Props> = ({
         isDisabled={token === null}
         variant="control"
         aria-label="CopyTokenToClipboard"
+        style={{ alignItems: "center" }}
       />
     </StyledInputGroup>
     {error && (

--- a/src/UI/Components/ClipboardCopyButton/ClipboardCopyButton.tsx
+++ b/src/UI/Components/ClipboardCopyButton/ClipboardCopyButton.tsx
@@ -11,6 +11,7 @@ interface Props {
   isDisabled?: boolean;
   className?: string;
   variant?: ButtonProps["variant"];
+  style?: React.CSSProperties;
 }
 
 export const ClipboardCopyButton: React.FC<Props> = ({
@@ -43,7 +44,7 @@ export const ClipboardCopyButton: React.FC<Props> = ({
         onClick={onClick}
         isDisabled={isDisabled}
         size="sm"
-      ></Button>
+      />
     </WidthLimitedTooltip>
   );
 };


### PR DESCRIPTION
# Description

- Copy button on settings, tokens tab is now centered.

https://github.com/inmanta/web-console/issues/6618


<img width="648" height="364" alt="Screenshot 2026-03-13 at 10 46 30" src="https://github.com/user-attachments/assets/cdb2dc5c-745a-4a6a-b024-0ef6fc7e44a4" />
