### PR TITLE
update url to jointjs registry

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,7 @@ version: 2
 registries:
   jointjs-registry:
     type: npm-registry
-    url: https://npm.jointjs.com
+    url: https://npm.jointjs.com/api/v4/projects/77690663/packages/npm/
     token: ${{secrets.JOINTJS_NPM_TOKEN}}
 updates:
   - package-ecosystem: "npm"

--- a/changelogs/unreleased/dependabot-update-jointjs-url.yml
+++ b/changelogs/unreleased/dependabot-update-jointjs-url.yml
@@ -1,0 +1,3 @@
+description: Update for dependabot.
+change-type: patch
+destination-branches: [master, iso9]


### PR DESCRIPTION
# Description

After digging... it could potentially be that packages hosted on gitlab, require a more explict url for dependabot. This is a longshot, because it's not anywhere in the documentation of jointjs that they are hosting on gitlab, it's just a suspicion. If that doesn't work... well I'm clueless. I'm sorry to bother with recurring prs x)
