### PR TITLE
Hide Markdown Preview Button on Older Versions

### DIFF
--- a/changelogs/unreleased/6880-hide-preview-markdown-older-versions.yml
+++ b/changelogs/unreleased/6880-hide-preview-markdown-older-versions.yml
@@ -1,0 +1,8 @@
+change-type: patch
+description: "Hide the Markdown Previewer button on the Documentation tab when viewing older versions of a service instance."
+issue-nr: 6880
+destination-branches:
+- master
+- iso9
+sections:
+  minor-improvement: "{{description}}"

--- a/src/Slices/ServiceInstanceDetails/Test/Page.test.tsx
+++ b/src/Slices/ServiceInstanceDetails/Test/Page.test.tsx
@@ -461,4 +461,38 @@ describe("ServiceInstanceDetailsPage", () => {
 
     server.close();
   }, 25000);
+
+  it("Should hide the Markdown Previewer button on older versions when expert mode is enabled", async () => {
+    const server = serverWithDocumentation;
+
+    server.listen();
+    const component = setupServiceInstanceDetails(true);
+
+    render(component);
+
+    expect(
+      await screen.findByRole("region", { name: "Instance-Details-Success" })
+    ).toBeInTheDocument();
+
+    // On the latest version, the preview button should be visible in expert mode
+    expect(screen.getByRole("button", { name: "preview-button" })).toBeVisible();
+
+    // Switch to an older version
+    await userEvent.click(screen.getByRole("cell", { name: "3" }));
+
+    expect(screen.getByTestId("selected-version")).toHaveTextContent("Version: 3");
+
+    // The preview button should be hidden on older versions
+    expect(screen.queryByRole("button", { name: "preview-button" })).not.toBeInTheDocument();
+
+    // Switch back to the latest version
+    await userEvent.click(screen.getByRole("cell", { name: "4" }));
+
+    expect(screen.queryByTestId("selected-version")).not.toBeInTheDocument();
+
+    // The preview button should be visible again on the latest version
+    expect(screen.getByRole("button", { name: "preview-button" })).toBeVisible();
+
+    server.close();
+  }, 15000);
 });

--- a/src/Slices/ServiceInstanceDetails/UI/Tabs/DocumentationTabContent.tsx
+++ b/src/Slices/ServiceInstanceDetails/UI/Tabs/DocumentationTabContent.tsx
@@ -137,7 +137,7 @@ export const DocumentationTabContent: React.FC<Props> = ({
   };
 
   const MarkdownPreviewerButton = () => {
-    if (!isExpertModeEnabled) {
+    if (!isExpertModeEnabled || !isLatest) {
       return null;
     }
 


### PR DESCRIPTION
# Description

Only show the Markdown Preview button on the latest version. Showing the button on older versions has no purpose, the preview page always displays the latest version because that's the only editable one in expert mode. You cannot edit older versions with expert mode. 

## Implementation
- Add `|| !isLatest` to the guard in MarkdownPreviewerButton

## Test coverage
- Add assertion to existing documentation test: preview-button absent on older versions (expertMode: true setup)
- Add assertion: preview-button present on latest version (expertMode: true setup)

closes
- #6880 

https://github.com/user-attachments/assets/265c8f0d-42c8-49c6-9803-5e966e7ba6ed

