### PR TITLE
Add version tag on desired state details page

### DIFF
--- a/changelogs/unreleased/6845-add-version-label-desiredState-details.yml
+++ b/changelogs/unreleased/6845-add-version-label-desiredState-details.yml
@@ -1,0 +1,3 @@
+description: Add a label tag to the desired state details page to show the version of the desired state being viewed.
+change-type: patch
+destination-branches: [master, iso9]

--- a/src/Slices/DesiredStateDetails/UI/Page.test.tsx
+++ b/src/Slices/DesiredStateDetails/UI/Page.test.tsx
@@ -135,6 +135,8 @@ describe("DesiredStateDetails", () => {
       })
     ).toBeVisible();
 
+    expect(await screen.findByTestId("version-label")).toHaveTextContent("Version: 123");
+
     await act(async () => {
       const results = await axe(document.body);
 

--- a/src/Slices/DesiredStateDetails/UI/Page.tsx
+++ b/src/Slices/DesiredStateDetails/UI/Page.tsx
@@ -4,6 +4,8 @@ import {
   Drawer,
   DrawerContent,
   DrawerContentBody,
+  Flex,
+  Label,
   PageSection,
 } from "@patternfly/react-core";
 import { Resource } from "@/Core";
@@ -69,7 +71,14 @@ export const Page: React.FC<{ version: string }> = ({ version }) => {
             paddingBottom: "var(--pf-t--global--spacer--md)",
           }}
         >
-          <Content component="h1">{words("desiredState.details.title")}</Content>
+          <Content component="h1">
+            <Flex gap={{ default: "gapSm" }} alignItems={{ default: "alignItemsCenter" }}>
+              {words("desiredState.details.title")}
+              <Label color="purple" data-testid="version-label">
+                {words("desiredState.details.title.tag")(version)}
+              </Label>
+            </Flex>
+          </Content>
           <Controls
             paginationWidget={
               <PaginationWidget

--- a/src/UI/words.tsx
+++ b/src/UI/words.tsx
@@ -810,6 +810,7 @@ const dict = {
 
   /** Desired State */
   "desiredState.title": "Desired State",
+  "desiredState.details.title.tag": (version) => `Version: ${version}`,
   "desiredState.empty.message": "No desired state versions found",
   "desiredState.columns.date": "Date",
   "desiredState.columns.version": "Version",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11983,11 +11983,11 @@ __metadata:
   linkType: hard
 
 "systeminformation@npm:^5.31.1":
-  version: 5.31.5
-  resolution: "systeminformation@npm:5.31.5"
+  version: 5.31.6
+  resolution: "systeminformation@npm:5.31.6"
   bin:
     systeminformation: lib/cli.js
-  checksum: 10/6efe04b1873bf3e6488064a9462575dc6d83fc4b509bd8922304c87b658964e3ce598db8e1af123e0fa49d76b2cc85c7211b8f6c8a6b8c69846698f8ce65ca2c
+  checksum: 10/42c986adc6af3dc296458177a5bb79922d7892a684b8271bce6dfaf9d40285330606a36dbb0b41f3b76fd745b6658a92bf5c62d6d56d4a746d64bb45be81b394
   conditions: (os=darwin | os=linux | os=win32 | os=freebsd | os=openbsd | os=netbsd | os=sunos | os=android)
   languageName: node
   linkType: hard


### PR DESCRIPTION
# Description

Add a label tag with the version number that is currently viewed on the page. It has the same color as the tag on the instance details page, when informing the user about which verison is being showed.

closes:
- #6845 

<img width="550" height="419" alt="image" src="https://github.com/user-attachments/assets/33c33291-6287-40ca-b836-82fe47c82121" />
