### PR TITLE
Removing wrong assertion e2e

### DIFF
--- a/changelogs/unreleased/remove-breaking-assertion-e2e.yml
+++ b/changelogs/unreleased/remove-breaking-assertion-e2e.yml
@@ -1,0 +1,3 @@
+description: An assertion that wasn't meant to be there was causing the test to fail. Removing it.
+change-type: patch
+destination-branches: [master, iso9]

--- a/cypress/e2e/scenario-2.4-expert-mode.cy.js
+++ b/cypress/e2e/scenario-2.4-expert-mode.cy.js
@@ -183,11 +183,6 @@ if (isIso) {
         .click({ force: true })
         .type("{selectall}{backspace}eth1{enter}{enter}", { delay: 100 });
 
-      //expect the toprow to contain up
-      cy.get('[aria-label="History-Row"]', { timeout: 90000 }).should(($rows) => {
-        expect($rows[0]).to.contain("up");
-      });
-
       // confirm edit
       cy.get('[aria-label="Expert-Submit-Button"]').click();
       cy.get("button").contains("Yes").click();


### PR DESCRIPTION
# Description

An assertion creeped in the expert mode test, that wasn't supposed to be there (it wasn't there before either the recent changes that came with the multi-text-input pr). This was causing the pipeline to break.  If the test suit was fast enough, it would pass because the toprow in the history would still be in "up" state, but 99% of the cases, it would already be in creating state. 