### PR TITLE
fix: some SingleTextSelect fixes and adding of some tests

### DIFF
--- a/changelogs/unreleased/6530-singleTextSelectFix.yml
+++ b/changelogs/unreleased/6530-singleTextSelectFix.yml
@@ -1,0 +1,6 @@
+description: Pressing enter in the project name field under create environment will now correctly create, set and filter project names.
+issue-nr: 6530
+change-type: patch
+destination-branches: [master, iso9]
+sections:
+  bugfix: "{{description}}"

--- a/src/UI/Components/SingleTextSelect/SingleTextSelect.test.tsx
+++ b/src/UI/Components/SingleTextSelect/SingleTextSelect.test.tsx
@@ -1,0 +1,114 @@
+import { render, screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { SingleTextSelect } from "./SingleTextSelect";
+
+const options = [
+  { children: "Apple", value: "apple" },
+  { children: "Banana", value: "banana" },
+  { children: "Cherry", value: "cherry" },
+];
+
+test("SingleTextSelect renders with placeholder text", () => {
+  render(
+    <SingleTextSelect
+      selected={null}
+      setSelected={vi.fn()}
+      options={options}
+      placeholderText="Select a fruit"
+    />
+  );
+  expect(screen.getByPlaceholderText("Select a fruit")).toBeVisible();
+});
+
+test("SingleTextSelect opens dropdown on click", async () => {
+  render(<SingleTextSelect selected={null} setSelected={vi.fn()} options={options} />);
+  await userEvent.click(screen.getByRole("combobox"));
+  expect(screen.getByText("Apple")).toBeVisible();
+});
+
+test("SingleTextSelect calls setSelected when selecting an option", async () => {
+  const setSelected = vi.fn();
+
+  render(<SingleTextSelect selected={null} setSelected={setSelected} options={options} />);
+  await userEvent.click(screen.getByRole("combobox"));
+  await userEvent.click(screen.getByText("Apple"));
+
+  expect(setSelected).toHaveBeenCalledWith("apple");
+});
+
+test("SingleTextSelect filters options based on input", async () => {
+  render(<SingleTextSelect selected={null} setSelected={vi.fn()} options={options} hasCreation />);
+  await userEvent.click(screen.getByRole("combobox"));
+  await userEvent.type(screen.getByRole("combobox"), "ban");
+
+  expect(screen.getByText("Banana")).toBeVisible();
+  expect(screen.queryByText("Apple")).not.toBeInTheDocument();
+});
+
+test("SingleTextSelect selects exact match on Enter regardless of casing", async () => {
+  const setSelected = vi.fn();
+
+  render(<SingleTextSelect selected={null} setSelected={setSelected} options={options} />);
+  await userEvent.type(screen.getByRole("combobox"), "APPLE");
+  await userEvent.keyboard("{Enter}");
+
+  expect(setSelected).toHaveBeenCalledWith("apple");
+});
+
+test("SingleTextSelect shows Create option when hasCreation is true and no match exists", async () => {
+  render(<SingleTextSelect selected={null} setSelected={vi.fn()} options={options} hasCreation />);
+  await userEvent.type(screen.getByRole("combobox"), "Mango");
+
+  expect(screen.getByText('Create "Mango"')).toBeVisible();
+});
+
+test("SingleTextSelect calls onCreate and setSelected when creating a new entry via Enter", async () => {
+  const setSelected = vi.fn();
+  const onCreate = vi.fn();
+
+  render(
+    <SingleTextSelect
+      selected={null}
+      setSelected={setSelected}
+      options={options}
+      hasCreation
+      onCreate={onCreate}
+    />
+  );
+  await userEvent.type(screen.getByRole("combobox"), "Mango");
+  await userEvent.keyboard("{Enter}");
+
+  expect(onCreate).toHaveBeenCalledWith("Mango");
+  expect(setSelected).toHaveBeenCalledWith("Mango");
+});
+
+test("SingleTextSelect calls onCreate and setSelected when clicking the Create option", async () => {
+  const setSelected = vi.fn();
+  const onCreate = vi.fn();
+
+  render(
+    <SingleTextSelect
+      selected={null}
+      setSelected={setSelected}
+      options={options}
+      hasCreation
+      onCreate={onCreate}
+    />
+  );
+  await userEvent.type(screen.getByRole("combobox"), "Mango");
+  await userEvent.click(screen.getByText('Create "Mango"'));
+
+  expect(onCreate).toHaveBeenCalledWith("Mango");
+  expect(setSelected).toHaveBeenCalledWith("Mango");
+});
+
+test("SingleTextSelect clears input when clear button is clicked", async () => {
+  const setSelected = vi.fn();
+
+  render(<SingleTextSelect selected={null} setSelected={setSelected} options={options} />);
+  await userEvent.type(screen.getByRole("combobox"), "Apple");
+  await userEvent.click(screen.getByLabelText("Clear input value"));
+
+  expect(setSelected).toHaveBeenCalledWith("");
+  expect(screen.getByRole("combobox")).toHaveValue("");
+});

--- a/src/UI/Components/SingleTextSelect/SingleTextSelect.tsx
+++ b/src/UI/Components/SingleTextSelect/SingleTextSelect.tsx
@@ -192,14 +192,30 @@ export const SingleTextSelect: React.FC<Props> = ({
     switch (event.key) {
       // Select the first available option
       case "Enter":
-        if (isOpen && focusedItem.value !== "no results") {
+        if (!isOpen) break;
+
+        const hasExplicitFocus = focusedItemIndex !== null && focusedItem.value !== "no results";
+        const exactMatch = options.find(
+          (option) => option.children?.toLocaleString().toLowerCase() === filterValue.toLowerCase()
+        );
+
+        if (hasExplicitFocus && focusedItem.value === "create") {
+          onCreate(inputValue);
+          setSelected(inputValue);
+          setFilterValue(inputValue);
+        } else if (hasExplicitFocus) {
           setInputValue(String(focusedItem.children));
           setFilterValue("");
-          setSelected(String(focusedItem.children));
-        }
-
-        if (checkIfOptionMatchInput(options, filterValue)) {
-          setSelected(String(filterValue));
+          setSelected(String(focusedItem.value));
+        } else if (exactMatch) {
+          setInputValue(String(exactMatch.children));
+          setFilterValue("");
+          setSelected(String(exactMatch.value));
+        } else if (hasCreation && filterValue.trim()) {
+          onCreate(filterValue);
+          setSelected(filterValue);
+          setFilterValue(filterValue);
+          setInputValue(filterValue);
         }
 
         setIsOpen((prevIsOpen) => !prevIsOpen);
@@ -297,5 +313,7 @@ export const SingleTextSelect: React.FC<Props> = ({
 };
 
 export const checkIfOptionMatchInput = (options: SelectOptionProps[], input: string) => {
-  return options.some((option) => option.children?.toLocaleString() === input.toLocaleLowerCase());
+  return options.some(
+    (option) => option.children?.toLocaleString().toLowerCase() === input.toLowerCase()
+  );
 };


### PR DESCRIPTION
# Description

- Pressing enter in the project name field under create environment will now correctly create, set and filter project names.
Before it used to put "create test" in the input, now only test gets added to input and options.

https://github.com/inmanta/web-console/issues/6530

https://github.com/user-attachments/assets/6d754cd1-b9b7-4804-9b54-785d78a10b23

