### PR TITLE
fix: final adjustments resource view

### DIFF
--- a/changelogs/template.yml
+++ b/changelogs/template.yml
@@ -1,6 +1,6 @@
 description: Added unicode support to templates
 issue-nr: >"fill in"
-change-type: >"fill in"
+change-type: >"fill in" #patch, minor, major
 destination-branches: [master, iso7]
 sections:
   feature: "{{description}}"

--- a/changelogs/unreleased/6690-graphql-resources.yml
+++ b/changelogs/unreleased/6690-graphql-resources.yml
@@ -1,4 +1,6 @@
-description: Replace the REST /api/v2/resource call with the GraphQL endpoint for fetching the resource list.
+description: Resources view has been reworked. Compound states have now been added to better reflect the resources intent. In the past this would have been represented by 1 field. By splitting this into multiple (3) states, more information about that resource becomes available at any time.
 issue-nr: 6690
-change-type: patch
+change-type: minor
 destination-branches: [master, iso9]
+sections:
+  feature: "{{description}}"

--- a/src/Data/Queries/Slices/Agents/GetAgents/getUrl.ts
+++ b/src/Data/Queries/Slices/Agents/GetAgents/getUrl.ts
@@ -44,11 +44,13 @@ export function getUrl(params: GetAgentsParams | GetAgentsInfiniteParams, cursor
         )}`
       : "";
   const sortParam = sort ? `&sort=${Sort.serialize(sort)}` : "";
-  const cursorParam = cursor
-    ? `&start=${cursor}`
-    : "currentPage" in params && params.currentPage.value
-      ? `&${params.currentPage.value}`
-      : "";
+
+  let cursorParam = "";
+  if (cursor) {
+    cursorParam = `&start=${cursor}`;
+  } else if ("currentPage" in params && params.currentPage.value) {
+    cursorParam = `&${params.currentPage.value}`;
+  }
 
   return `/api/v2/agents?limit=${pageSize.value}${filterParam}${sortParam}${cursorParam}`;
 }

--- a/src/Data/Queries/Slices/Resource/GetResources/useGetResources.ts
+++ b/src/Data/Queries/Slices/Resource/GetResources/useGetResources.ts
@@ -123,13 +123,18 @@ export const useGetResources = (params: GetResourcesParams): GetResources => {
   );
 
   const statusFilter = mapStatusToGraphQLFilter(filter?.status);
-
   const graphqlFilter: Record<string, unknown> = {
     environment: env,
     //TODO: https://github.com/inmanta/web-console/issues/6823 => same as in ResourceFilterForm.tsx
-    ...(filter?.type?.length ? { resourceType: { contains: `%${filter.type}%` } } : {}),
-    ...(filter?.agent?.length ? { agent: { contains: `%${filter.agent}%` } } : {}),
-    ...(filter?.value?.length ? { resourceIdValue: { contains: `%${filter.value}%` } } : {}),
+    ...(filter?.type?.length
+      ? { resourceType: { contains: filter.type.map((type) => `%${type}%`) } }
+      : {}),
+    ...(filter?.agent?.length
+      ? { agent: { contains: filter.agent.map((agent) => `%${agent}%`) } }
+      : {}),
+    ...(filter?.value?.length
+      ? { resourceIdValue: { contains: filter.value.map((value) => `%${value}%`) } }
+      : {}),
     ...statusFilter,
   };
 

--- a/src/Slices/Resource/UI/ResourcesPage/Components/FilterWidget/FilterWidgetComponent.test.tsx
+++ b/src/Slices/Resource/UI/ResourcesPage/Components/FilterWidget/FilterWidgetComponent.test.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { Drawer, DrawerContent, DrawerContentBody } from "@patternfly/react-core";
 import { render, screen } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
@@ -160,5 +160,32 @@ describe("FilterWidgetComponent", () => {
     expect(setFilter).toHaveBeenNthCalledWith(9, {
       disregardDefault: true,
     });
+  });
+
+  it("toggles the purged status via the switch in the resource tab", async () => {
+    const Wrapper = () => {
+      const [filter, setFilter] = useState<Resource.Filter>({});
+      return (
+        <FilterWidgetComponent
+          filter={filter}
+          onClose={vi.fn()}
+          setFilter={(update) => setFilter(update)}
+        />
+      );
+    };
+
+    renderWithDrawer(<Wrapper />);
+
+    const purgedSwitch = screen.getByRole("switch", {
+      name: words("resources.filters.desiredState.purged"),
+    });
+
+    expect(purgedSwitch).not.toBeChecked();
+
+    await userEvent.click(purgedSwitch);
+    expect(purgedSwitch).toBeChecked();
+
+    await userEvent.click(purgedSwitch);
+    expect(purgedSwitch).not.toBeChecked();
   });
 });

--- a/src/Slices/Resource/UI/ResourcesPage/Components/FilterWidget/ResourceFilterForm.tsx
+++ b/src/Slices/Resource/UI/ResourcesPage/Components/FilterWidget/ResourceFilterForm.tsx
@@ -15,12 +15,6 @@ export interface ResourceFilterFormProps {
   filter: Resource.Filter;
 }
 
-/** These are the statuses which filter out the report only resources. */
-const REPORT_ONLY_STATUSES: (Resource.ComplianceKey | Resource.LastHandlerRunKey)[] = [
-  "non_compliant",
-  "successful",
-] as const;
-
 /**
  * The ResourceFilterForm component.
  *
@@ -67,19 +61,6 @@ export const ResourceFilterForm: React.FC<ResourceFilterFormProps> = ({
     const current = filter.status ?? [];
 
     const updated = hasChanged ? [...current, "purged"] : current.filter((s) => s !== "purged");
-
-    onChangeStatus(updated);
-  };
-
-  const handleReportOnlyChange = (hasChanged: boolean) => {
-    const current = filter.status ?? [];
-
-    const updated = hasChanged
-      ? [...new Set([...current, ...REPORT_ONLY_STATUSES])]
-      : current.filter(
-          (s) =>
-            !REPORT_ONLY_STATUSES.includes(s as Resource.ComplianceKey | Resource.LastHandlerRunKey)
-        );
 
     onChangeStatus(updated);
   };
@@ -151,16 +132,6 @@ export const ResourceFilterForm: React.FC<ResourceFilterFormProps> = ({
             label={words("resources.filters.desiredState.purged")}
             isChecked={filter.status?.includes("purged") ?? false}
             onChange={(_event, hasChanged) => handlePurgedChange(hasChanged)}
-            isReversed
-          />
-        </StackItem>
-        <StackItem>
-          <Switch
-            id={words("resources.filters.desiredState.reportOnly")}
-            aria-label={words("resources.filters.desiredState.reportOnly")}
-            label={words("resources.filters.desiredState.reportOnly")}
-            isChecked={REPORT_ONLY_STATUSES.every((s) => filter.status?.includes(s)) ?? false}
-            onChange={(_event, hasChanged) => handleReportOnlyChange(hasChanged)}
             isReversed
           />
         </StackItem>

--- a/src/Slices/Resource/UI/ResourcesPage/Page.test.tsx
+++ b/src/Slices/Resource/UI/ResourcesPage/Page.test.tsx
@@ -396,7 +396,11 @@ describe("ResourcesPage", () => {
           const field = variables.filter?.[filterVariableKey as keyof typeof variables.filter] as
             | { eq?: string[]; contains?: string[] }
             | undefined;
-          const values = field?.eq ?? field?.contains ?? [];
+
+          //This is for now until we rework the filtering part where we don't have to manually pass %
+          const values = (field?.eq ?? field?.contains ?? []).map((v: string) =>
+            v.replace(/%/g, "")
+          );
 
           return HttpResponse.json({
             data: values.includes(filterVariableValue) ? gqlFirst3 : gqlFull,
@@ -450,8 +454,13 @@ describe("ResourcesPage", () => {
             | { eq?: string[]; contains?: string[] }
             | undefined;
 
-          const hasOne = (fieldOne?.eq ?? fieldOne?.contains ?? []).includes(filterValueOne);
-          const hasTwo = (fieldTwo?.eq ?? fieldTwo?.contains ?? []).includes(filterValueTwo);
+          //This is for now until we rework the filtering part where we don't have to manually pass %
+          const hasOne = (fieldOne?.eq ?? fieldOne?.contains ?? []).some(
+            (v: string) => v.replace(/%/g, "") === filterValueOne
+          );
+          const hasTwo = (fieldTwo?.eq ?? fieldTwo?.contains ?? []).some(
+            (v: string) => v.replace(/%/g, "") === filterValueTwo
+          );
 
           return HttpResponse.json({ data: hasOne && hasTwo ? gqlFirst3 : gqlFull });
         })
@@ -488,9 +497,16 @@ describe("ResourcesPage", () => {
 
     server.use(
       queryLink.query("GetResources", ({ variables }: { variables: GqlVariables }) => {
-        const hasAgent = (variables.filter?.agent?.contains ?? []).includes(agentValue);
-        const hasType = (variables.filter?.resourceType?.contains ?? []).includes(typeValue);
-        const hasId = (variables.filter?.resourceIdValue?.contains ?? []).includes(idValue);
+        //This is for now until we rework the filtering part where we don't have to manually pass %
+        const hasAgent = (variables.filter?.agent?.contains ?? []).some(
+          (v) => v.replace(/%/g, "") === agentValue
+        );
+        const hasType = (variables.filter?.resourceType?.contains ?? []).some(
+          (v) => v.replace(/%/g, "") === typeValue
+        );
+        const hasId = (variables.filter?.resourceIdValue?.contains ?? []).some(
+          (v) => v.replace(/%/g, "") === idValue
+        );
 
         return HttpResponse.json({ data: hasAgent && hasType && hasId ? gqlFirst3 : gqlFull });
       })

--- a/src/Slices/Resource/UI/ResourcesPage/ResourcesTable.tsx
+++ b/src/Slices/Resource/UI/ResourcesPage/ResourcesTable.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { OnSort, Table, Th, Thead, Tr } from "@patternfly/react-table";
+import { OnSort, Table, TableVariant, Th, Thead, Tr } from "@patternfly/react-table";
 import { Resource, Sort } from "@/Core";
 import { words } from "@/UI";
 import { ResourceTableRow, ResourceRow } from "./ResourceTableRow";
@@ -55,7 +55,7 @@ export const ResourcesTable: React.FC<Props> = ({ rows, sort, setSort, ...props 
   });
 
   return (
-    <Table {...props} isStickyHeader>
+    <Table {...props} isStickyHeader variant={TableVariant.compact}>
       <Thead>
         <Tr>
           {heads}

--- a/src/UI/words.tsx
+++ b/src/UI/words.tsx
@@ -579,7 +579,6 @@ const dict = {
   "resources.filters.resource.agent.loading": "Loading agents...",
   "resources.filters.desiredState.sectionTitle": "Desired State",
   "resources.filters.desiredState.purged": "Purged",
-  "resources.filters.desiredState.reportOnly": "Report Only",
   "resources.filters.active.title": "Active filters",
   "resources.filters.active.clearAll": "Clear all",
   "resources.filters.active.empty.title": "No filters applied",


### PR DESCRIPTION
# Description

These are the last adjustments for the resource view:
1. removed report only switch
2. type, agent, value filters now send over arrays of strings to the backend
3. compact table fix
4. adjustments of tests + extra test which covers the purged boolean added
5. changelog added as well but waiting for more feedback on this one

