### PR TITLE
6883 sort documentation tab items

### DIFF
--- a/changelogs/unreleased/6883-sort-documentation-tab-items.yml
+++ b/changelogs/unreleased/6883-sort-documentation-tab-items.yml
@@ -1,0 +1,11 @@
+change-type: patch
+description: Add web_order sorting and multi-expand support to the documentation tab collapsibles
+destination-branches:
+- master
+- iso9
+- iso8
+sections:
+  feature: |
+    "Add support for `web_order` and `web_default_open` attribute annotations on the Service Instance Details documentation tab. 
+    Sections can now be sorted by `web_order` (use `-1` or omit to keep declaration order), multiple sections can be open simultaneously, 
+    and `web_default_open: true` expands a section on first render."

--- a/src/Core/Domain/ServiceModel.ts
+++ b/src/Core/Domain/ServiceModel.ts
@@ -31,6 +31,8 @@ export interface AttributeAnnotations {
   web_icon?: string;
   web_title?: string;
   web_content_type?: string;
+  web_order?: number;
+  web_default_open?: boolean;
 }
 
 /**

--- a/src/Slices/ServiceInstanceDetails/Test/Page.test.tsx
+++ b/src/Slices/ServiceInstanceDetails/Test/Page.test.tsx
@@ -8,8 +8,13 @@ import {
   errorServerInstance,
   loadingServer,
   serverWithDocumentation,
+  serverWithMultipleDocumentation,
 } from "./mockServer";
 import { setupServiceInstanceDetails } from "./mockSetup";
+import {
+  DocAttributeDescriptors,
+  sortDocAttributeDescriptors,
+} from "../UI/Tabs/DocumentationTabContent";
 
 describe("ServiceInstanceDetailsPage", () => {
   it("Should render the view in its loading states", async () => {
@@ -461,4 +466,148 @@ describe("ServiceInstanceDetailsPage", () => {
 
     server.close();
   }, 25000);
+
+  it("Should render documentation sections in web_order sort order with the default-open section expanded", async () => {
+    const server = serverWithMultipleDocumentation;
+
+    server.listen();
+    const component = setupServiceInstanceDetails();
+
+    render(component);
+
+    await screen.findByRole("region", { name: "Instance-Details-Success" });
+
+    expect(screen.getByText("Documentation")).toBeInTheDocument();
+
+    const architectureToggle = screen.getByRole("button", { name: /Architecture/i });
+    const topographyToggle = screen.getByRole("button", { name: /Topography/i });
+    const readmeToggle = screen.getByRole("button", { name: /Readme/i });
+
+    // Verify sort order: Architecture (1) → Topography (2) → Readme (-1 → last)
+    const allButtons = screen.getAllByRole("button");
+    const archIdx = allButtons.indexOf(architectureToggle);
+    const topoIdx = allButtons.indexOf(topographyToggle);
+    const readmeIdx = allButtons.indexOf(readmeToggle);
+
+    expect(archIdx).toBeLessThan(topoIdx);
+    expect(topoIdx).toBeLessThan(readmeIdx);
+
+    // Architecture has web_default_open: true → expanded by default
+    expect(architectureToggle).toHaveAttribute("aria-expanded", "true");
+    // Topography and Readme start collapsed
+    expect(topographyToggle).toHaveAttribute("aria-expanded", "false");
+    expect(readmeToggle).toHaveAttribute("aria-expanded", "false");
+
+    server.close();
+  }, 15000);
+
+  it("Should allow multiple documentation sections to be open simultaneously", async () => {
+    const server = serverWithMultipleDocumentation;
+
+    server.listen();
+    const component = setupServiceInstanceDetails();
+
+    render(component);
+
+    await screen.findByRole("region", { name: "Instance-Details-Success" });
+
+    const architectureToggle = screen.getByRole("button", { name: /Architecture/i });
+    const topographyToggle = screen.getByRole("button", { name: /Topography/i });
+    const readmeToggle = screen.getByRole("button", { name: /Readme/i });
+
+    // Architecture is open by default; others are closed
+    expect(architectureToggle).toHaveAttribute("aria-expanded", "true");
+    expect(topographyToggle).toHaveAttribute("aria-expanded", "false");
+
+    // Open Topography
+    await userEvent.click(topographyToggle);
+
+    // Both Architecture AND Topography must now be open — multi-expand
+    expect(architectureToggle).toHaveAttribute("aria-expanded", "true");
+    expect(topographyToggle).toHaveAttribute("aria-expanded", "true");
+    expect(readmeToggle).toHaveAttribute("aria-expanded", "false");
+
+    server.close();
+  }, 15000);
+
+  it("Should collapse a documentation section when its open toggle is clicked again", async () => {
+    const server = serverWithMultipleDocumentation;
+
+    server.listen();
+    const component = setupServiceInstanceDetails();
+
+    render(component);
+
+    await screen.findByRole("region", { name: "Instance-Details-Success" });
+
+    const architectureToggle = screen.getByRole("button", { name: /Architecture/i });
+
+    // Architecture is open by default
+    expect(architectureToggle).toHaveAttribute("aria-expanded", "true");
+
+    // Clicking it again should collapse it
+    await userEvent.click(architectureToggle);
+
+    expect(architectureToggle).toHaveAttribute("aria-expanded", "false");
+
+    server.close();
+  }, 15000);
+});
+
+describe("sortDocAttributeDescriptors", () => {
+  const makeDescriptor = (title: string, webOrder?: number): DocAttributeDescriptors => ({
+    title,
+    iconName: "FaBook",
+    attributeName: title.toLowerCase(),
+    webOrder,
+  });
+
+  it("should sort items by webOrder ascending", () => {
+    const input = [makeDescriptor("C", 3), makeDescriptor("A", 1), makeDescriptor("B", 2)];
+    const result = sortDocAttributeDescriptors(input);
+
+    expect(result.map((d) => d.title)).toEqual(["A", "B", "C"]);
+  });
+
+  it("should place items with webOrder === -1 after explicitly ordered items", () => {
+    const input = [makeDescriptor("Unordered", -1), makeDescriptor("First", 1)];
+    const result = sortDocAttributeDescriptors(input);
+
+    expect(result[0].title).toBe("First");
+    expect(result[1].title).toBe("Unordered");
+  });
+
+  it("should place items without webOrder after explicitly ordered items", () => {
+    const input = [
+      makeDescriptor("NoOrder"),
+      makeDescriptor("Second", 2),
+      makeDescriptor("First", 1),
+    ];
+    const result = sortDocAttributeDescriptors(input);
+
+    expect(result.map((d) => d.title)).toEqual(["First", "Second", "NoOrder"]);
+  });
+
+  it("should preserve the relative order of multiple unordered items", () => {
+    const input = [makeDescriptor("X"), makeDescriptor("Y"), makeDescriptor("A", 1)];
+    const result = sortDocAttributeDescriptors(input);
+
+    expect(result.map((d) => d.title)).toEqual(["A", "X", "Y"]);
+  });
+
+  it("should return original order when all items lack webOrder", () => {
+    const input = [makeDescriptor("X"), makeDescriptor("Y"), makeDescriptor("Z")];
+    const result = sortDocAttributeDescriptors(input);
+
+    expect(result.map((d) => d.title)).toEqual(["X", "Y", "Z"]);
+  });
+
+  it("should not mutate the input array", () => {
+    const input = [makeDescriptor("B", 2), makeDescriptor("A", 1)];
+    const snapshot = input.map((d) => d.title);
+
+    sortDocAttributeDescriptors(input);
+
+    expect(input.map((d) => d.title)).toEqual(snapshot);
+  });
 });

--- a/src/Slices/ServiceInstanceDetails/Test/Page.test.tsx
+++ b/src/Slices/ServiceInstanceDetails/Test/Page.test.tsx
@@ -3,6 +3,10 @@ import { render, screen, waitFor } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
 import { axe } from "jest-axe";
 import {
+  DocAttributeDescriptors,
+  sortDocAttributeDescriptors,
+} from "../UI/Tabs/DocumentationTabContent";
+import {
   defaultServer,
   errorServerHistory,
   errorServerInstance,
@@ -11,10 +15,6 @@ import {
   serverWithMultipleDocumentation,
 } from "./mockServer";
 import { setupServiceInstanceDetails } from "./mockSetup";
-import {
-  DocAttributeDescriptors,
-  sortDocAttributeDescriptors,
-} from "../UI/Tabs/DocumentationTabContent";
 
 describe("ServiceInstanceDetailsPage", () => {
   it("Should render the view in its loading states", async () => {

--- a/src/Slices/ServiceInstanceDetails/Test/mockData.ts
+++ b/src/Slices/ServiceInstanceDetails/Test/mockData.ts
@@ -1656,6 +1656,148 @@ export const logsWithDocumentationResponse = {
   },
 };
 
+// --- Multi-documentation fixtures ---
+// Three documentation sections with web_order and web_default_open set, to cover
+// sorting, default-open, and multi-expand behaviour.
+//
+// Declaration order:  topography (order 2) → architecture (order 1) → readme (order -1)
+// Expected sort order: architecture (1) → topography (2) → readme (-1 → last)
+
+export const instanceDataWithMultipleDocumentation: ServiceInstanceModel = {
+  ...instanceData,
+  version: 2,
+  candidate_attributes: {
+    topography: "# Topography\n\nTopography content.",
+    architecture: "# Architecture\n\nArchitecture content.",
+    readme: "# Readme\n\nReadme content.",
+  },
+};
+
+export const serviceModelWithMultipleDocumentation: ServiceModel = {
+  ...serviceModel,
+  attributes: [
+    // declared first, web_order: 2 → renders second after sort
+    {
+      name: "topography",
+      description: "Topography of this instance",
+      modifier: "r",
+      attribute_annotations: {
+        web_icon: "FaBook",
+        web_content_type: "text/markdown",
+        web_title: "Topography",
+        web_presentation: "documentation",
+        web_order: 2,
+      },
+      type: "string",
+      default_value: "# Topography\n\nTopography content.",
+      default_value_set: true,
+      validation_type: null,
+      validation_parameters: null,
+    },
+    // declared second, web_order: 1, web_default_open: true → renders first, expanded by default
+    {
+      name: "architecture",
+      description: "Architecture of this instance",
+      modifier: "r",
+      attribute_annotations: {
+        web_icon: "FaNetworkWired",
+        web_content_type: "text/markdown",
+        web_title: "Architecture",
+        web_presentation: "documentation",
+        web_order: 1,
+        web_default_open: true,
+      },
+      type: "string",
+      default_value: "# Architecture\n\nArchitecture content.",
+      default_value_set: true,
+      validation_type: null,
+      validation_parameters: null,
+    },
+    // web_order: -1 → treated as unordered, sorts to end
+    {
+      name: "readme",
+      description: "Readme for this instance",
+      modifier: "r",
+      attribute_annotations: {
+        web_icon: "FaFileAlt",
+        web_content_type: "text/markdown",
+        web_title: "Readme",
+        web_presentation: "documentation",
+        web_order: -1,
+      },
+      type: "string",
+      default_value: "# Readme\n\nReadme content.",
+      default_value_set: true,
+      validation_type: null,
+      validation_parameters: null,
+    },
+  ],
+};
+
+const historyDataWithMultipleDocumentation: InstanceLog[] = [
+  {
+    service_instance_id: "1d96a1ab",
+    environment: "5bfe1994-365f-49ec-bff1-fed77bbbf8e6",
+    service_entity: "mobileCore",
+    service_entity_version: 0,
+    version: 2,
+    desired_state_version: 2,
+    timestamp: "2022-09-02T12:01:19.626854+00:00",
+    config: {},
+    state: "up",
+    candidate_attributes: {
+      topography: "# Topography\n\nTopography content.",
+      architecture: "# Architecture\n\nArchitecture content.",
+      readme: "# Readme\n\nReadme content.",
+    },
+    active_attributes: null,
+    rollback_attributes: null,
+    created_at: "2022-09-02T11:56:06.852941+00:00",
+    last_updated: "2022-09-02T12:01:19.626854+00:00",
+    callback: [],
+    deleted: false,
+    events: [],
+    service_identity_attribute_value: "core1",
+    transfer_context: "auto",
+  },
+  {
+    service_instance_id: "1d96a1ab",
+    environment: "5bfe1994-365f-49ec-bff1-fed77bbbf8e6",
+    service_entity: "mobileCore",
+    service_entity_version: 0,
+    version: 1,
+    desired_state_version: 1,
+    timestamp: "2022-09-02T11:56:06.852941+00:00",
+    config: {},
+    state: "start",
+    candidate_attributes: {
+      topography: "# Old topography.",
+    },
+    active_attributes: null,
+    rollback_attributes: null,
+    created_at: "2022-09-02T11:56:06.852941+00:00",
+    last_updated: "2022-09-02T11:56:06.852941+00:00",
+    callback: [],
+    deleted: false,
+    events: [],
+    service_identity_attribute_value: "core1",
+    transfer_context: "auto",
+  },
+];
+
+export const logsWithMultipleDocumentationResponse = {
+  data: historyDataWithMultipleDocumentation,
+  links: {
+    self: "/lsm/v1/service_inventory/mobileCore/1d96a1ab/log?limit=50&sort=version.desc",
+  },
+  metadata: {
+    total: 2,
+    before: 0,
+    after: 0,
+    page_size: 50,
+  },
+};
+
 export const JSONSchema = {
   data: {
     $defs: {

--- a/src/Slices/ServiceInstanceDetails/Test/mockServer.ts
+++ b/src/Slices/ServiceInstanceDetails/Test/mockServer.ts
@@ -4,11 +4,14 @@ import {
   logsResponse,
   instanceData,
   instanceDataWithDocumentation,
+  instanceDataWithMultipleDocumentation,
   JSONSchema,
   serviceModel,
   serviceModelWithConfig,
   serviceModelWithDocumentation,
+  serviceModelWithMultipleDocumentation,
   logsWithDocumentationResponse,
+  logsWithMultipleDocumentationResponse,
 } from "./mockData";
 
 const getServiceModel = http.get("/lsm/v1/service_catalog/mobileCore", () => {
@@ -261,6 +264,43 @@ export const serverWithDocumentation = setupServer(
   getServiceModelWithDocumentation,
   getHistoryLogsWithDocumentation,
   getInstanceDataWithDocumentation,
+  getResources
+);
+
+const getServiceModelWithMultipleDocumentation = http.get(
+  "/lsm/v1/service_catalog/mobileCore",
+  async () => {
+    return HttpResponse.json({
+      data: serviceModelWithMultipleDocumentation,
+    });
+  }
+);
+
+const getInstanceDataWithMultipleDocumentation = http.get(
+  "/lsm/v1/service_inventory/mobileCore/1d96a1ab",
+  async () => {
+    return HttpResponse.json({
+      data: instanceDataWithMultipleDocumentation,
+    });
+  }
+);
+
+const getHistoryLogsWithMultipleDocumentation = http.get(
+  "/lsm/v1/service_inventory/mobileCore/1d96a1ab/log",
+  async () => {
+    return HttpResponse.json(logsWithMultipleDocumentationResponse);
+  }
+);
+
+/**
+ * Setup a test server with multiple documentation sections that carry
+ * web_order and web_default_open annotations, used to test sorting,
+ * default-open, and multi-expand behaviour.
+ */
+export const serverWithMultipleDocumentation = setupServer(
+  getServiceModelWithMultipleDocumentation,
+  getHistoryLogsWithMultipleDocumentation,
+  getInstanceDataWithMultipleDocumentation,
   getResources
 );
 

--- a/src/Slices/ServiceInstanceDetails/UI/Tabs/DocumentationTabContent.tsx
+++ b/src/Slices/ServiceInstanceDetails/UI/Tabs/DocumentationTabContent.tsx
@@ -75,10 +75,15 @@ export const DocumentationTabContent: React.FC<Props> = ({
     }
   }, [isLatest, logsQuery.data, logsQuery.isLoading, selectedVersion, instance]);
 
+  const sortedDescriptors = useMemo(
+    () => sortDocAttributeDescriptors(docAttributeDescriptors),
+    [docAttributeDescriptors]
+  );
+
   // Memoize sections calculation
   const sections = useMemo(() => {
-    return selectedSet ? getDocumentationSections(docAttributeDescriptors, selectedSet) : [];
-  }, [docAttributeDescriptors, selectedSet]);
+    return selectedSet ? getDocumentationSections(sortedDescriptors, selectedSet) : [];
+  }, [sortedDescriptors, selectedSet]);
 
   const handleStateTransferClick = useCallback(
     ({ targetState }: { content: string; targetState: string }) => {
@@ -211,6 +216,29 @@ export const DocumentationTabContent: React.FC<Props> = ({
       </Accordion>
     </TabContentWrapper>
   );
+};
+
+/**
+ * Sorts documentation attribute descriptors by webOrder ascending.
+ * Descriptors without webOrder or with webOrder === -1 are placed after all
+ * explicitly ordered items, preserving their original relative order.
+ */
+export const sortDocAttributeDescriptors = (
+  descriptors: DocAttributeDescriptors[]
+): DocAttributeDescriptors[] => {
+  return descriptors.slice().sort((a, b) => {
+    const aOrdered = a.webOrder !== undefined && a.webOrder !== -1;
+    const bOrdered = b.webOrder !== undefined && b.webOrder !== -1;
+
+    if (aOrdered && bOrdered) {
+      return (a.webOrder as number) - (b.webOrder as number);
+    } else if (aOrdered) {
+      return -1;
+    } else if (bOrdered) {
+      return 1;
+    }
+    return 0;
+  });
 };
 
 /**

--- a/src/Slices/ServiceInstanceDetails/UI/Tabs/DocumentationTabContent.tsx
+++ b/src/Slices/ServiceInstanceDetails/UI/Tabs/DocumentationTabContent.tsx
@@ -58,7 +58,23 @@ export const DocumentationTabContent: React.FC<Props> = ({
   const { logsQuery, instance } = useContext(InstanceDetailsContext);
   const { environmentHandler } = useContext(DependencyContext);
   const { triggerModal } = useContext(ModalContext);
-  const [expanded, setExpanded] = useState(0);
+  const [expandedSet, setExpandedSet] = useState<Set<number>>(() => {
+    const sorted = sortDocAttributeDescriptors(docAttributeDescriptors);
+    const initial = new Set<number>();
+
+    sorted.forEach((d, i) => {
+      if (d.webDefaultOpen) {
+        initial.add(i);
+      }
+    });
+
+    // Fall back to opening the first item when none are marked as default open
+    if (initial.size === 0 && sorted.length > 1) {
+      initial.add(0);
+    }
+
+    return initial;
+  });
   const [, setInterfaceBlocked] = useState(false);
   const navigateTo = useNavigateTo();
 
@@ -136,11 +152,17 @@ export const DocumentationTabContent: React.FC<Props> = ({
   }
 
   const onToggle = (index: number) => {
-    if (index === expanded) {
-      setExpanded(-1);
-    } else {
-      setExpanded(index);
-    }
+    setExpandedSet((prev) => {
+      const next = new Set(prev);
+
+      if (next.has(index)) {
+        next.delete(index);
+      } else {
+        next.add(index);
+      }
+
+      return next;
+    });
   };
 
   const MarkdownPreviewerButton = () => {
@@ -191,7 +213,7 @@ export const DocumentationTabContent: React.FC<Props> = ({
       <MarkdownPreviewerButton />
       <Accordion asDefinitionList togglePosition="start">
         {sections.map((section, index) => (
-          <AccordionItem isExpanded={expanded === index} key={section.title}>
+          <AccordionItem isExpanded={expandedSet.has(index)} key={section.title}>
             <AccordionToggle
               onClick={() => {
                 onToggle(index);
@@ -205,7 +227,7 @@ export const DocumentationTabContent: React.FC<Props> = ({
                 attributeValue={section.value}
                 web_title={section.title}
                 onSetStateClick={handleStateTransferClick}
-                isExpanded={expanded === index}
+                isExpanded={expandedSet.has(index)}
               />
             </AccordionContent>
           </AccordionItem>

--- a/src/Slices/ServiceInstanceDetails/UI/Tabs/DocumentationTabContent.tsx
+++ b/src/Slices/ServiceInstanceDetails/UI/Tabs/DocumentationTabContent.tsx
@@ -26,6 +26,8 @@ export interface DocAttributeDescriptors {
   title: string;
   iconName: string;
   attributeName: string;
+  webOrder?: number;
+  webDefaultOpen?: boolean;
 }
 
 // Interface representing the attributes needed for the markdownCards

--- a/src/Slices/ServiceInstanceDetails/UI/Tabs/TabView.tsx
+++ b/src/Slices/ServiceInstanceDetails/UI/Tabs/TabView.tsx
@@ -152,6 +152,8 @@ const getDocumentationAttributeDescriptors = (
           title: attribute.attribute_annotations.web_title,
           iconName: attribute.attribute_annotations.web_icon || "FaBook",
           attributeName: attribute.name,
+          webOrder: attribute.attribute_annotations.web_order,
+          webDefaultOpen: attribute.attribute_annotations.web_default_open,
         });
       }
     }


### PR DESCRIPTION
## Summary

Add two optional annotation properties to Service Instance Details documentation tab collapsibles:

| Property | Type | Behaviour |
|---|---|---|
| `web_order` | `number` (optional) | Sort collapsibles ascending. `-1` or absent → keep declaration order. |
| `web_default_open` | `boolean` (optional) | When `true`, the collapsible is expanded on first render. Absent/`false` → collapsed. If no default item found, expand first one by default. |

Additionally, allow **multiple collapsibles to be open simultaneously** (currently only one at a time is allowed).

closes: 
- #6883