### PR TITLE
fix: layout shift resource view

### DIFF
--- a/changelogs/unreleased/6833-progressBars.yml
+++ b/changelogs/unreleased/6833-progressBars.yml
@@ -1,0 +1,6 @@
+description: Fixed a layout shift causing progress bars in the resources view to resize when pagination controls changed.
+issue-nr: 6833
+change-type: patch
+destination-branches: [master, iso9]
+sections:
+  bugfix: "{{description}}"

--- a/src/Slices/Resource/UI/ResourcesPage/Components/ResourceTableControls.tsx
+++ b/src/Slices/Resource/UI/ResourcesPage/Components/ResourceTableControls.tsx
@@ -45,7 +45,9 @@ export const ResourceTableControls: React.FC<Props> = ({
     <ToolbarContent>
       <Flex style={{ width: "100%" }} alignItems={{ default: "alignItemsFlexEnd" }}>
         {summaryWidget}
-        <ToolbarItem variant="pagination">{paginationWidget}</ToolbarItem>
+        <ToolbarItem variant="pagination" style={{ justifyContent: "flex-end", minWidth: "320px" }}>
+          {paginationWidget}
+        </ToolbarItem>
         <ToolbarItem>
           <Button
             {...(noResourcesFound && { isDanger: true })}


### PR DESCRIPTION
# Description

Fixed a layout shift causing progress bars in the resources view to resize when pagination controls changed.
Chose for the minWidth option on the pagination controls itself.

closes https://github.com/inmanta/web-console/issues/6833

<img width="1652" height="348" alt="Screenshot 2026-05-04 at 09 00 15" src="https://github.com/user-attachments/assets/bded57c4-22f0-416f-a51c-822640d2f252" />
