### PR TITLE
Fix Dependabot authentication for JointJS npm registry

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -8,6 +8,9 @@ npmRegistries:
   "https://npm.pkg.github.com":
     npmAlwaysAuth: true
     npmAuthToken: "${IRT_GIT_TOKEN:-}"
+  "https://npm.jointjs.com":
+    npmAlwaysAuth: true
+    npmAuthToken: "${JOINTJS_NPM_TOKEN}"
 
 npmScopes:
   joint:

--- a/changelogs/unreleased/fix-dependabot-jointjs-auth.yml
+++ b/changelogs/unreleased/fix-dependabot-jointjs-auth.yml
@@ -1,0 +1,3 @@
+description: Fix Dependabot authentication for JointJS private npm registry
+change-type: patch
+destination-branches: [master]

--- a/changelogs/unreleased/fix-dependabot-jointjs-auth.yml
+++ b/changelogs/unreleased/fix-dependabot-jointjs-auth.yml
@@ -1,3 +1,3 @@
 description: Fix Dependabot authentication for JointJS private npm registry
 change-type: patch
-destination-branches: [master]
+destination-branches: [master, iso9, iso8]


### PR DESCRIPTION
## Summary
- Add `https://npm.jointjs.com` to `npmRegistries` in `.yarnrc.yml` so Dependabot can properly inject authentication tokens when checking for dependency updates.
- Dependabot's Yarn Berry integration matches and replaces tokens via `npmRegistries`, not `npmScopes`. The existing `npmScopes.joint` entry alone was insufficient for Dependabot, even though it works for regular Yarn operations.

## Test plan
- [ ] Verify Dependabot can successfully check for `@joint/*` package updates after merge
- [ ] Verify `yarn install` still works locally and in Jenkins CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)