### PR TITLE
make optional field set values to null when absent

### DIFF
--- a/changelogs/unreleased/fix-empty-optional-values.yml
+++ b/changelogs/unreleased/fix-empty-optional-values.yml
@@ -1,0 +1,5 @@
+description: Empty optional values are now submitted as `null` to the API instead of an empty string/array/object.
+change-type: patch
+destination-branches: [master, iso9]
+sections:
+  minor-improvement: "{{description}}"

--- a/src/Core/Language/collection.test.ts
+++ b/src/Core/Language/collection.test.ts
@@ -1,5 +1,6 @@
 import {
   cloneDeep,
+  get,
   groupBy,
   isEqual,
   merge,
@@ -82,5 +83,39 @@ describe("collection utils", () => {
     const result = pickBy(input, (value) => value !== undefined);
 
     expect(result).toEqual({ a: 1, c: 3 });
+  });
+
+  describe("get", () => {
+    it("returns the value at the given path", () => {
+      expect(get({ a: 1 }, "a")).toBe(1);
+    });
+
+    it("returns null when the field value is null", () => {
+      expect(get({ a: null }, "a")).toBeNull();
+    });
+
+    it("returns undefined when the key is absent", () => {
+      expect(get({}, "a")).toBeUndefined();
+    });
+
+    it("does not substitute the default value when the field value is null", () => {
+      expect(get({ a: null }, "a", "fallback")).toBeNull();
+    });
+
+    it("returns the default value when the key is absent", () => {
+      expect(get({}, "a", "fallback")).toBe("fallback");
+    });
+
+    it("traverses nested paths", () => {
+      expect(get({ a: { b: { c: 42 } } }, "a.b.c")).toBe(42);
+    });
+
+    it("returns undefined for a missing nested segment", () => {
+      expect(get({ a: {} }, "a.b.c")).toBeUndefined();
+    });
+
+    it("returns the default value when the root object is null", () => {
+      expect(get(null, "a", "fallback")).toBe("fallback");
+    });
   });
 });

--- a/src/Core/Language/collection.ts
+++ b/src/Core/Language/collection.ts
@@ -240,7 +240,7 @@ function get<T>(obj: unknown, path: string | (string | number)[], defaultValue?:
     current = (current as Record<string, unknown>)[segment];
   }
 
-  return (current === undefined ? defaultValue : (current as T | undefined)) ?? defaultValue;
+  return current === undefined ? defaultValue : (current as T);
 }
 
 export { get };

--- a/src/Data/Common/AttributeConverter/AttributeConverter.test.ts
+++ b/src/Data/Common/AttributeConverter/AttributeConverter.test.ts
@@ -126,27 +126,30 @@ describe("AttributeResultConverter ", () => {
 
   describe("Converts attributes to proper types ", () => {
     it.each`
-      value                    | type          | parsedValue
-      ${"5"}                   | ${"int"}      | ${5}
-      ${"5oooo"}               | ${"int"}      | ${"5oooo"}
-      ${"9223372036854775807"} | ${"int"}      | ${9223372036854775807n}
-      ${"9223372036854775807"} | ${"float"}    | ${9223372036854775807n}
-      ${'{"key": "val"}'}      | ${"dict"}     | ${{ key: "val" }}
-      ${'{"key: "val"}'}       | ${"dict"}     | ${'{"key: "val"}'}
-      ${"first, "}             | ${"string[]"} | ${["first", ""]}
-      ${""}                    | ${"string[]"} | ${[""]}
-      ${""}                    | ${"int?"}     | ${null}
-      ${""}                    | ${"int"}      | ${null}
-      ${"50"}                  | ${"int?"}     | ${50}
-      ${""}                    | ${"bool?"}    | ${null}
-      ${"true"}                | ${"bool?"}    | ${true}
-      ${"false"}               | ${"bool?"}    | ${false}
-      ${"false"}               | ${"bool"}     | ${false}
-      ${"randomValue"}         | ${"bool"}     | ${null}
-      ${true}                  | ${"bool"}     | ${true}
-      ${"1,2"}                 | ${"int[]"}    | ${[1, 2]}
-      ${"1, 2 ,a"}             | ${"int[]"}    | ${[1, 2, "a"]}
-      ${"1.2,3.4"}             | ${"float[]"}  | ${[1.2, 3.4]}
+      value                    | type           | parsedValue
+      ${"5"}                   | ${"int"}       | ${5}
+      ${"5oooo"}               | ${"int"}       | ${"5oooo"}
+      ${"9223372036854775807"} | ${"int"}       | ${9223372036854775807n}
+      ${"9223372036854775807"} | ${"float"}     | ${9223372036854775807n}
+      ${'{"key": "val"}'}      | ${"dict"}      | ${{ key: "val" }}
+      ${'{"key: "val"}'}       | ${"dict"}      | ${'{"key: "val"}'}
+      ${"first, "}             | ${"string[]"}  | ${["first", ""]}
+      ${""}                    | ${"string[]"}  | ${[""]}
+      ${""}                    | ${"string?"}   | ${null}
+      ${[]}                    | ${"string[]?"} | ${null}
+      ${""}                    | ${"string[]?"} | ${null}
+      ${""}                    | ${"int?"}      | ${null}
+      ${""}                    | ${"int"}       | ${null}
+      ${"50"}                  | ${"int?"}      | ${50}
+      ${""}                    | ${"bool?"}     | ${null}
+      ${"true"}                | ${"bool?"}     | ${true}
+      ${"false"}               | ${"bool?"}     | ${false}
+      ${"false"}               | ${"bool"}      | ${false}
+      ${"randomValue"}         | ${"bool"}      | ${null}
+      ${true}                  | ${"bool"}      | ${true}
+      ${"1,2"}                 | ${"int[]"}     | ${[1, 2]}
+      ${"1, 2 ,a"}             | ${"int[]"}     | ${[1, 2, "a"]}
+      ${"1.2,3.4"}             | ${"float[]"}   | ${[1.2, 3.4]}
     `("converts $value of type $type to $parsedValue", ({ value, type, parsedValue }) => {
       const result = attributeResultConverter.ensureAttributeType(value, type);
 

--- a/src/Data/Common/AttributeConverter/AttributeConverterImpl.ts
+++ b/src/Data/Common/AttributeConverter/AttributeConverterImpl.ts
@@ -98,7 +98,10 @@ export class AttributeResultConverterImpl implements AttributeResultConverter {
     try {
       if (type.includes("bool")) {
         parsedValue = toOptionalBoolean(value);
-      } else if (type.includes("?") && value === "") {
+      } else if (
+        type.includes("?") &&
+        (value === "" || (Array.isArray(value) && value.length === 0))
+      ) {
         parsedValue = null;
       } else if ((isNumberType(type) || isNumberArray(type)) && value === "") {
         parsedValue = null;

--- a/src/Data/Common/AttributeConverter/sanitizeAttributes.spec.ts
+++ b/src/Data/Common/AttributeConverter/sanitizeAttributes.spec.ts
@@ -1,3 +1,5 @@
+import { TextInputTypes } from "@patternfly/react-core";
+import { Textarea } from "@/Core";
 import { Field } from "@/Test";
 import { createFormState } from "@/UI/Components";
 import { sanitizeAttributes } from "./sanitizeAttributes";
@@ -152,4 +154,61 @@ test("GIVEN sanitizeAttributes WHEN InterServiceRelation field value is valid st
   expect(sanitized).toMatchObject({
     related_service: "service-instance-id-123", // Should preserve valid string value
   });
+});
+
+test("GIVEN sanitizeAttributes WHEN TextList field value is empty string THEN converts to null for optional type", () => {
+  const textListField = {
+    kind: "TextList" as const,
+    name: "tags",
+    description: "Tags",
+    isOptional: true,
+    isDisabled: false,
+    defaultValue: [],
+    inputType: TextInputTypes.text,
+    type: "string[]?",
+  };
+
+  const fields = [textListField];
+  const formState = { tags: "" };
+  const sanitized = sanitizeAttributes(fields, formState);
+
+  expect(sanitized).toMatchObject({ tags: null });
+});
+
+test("GIVEN sanitizeAttributes WHEN TextList field value is empty array THEN converts to null for optional type", () => {
+  const textListField = {
+    kind: "TextList" as const,
+    name: "tags",
+    description: "Tags",
+    isOptional: true,
+    isDisabled: false,
+    defaultValue: [],
+    inputType: TextInputTypes.text,
+    type: "string[]?",
+  };
+
+  const fields = [textListField];
+  const formState = { tags: [] };
+  const sanitized = sanitizeAttributes(fields, formState);
+
+  expect(sanitized).toMatchObject({ tags: null });
+});
+
+test("GIVEN sanitizeAttributes WHEN Textarea field value is empty string THEN converts to null for optional type", () => {
+  const textareaField: Textarea = {
+    kind: "Textarea",
+    name: "description",
+    description: "Description",
+    isOptional: true,
+    isDisabled: false,
+    defaultValue: "",
+    inputType: TextInputTypes.text,
+    type: "string?",
+  };
+
+  const fields = [textareaField];
+  const formState = { description: "" };
+  const sanitized = sanitizeAttributes(fields, formState);
+
+  expect(sanitized).toMatchObject({ description: null });
 });

--- a/src/Data/Common/AttributeConverter/sanitizeAttributes.ts
+++ b/src/Data/Common/AttributeConverter/sanitizeAttributes.ts
@@ -19,6 +19,8 @@ export function sanitizeAttributes(
     switch (field.kind) {
       case "Enum":
       case "Boolean":
+      case "Textarea":
+      case "TextList":
       case "Text": {
         sanitized[field.name] = converter.ensureAttributeType(formState[field.name], field.type);
 

--- a/src/UI/Components/Composer/Data/Helpers/initializeCanvasFromInstance.ts
+++ b/src/UI/Components/Composer/Data/Helpers/initializeCanvasFromInstance.ts
@@ -348,6 +348,7 @@ export const initializeCanvasFromInstance = (
      * while existing instances loaded from the backend remain non-new.
      */
     const isNewEntity = instance.state === "creating" && !instance.active_attributes;
+    console.log(`Initializing shape for ${instance.id} (isNew: ${isNewEntity})`);
 
     const interServiceRelations: Record<string, string[]> = {};
     const rootEntities: Record<string, string[]> = {};
@@ -429,7 +430,8 @@ export const initializeCanvasFromInstance = (
           embeddedEntityCache,
           positionTracker,
           parentPosition.x + HORIZONTAL_SPACING,
-          parentPosition.y
+          parentPosition.y, 
+          isNewEntity
         );
 
         if (embeddedIds.length > 0) {

--- a/src/UI/Components/Composer/Data/Helpers/initializeCanvasFromInstance.ts
+++ b/src/UI/Components/Composer/Data/Helpers/initializeCanvasFromInstance.ts
@@ -348,7 +348,6 @@ export const initializeCanvasFromInstance = (
      * while existing instances loaded from the backend remain non-new.
      */
     const isNewEntity = instance.state === "creating" && !instance.active_attributes;
-    console.log(`Initializing shape for ${instance.id} (isNew: ${isNewEntity})`);
 
     const interServiceRelations: Record<string, string[]> = {};
     const rootEntities: Record<string, string[]> = {};

--- a/src/UI/Components/Composer/Data/Helpers/initializeCanvasFromInstance.ts
+++ b/src/UI/Components/Composer/Data/Helpers/initializeCanvasFromInstance.ts
@@ -81,7 +81,8 @@ export const createEmbeddedEntityShapes = (
   embeddedEntityCache: Map<string, string>,
   positionTracker: PositionTracker,
   offsetX: number,
-  offsetY: number
+  offsetY: number,
+  isNew: boolean = false
 ): string[] => {
   const createdIds: string[] = [];
   const dataArray = Array.isArray(embeddedData) ? embeddedData : [embeddedData];
@@ -171,7 +172,8 @@ export const createEmbeddedEntityShapes = (
           embeddedEntityCache,
           positionTracker,
           offsetX + NESTED_HORIZONTAL_OFFSET,
-          offsetY
+          offsetY,
+          isNew
         );
 
         if (nestedIds.length > 0) {
@@ -190,7 +192,7 @@ export const createEmbeddedEntityShapes = (
     const shapeOptions: ServiceEntityOptions = {
       entityType: "embedded",
       readonly: false,
-      isNew: false,
+      isNew,
       lockedOnCanvas: false,
       id: embeddedId,
       relationsDictionary,

--- a/src/UI/Components/Composer/Data/Helpers/initializeCanvasFromInstance.ts
+++ b/src/UI/Components/Composer/Data/Helpers/initializeCanvasFromInstance.ts
@@ -430,7 +430,7 @@ export const initializeCanvasFromInstance = (
           embeddedEntityCache,
           positionTracker,
           parentPosition.x + HORIZONTAL_SPACING,
-          parentPosition.y, 
+          parentPosition.y,
           isNewEntity
         );
 

--- a/src/UI/Components/Composer/UI/JointJsShapes/InstanceTabElement.ts
+++ b/src/UI/Components/Composer/UI/JointJsShapes/InstanceTabElement.ts
@@ -152,7 +152,8 @@ export class InstanceTabElement {
           embeddedEntityCache,
           positionTracker,
           parentPosition.x + HORIZONTAL_SPACING,
-          parentPosition.y
+          parentPosition.y,
+          true
         );
 
         if (embeddedIds.length > 0) {

--- a/src/UI/Components/ServiceInstanceForm/Components/FieldInput.tsx
+++ b/src/UI/Components/ServiceInstanceForm/Components/FieldInput.tsx
@@ -154,7 +154,7 @@ export const FieldInput: React.FC<Props> = ({
         <TextListFormInput
           aria-label={`TextFieldInput-${field.name}`}
           attributeName={field.name}
-          attributeValue={get<string[]>(formState, makePath(path, field.name), [])}
+          attributeValue={get<string[]>(formState, makePath(path, field.name), []) ?? []}
           description={field.description}
           shouldBeDisabled={
             field.isDisabled &&
@@ -174,7 +174,7 @@ export const FieldInput: React.FC<Props> = ({
         <TextFormInput
           aria-label={`TextFieldInput-${field.name}`}
           attributeName={field.name}
-          attributeValue={get<string>(formState, makePath(path, field.name), "")}
+          attributeValue={get<string>(formState, makePath(path, field.name), "") ?? ""}
           description={field.description}
           isOptional={field.isOptional}
           shouldBeDisabled={
@@ -239,7 +239,7 @@ export const FieldInput: React.FC<Props> = ({
           aria-label={`EnumFieldInput-${field.name}`}
           options={field.options}
           attributeName={field.name}
-          attributeValue={get<string>(formState, makePath(path, field.name), "")}
+          attributeValue={get<string>(formState, makePath(path, field.name), "") ?? ""}
           description={field.description}
           isOptional={field.isOptional}
           handleInputChange={getEnumUpdate}
@@ -460,7 +460,7 @@ const DictListFieldInput: React.FC<DictListProps> = ({
   isNew = false,
 }) => {
   const list = useMemo(
-    () => get<Array<unknown>>(formState, makePath(path, field.name), []),
+    () => get<Array<unknown>>(formState, makePath(path, field.name), []) ?? [],
     [formState, path, field.name]
   );
 


### PR DESCRIPTION
# Description

After a discussion with Guillaume, it was aggreed that the web-console would submit null for the types that contain a questionmark. 

There was also a minor issue in the composer when dragging items from the inventory, their placeholder relations were not set as new, blocking edits if the shape was RW.