### PR TITLE
fix: compound state icon colors adjusted

### DIFF
--- a/changelogs/unreleased/colorFixes.yml
+++ b/changelogs/unreleased/colorFixes.yml
@@ -1,0 +1,3 @@
+description: Color adjustments applied for compound state icons on the resource page.
+change-type: patch
+destination-branches: [master, iso9]

--- a/src/UI/Components/CompoundResourceStatus/config.tsx
+++ b/src/UI/Components/CompoundResourceStatus/config.tsx
@@ -45,18 +45,18 @@ export const colorConfig: Record<Resource.CompoundStateKey, string> = {
 export const statusPriority: Record<Resource.CompoundStateKey, number> = {
   // --- Blocked---
   not_blocked: 0,
-  blocked: 1,
-  temporarily_blocked: 2,
+  temporarily_blocked: 1,
+  blocked: 2,
   // --- Compliance ---
   compliant: 0,
-  non_compliant: 1,
-  has_update: 2,
-  undefined: 3,
+  has_update: 1,
+  undefined: 2,
+  non_compliant: 3,
   // --- LastHandlerRun ---
   successful: 0,
-  failed: 1,
-  new: 2,
-  skipped: 3,
+  skipped: 1,
+  failed: 2,
+  new: 3,
 };
 
 /** default is the neutral icons color and state is whenever the colorConfig should be used for the icons. */

--- a/src/UI/Components/CompoundResourceStatus/config.tsx
+++ b/src/UI/Components/CompoundResourceStatus/config.tsx
@@ -31,14 +31,14 @@ export const colorConfig: Record<Resource.CompoundStateKey, string> = {
   temporarily_blocked: "var(--pf-t--color--orange--40)",
   // --- Compliance ---
   compliant: "var(--pf-t--color--green--50)",
-  non_compliant: "var(--pf-t--color--red--60)",
-  has_update: "var(--pf-t--color--orange--40)",
-  undefined: "var(--pf-t--color--gray--40)",
+  non_compliant: "var(--pf-t--color--orange--40)",
+  has_update: "var(--pf-t--color--blue--50)",
+  undefined: "var(--pf-t--color--red--60)",
   // --- LastHandlerRun ---
   failed: "var(--pf-t--color--red--60)",
-  skipped: "var(--pf-t--color--gray--40)",
+  skipped: "var(--pf-t--color--blue--50)",
   successful: "var(--pf-t--color--green--50)",
-  new: "var(--pf-t--color--blue--50)",
+  new: "var(--pf-t--color--gray--40)",
 };
 
 /** Maps each compound state type to a numeric priority value. */


### PR DESCRIPTION
# Description

Requested color adjustments from Bart on the compound state icons are applied.

<img width="867" height="205" alt="Screenshot 2026-04-29 at 09 36 19" src="https://github.com/user-attachments/assets/c8fd1145-1e44-4069-abec-75493584ad85" />


