### PR TITLE
ISO8- Add web_order sorting and multi-expand support to the documentation tab

### DIFF
--- a/changelogs/unreleased/6883-sort-documentation-tab-items.yml
+++ b/changelogs/unreleased/6883-sort-documentation-tab-items.yml
@@ -1,0 +1,9 @@
+change-type: patch
+description: Add web_order sorting and multi-expand support to the documentation tab collapsibles
+destination-branches:
+- iso8
+sections:
+  feature: |
+    "Add support for `web_order` and `web_default_open` attribute annotations on the Service Instance Details documentation tab. 
+    Sections can now be sorted by `web_order` (use `-1` or omit to keep declaration order), multiple sections can be open simultaneously, 
+    and `web_default_open: true` expands a section on first render."

--- a/src/Core/Domain/ServiceModel.ts
+++ b/src/Core/Domain/ServiceModel.ts
@@ -31,6 +31,8 @@ export interface AttributeAnnotations {
   web_icon?: string;
   web_title?: string;
   web_content_type?: string;
+  web_order?: number;
+  web_default_open?: boolean;
 }
 
 /**

--- a/src/Slices/ServiceInstanceDetails/Test/Page.test.tsx
+++ b/src/Slices/ServiceInstanceDetails/Test/Page.test.tsx
@@ -3,11 +3,16 @@ import { render, screen, waitFor } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
 import { axe, toHaveNoViolations } from "jest-axe";
 import {
+  DocAttributeDescriptors,
+  sortDocAttributeDescriptors,
+} from "../UI/Tabs/DocumentationTabContent";
+import {
   defaultServer,
   errorServerHistory,
   errorServerInstance,
   loadingServer,
   serverWithDocumentation,
+  serverWithMultipleDocumentation,
 } from "./mockServer";
 import { setupServiceInstanceDetails } from "./mockSetup";
 
@@ -256,213 +261,382 @@ describe("ServiceInstanceDetailsPage", () => {
   // TODO: @LukasStordeur Implement test when config tab has usecases.
   //it("Should render a success view and with config section if present", async () => { });
 
-  it("Should render a success view with documentation", async () => {
+  describe("with documentation server", () => {
     const server = serverWithDocumentation;
 
-    server.listen();
-    const component = setupServiceInstanceDetails();
+    beforeAll(() => server.listen());
+    afterEach(() => server.resetHandlers());
+    afterAll(() => server.close());
 
-    render(component);
+    it("Should render a success view with documentation", async () => {
+      const component = setupServiceInstanceDetails();
 
-    expect(
-      await screen.findByRole("region", { name: "Instance-Details-Success" })
-    ).toBeInTheDocument();
+      render(component);
 
-    // active attribute set. By default, the latest version is selected, and shouldn't display a label.
-    expect(screen.queryByTestId("selected-version")).not.toBeInTheDocument();
+      expect(
+        await screen.findByRole("region", { name: "Instance-Details-Success" })
+      ).toBeInTheDocument();
 
-    // should display the right timestamp in the rows for each version
-    expect(screen.getByTestId("version-4-timestamp")).toHaveTextContent("2022/09/02 14:01:19");
-    expect(screen.getByTestId("version-3-timestamp")).toHaveTextContent("2022/09/02 13:56:16");
+      // active attribute set. By default, the latest version is selected, and shouldn't display a label.
+      expect(screen.queryByTestId("selected-version")).not.toBeInTheDocument();
 
-    expect(screen.getByText("Documentation")).toBeInTheDocument();
+      // should display the right timestamp in the rows for each version
+      expect(screen.getByTestId("version-4-timestamp")).toHaveTextContent("2022/09/02 14:01:19");
+      expect(screen.getByTestId("version-3-timestamp")).toHaveTextContent("2022/09/02 13:56:16");
 
-    expect(
-      screen.getByRole("heading", {
-        name: /Getting started/i,
-      })
-    ).toBeVisible();
+      expect(screen.getByText("Documentation")).toBeInTheDocument();
 
-    // candidate attribute set
-    // in this version, we should have documentation available
-    await userEvent.click(screen.getByRole("cell", { name: "3" }));
+      expect(
+        screen.getByRole("heading", {
+          name: /Getting started/i,
+        })
+      ).toBeVisible();
 
-    expect(screen.getByTestId("selected-version")).toHaveTextContent("Version: 3");
+      // candidate attribute set
+      // in this version, we should have documentation available
+      await userEvent.click(screen.getByRole("cell", { name: "3" }));
 
-    expect(
-      screen.getByRole("heading", {
-        name: /we are adding documentation/i,
-      })
-    ).toBeVisible();
+      expect(screen.getByTestId("selected-version")).toHaveTextContent("Version: 3");
 
-    // rollback attribute set
-    // in this version, topography documentation is an empty string, so fall back to message informing the user.
-    await userEvent.click(screen.getByRole("cell", { name: "2" }));
+      expect(
+        screen.getByRole("heading", {
+          name: /we are adding documentation/i,
+        })
+      ).toBeVisible();
 
-    expect(screen.getByTestId("selected-version")).toHaveTextContent("Version: 2");
+      // rollback attribute set
+      // in this version, topography documentation is an empty string, so fall back to message informing the user.
+      await userEvent.click(screen.getByRole("cell", { name: "2" }));
 
-    expect(
-      screen.getByText(/this version doesn’t contain documentation for topography yet\./i)
-    ).toBeVisible();
+      expect(screen.getByTestId("selected-version")).toHaveTextContent("Version: 2");
 
-    // in this version, topography attribute didn't exist yet in any attribute set, but is available in the ServiceModel.
-    await userEvent.click(screen.getByRole("cell", { name: "1" }));
+      expect(
+        screen.getByText(/this version doesn’t contain documentation for topography yet\./i)
+      ).toBeVisible();
 
-    expect(screen.getByTestId("selected-version")).toHaveTextContent("Version: 1");
+      // in this version, topography attribute didn't exist yet in any attribute set, but is available in the ServiceModel.
+      await userEvent.click(screen.getByRole("cell", { name: "1" }));
 
-    expect(
-      screen.getByText(/this version doesn’t contain documentation for topography yet\./i)
-    ).toBeVisible();
+      expect(screen.getByTestId("selected-version")).toHaveTextContent("Version: 1");
 
-    // Events
+      expect(
+        screen.getByText(/this version doesn’t contain documentation for topography yet\./i)
+      ).toBeVisible();
 
-    // Select the Events tab
-    await userEvent.click(screen.getByText("Events"));
+      // Events
 
-    // Should have a link to navigate to the full events page
-    const allEventsLink = screen.getByRole("link", {
-      name: /see all events/i,
-    });
+      // Select the Events tab
+      await userEvent.click(screen.getByText("Events"));
 
-    expect(allEventsLink).toBeVisible();
+      // Should have a link to navigate to the full events page
+      const allEventsLink = screen.getByRole("link", {
+        name: /see all events/i,
+      });
 
-    // Should have the right href attribute
-    expect(allEventsLink).toHaveAttribute(
-      "href",
-      "/lsm/catalog/mobileCore/inventory/1d96a1ab/events?env=c85c0a64-ed45-4cba-bdc5-703f65a225f7&state.InstanceDetails.version=1&state.InstanceDetails.tab=Events"
-    );
+      expect(allEventsLink).toBeVisible();
 
-    // In this version, expect only two rows with aria-label Event table row
-    expect(
-      screen.getAllByRole("row", {
+      // Should have the right href attribute
+      expect(allEventsLink).toHaveAttribute(
+        "href",
+        "/lsm/catalog/mobileCore/inventory/1d96a1ab/events?env=c85c0a64-ed45-4cba-bdc5-703f65a225f7&state.InstanceDetails.version=1&state.InstanceDetails.tab=Events"
+      );
+
+      // In this version, expect only two rows with aria-label Event table row
+      expect(
+        screen.getAllByRole("row", {
+          name: /Event\-table\-row/i,
+        })
+      ).toHaveLength(2);
+
+      // The source state should be empty since this is the very first version and thus only has a target-state.
+      expect(
+        screen.getByRole("cell", {
+          name: /event\-source\-0/i,
+        })
+      ).toBeEmptyDOMElement();
+      expect(
+        screen.getByRole("cell", {
+          name: /event\-source\-1/i,
+        })
+      ).toBeEmptyDOMElement();
+
+      // both should have the same target state "start"
+      expect(
+        screen.getByRole("cell", {
+          name: /event\-target\-0/i,
+        })
+      ).toHaveTextContent(/start/i);
+      expect(
+        screen.getByRole("cell", {
+          name: /event\-target\-1/i,
+        })
+      ).toHaveTextContent(/start/i);
+
+      // the timestamps should be up to three fractions seconds
+      expect(
+        screen.getByRole("cell", {
+          name: /event\-date\-0/i,
+        })
+      ).toHaveTextContent(/2022\/09\/02 13:56:856/i);
+      expect(
+        screen.getByRole("cell", {
+          name: /event\-date\-1/i,
+        })
+      ).toHaveTextContent(/2022\/09\/02 13:56:840/i);
+
+      // expect that there are no compile reports available for these rows
+      expect(
+        screen.getByRole("cell", {
+          name: /event\-compile\-0/i,
+        })
+      ).toBeEmptyDOMElement();
+      expect(
+        screen.getByRole("cell", {
+          name: /event\-compile\-1/i,
+        })
+      ).toBeEmptyDOMElement();
+
+      // Select the version 3rd in the history, this one should contain three rows, and have one with a warning color, one with a validation report, and one with an export report.
+      await userEvent.click(screen.getByRole("cell", { name: "3" }));
+
+      const rowsVersion3 = screen.getAllByRole("row", {
         name: /Event\-table\-row/i,
-      })
-    ).toHaveLength(2);
+      });
 
-    // The source state should be empty since this is the very first version and thus only has a target-state.
-    expect(
-      screen.getByRole("cell", {
-        name: /event\-source\-0/i,
-      })
-    ).toBeEmptyDOMElement();
-    expect(
-      screen.getByRole("cell", {
-        name: /event\-source\-1/i,
-      })
-    ).toBeEmptyDOMElement();
+      expect(rowsVersion3).toHaveLength(3);
 
-    // both should have the same target state "start"
-    expect(
-      screen.getByRole("cell", {
-        name: /event\-target\-0/i,
-      })
-    ).toHaveTextContent(/start/i);
-    expect(
-      screen.getByRole("cell", {
-        name: /event\-target\-1/i,
-      })
-    ).toHaveTextContent(/start/i);
+      expect(rowsVersion3[0]).toHaveStyle(
+        "background-color: var(--pf-t--global--color--status--warning--default)"
+      );
+      expect(rowsVersion3[1]).not.toHaveStyle("background-color: inherit");
+      expect(rowsVersion3[2]).not.toHaveStyle("background-color: inherit");
 
-    // the timestamps should be up to three fractions seconds
-    expect(
-      screen.getByRole("cell", {
-        name: /event\-date\-0/i,
-      })
-    ).toHaveTextContent(/2022\/09\/02 13:56:856/i);
-    expect(
-      screen.getByRole("cell", {
-        name: /event\-date\-1/i,
-      })
-    ).toHaveTextContent(/2022\/09\/02 13:56:840/i);
+      expect(
+        screen.getByRole("cell", {
+          name: /event\-compile\-0/i,
+        })
+      ).toHaveTextContent(/validation/i);
+      expect(
+        screen.getByRole("cell", {
+          name: /event\-compile\-1/i,
+        })
+      ).toHaveTextContent(/export/i);
+      expect(
+        screen.getByRole("cell", {
+          name: /event\-compile\-2/i,
+        })
+      ).toBeEmptyDOMElement();
 
-    // expect that there are no compile reports available for these rows
-    expect(
-      screen.getByRole("cell", {
-        name: /event\-compile\-0/i,
-      })
-    ).toBeEmptyDOMElement();
-    expect(
-      screen.getByRole("cell", {
-        name: /event\-compile\-1/i,
-      })
-    ).toBeEmptyDOMElement();
+      expect(
+        screen.getByRole("cell", {
+          name: /event\-target\-0/i,
+        })
+      ).toHaveTextContent(/creating/i);
+      expect(
+        screen.getByRole("cell", {
+          name: /event\-source\-0/i,
+        })
+      ).toHaveTextContent(/acknowledged/i);
 
-    // Select the version 3rd in the history, this one should contain three rows, and have one with a warning color, one with a validation report, and one with an export report.
-    await userEvent.click(screen.getByRole("cell", { name: "3" }));
+      // Resources Tab
 
-    const rowsVersion3 = screen.getAllByRole("row", {
-      name: /Event\-table\-row/i,
-    });
+      // Make sure the version is set to latest
+      await userEvent.click(screen.getAllByLabelText("History-Row")[0]);
 
-    expect(rowsVersion3).toHaveLength(3);
+      // Select the Resources tab
+      await userEvent.click(screen.getByText("Resources"));
 
-    expect(rowsVersion3[0]).toHaveStyle(
-      "background-color: var(--pf-t--global--color--status--warning--default)"
-    );
-    expect(rowsVersion3[1]).not.toHaveStyle("background-color: inherit");
-    expect(rowsVersion3[2]).not.toHaveStyle("background-color: inherit");
+      expect(screen.getByText("Deployment Progress")).toBeVisible();
+      expect(screen.getByText("1 / 1")).toBeVisible();
+      expect(screen.getByLabelText("LegendItem-deployed")).toHaveTextContent("1");
 
-    expect(
-      screen.getByRole("cell", {
-        name: /event\-compile\-0/i,
-      })
-    ).toHaveTextContent(/validation/i);
-    expect(
-      screen.getByRole("cell", {
-        name: /event\-compile\-1/i,
-      })
-    ).toHaveTextContent(/export/i);
-    expect(
-      screen.getByRole("cell", {
-        name: /event\-compile\-2/i,
-      })
-    ).toBeEmptyDOMElement();
+      expect(screen.getByText("Resource")).toBeVisible();
+      expect(screen.getByText("State")).toBeVisible();
 
-    expect(
-      screen.getByRole("cell", {
-        name: /event\-target\-0/i,
-      })
-    ).toHaveTextContent(/creating/i);
-    expect(
-      screen.getByRole("cell", {
-        name: /event\-source\-0/i,
-      })
-    ).toHaveTextContent(/acknowledged/i);
+      expect(screen.getByTestId("Status-deployed")).toBeVisible();
 
-    // Resources Tab
+      expect(screen.getByText("hello[world,v=42]")).toBeVisible();
 
-    // Make sure the version is set to latest
-    await userEvent.click(screen.getAllByLabelText("History-Row")[0]);
+      // Change Version to older
+      await userEvent.click(screen.getAllByLabelText("History-Row")[1]);
 
-    // Select the Resources tab
-    await userEvent.click(screen.getByText("Resources"));
+      expect(screen.queryByText("Latest Version")).toBeNull();
+      expect(screen.getByRole("tab", { name: "resources-content" })).toBeDisabled();
 
-    expect(screen.getByText("Deployment Progress")).toBeVisible();
-    expect(screen.getByText("1 / 1")).toBeVisible();
-    expect(screen.getByLabelText("LegendItem-deployed")).toHaveTextContent("1");
+      expect(screen.getByTestId("Status-deployed")).not.toBeVisible();
 
-    expect(screen.getByText("Resource")).toBeVisible();
-    expect(screen.getByText("State")).toBeVisible();
+      expect(screen.getByText("hello[world,v=42]")).not.toBeVisible();
 
-    expect(screen.getByTestId("Status-deployed")).toBeVisible();
+      // Change Version to latest
+      await userEvent.click(screen.getAllByLabelText("History-Row")[0]);
 
-    expect(screen.getByText("hello[world,v=42]")).toBeVisible();
+      expect(screen.getByRole("tab", { name: "resources-content" })).toBeEnabled();
+    }, 25000);
 
-    // Change Version to older
-    await userEvent.click(screen.getAllByLabelText("History-Row")[1]);
+    it("Should hide the Markdown Previewer button on older versions when expert mode is enabled", async () => {
+      const component = setupServiceInstanceDetails(true);
 
-    expect(screen.queryByText("Latest Version")).toBeNull();
-    expect(screen.getByRole("tab", { name: "resources-content" })).toBeDisabled();
+      render(component);
 
-    expect(screen.getByTestId("Status-deployed")).not.toBeVisible();
+      expect(
+        await screen.findByRole("region", { name: "Instance-Details-Success" })
+      ).toBeInTheDocument();
 
-    expect(screen.getByText("hello[world,v=42]")).not.toBeVisible();
+      // On the latest version, the preview button should be visible in expert mode
+      expect(screen.getByRole("button", { name: "preview-button" })).toBeVisible();
 
-    // Change Version to latest
-    await userEvent.click(screen.getAllByLabelText("History-Row")[0]);
+      // Switch to an older version
+      await userEvent.click(screen.getByRole("cell", { name: "3" }));
 
-    expect(screen.getByRole("tab", { name: "resources-content" })).toBeEnabled();
+      expect(screen.getByTestId("selected-version")).toHaveTextContent("Version: 3");
 
-    server.close();
-  }, 20000);
+      // The preview button should be hidden on older versions
+      expect(screen.queryByRole("button", { name: "preview-button" })).not.toBeInTheDocument();
+
+      // Switch back to the latest version
+      await userEvent.click(screen.getByRole("cell", { name: "4" }));
+
+      expect(screen.queryByTestId("selected-version")).not.toBeInTheDocument();
+
+      // The preview button should be visible again on the latest version
+      expect(screen.getByRole("button", { name: "preview-button" })).toBeVisible();
+    }, 15000);
+  });
+
+  describe("with multiple documentation sections server", () => {
+    const server = serverWithMultipleDocumentation;
+
+    beforeAll(() => server.listen());
+    afterEach(() => server.resetHandlers());
+    afterAll(() => server.close());
+
+    it("Should render documentation sections in web_order sort order with the default-open section expanded", async () => {
+      const component = setupServiceInstanceDetails();
+
+      render(component);
+
+      await screen.findByRole("region", { name: "Instance-Details-Success" });
+
+      expect(screen.getByText("Documentation")).toBeInTheDocument();
+
+      const architectureToggle = screen.getByRole("button", { name: /Architecture/i });
+      const topographyToggle = screen.getByRole("button", { name: /Topography/i });
+      const readmeToggle = screen.getByRole("button", { name: /Readme/i });
+
+      // Verify sort order: Architecture (1) → Topography (2) → Readme (-1 → last)
+      const allButtons = screen.getAllByRole("button");
+      const archIdx = allButtons.indexOf(architectureToggle);
+      const topoIdx = allButtons.indexOf(topographyToggle);
+      const readmeIdx = allButtons.indexOf(readmeToggle);
+
+      expect(archIdx).toBeLessThan(topoIdx);
+      expect(topoIdx).toBeLessThan(readmeIdx);
+
+      // Architecture has web_default_open: true → expanded by default
+      expect(architectureToggle).toHaveAttribute("aria-expanded", "true");
+      // Topography and Readme start collapsed
+      expect(topographyToggle).toHaveAttribute("aria-expanded", "false");
+      expect(readmeToggle).toHaveAttribute("aria-expanded", "false");
+    }, 15000);
+
+    it("Should allow multiple documentation sections to be open simultaneously", async () => {
+      const component = setupServiceInstanceDetails();
+
+      render(component);
+
+      await screen.findByRole("region", { name: "Instance-Details-Success" });
+
+      const architectureToggle = screen.getByRole("button", { name: /Architecture/i });
+      const topographyToggle = screen.getByRole("button", { name: /Topography/i });
+      const readmeToggle = screen.getByRole("button", { name: /Readme/i });
+
+      // Architecture is open by default; others are closed
+      expect(architectureToggle).toHaveAttribute("aria-expanded", "true");
+      expect(topographyToggle).toHaveAttribute("aria-expanded", "false");
+
+      // Open Topography
+      await userEvent.click(topographyToggle);
+
+      // Both Architecture AND Topography must now be open — multi-expand
+      expect(architectureToggle).toHaveAttribute("aria-expanded", "true");
+      expect(topographyToggle).toHaveAttribute("aria-expanded", "true");
+      expect(readmeToggle).toHaveAttribute("aria-expanded", "false");
+    }, 15000);
+
+    it("Should collapse a documentation section when its open toggle is clicked again", async () => {
+      const component = setupServiceInstanceDetails();
+
+      render(component);
+
+      await screen.findByRole("region", { name: "Instance-Details-Success" });
+
+      const architectureToggle = screen.getByRole("button", { name: /Architecture/i });
+
+      // Architecture is open by default
+      expect(architectureToggle).toHaveAttribute("aria-expanded", "true");
+
+      // Clicking it again should collapse it
+      await userEvent.click(architectureToggle);
+
+      expect(architectureToggle).toHaveAttribute("aria-expanded", "false");
+    }, 15000);
+  });
+});
+
+describe("sortDocAttributeDescriptors", () => {
+  const makeDescriptor = (title: string, webOrder?: number): DocAttributeDescriptors => ({
+    title,
+    iconName: "FaBook",
+    attributeName: title.toLowerCase(),
+    webOrder,
+  });
+
+  it("should sort items by webOrder ascending", () => {
+    const input = [makeDescriptor("C", 3), makeDescriptor("A", 1), makeDescriptor("B", 2)];
+    const result = sortDocAttributeDescriptors(input);
+
+    expect(result.map((d) => d.title)).toEqual(["A", "B", "C"]);
+  });
+
+  it("should place items with webOrder === -1 after explicitly ordered items", () => {
+    const input = [makeDescriptor("Unordered", -1), makeDescriptor("First", 1)];
+    const result = sortDocAttributeDescriptors(input);
+
+    expect(result[0].title).toBe("First");
+    expect(result[1].title).toBe("Unordered");
+  });
+
+  it("should place items without webOrder after explicitly ordered items", () => {
+    const input = [
+      makeDescriptor("NoOrder"),
+      makeDescriptor("Second", 2),
+      makeDescriptor("First", 1),
+    ];
+    const result = sortDocAttributeDescriptors(input);
+
+    expect(result.map((d) => d.title)).toEqual(["First", "Second", "NoOrder"]);
+  });
+
+  it("should preserve the relative order of multiple unordered items", () => {
+    const input = [makeDescriptor("X"), makeDescriptor("Y"), makeDescriptor("A", 1)];
+    const result = sortDocAttributeDescriptors(input);
+
+    expect(result.map((d) => d.title)).toEqual(["A", "X", "Y"]);
+  });
+
+  it("should return original order when all items lack webOrder", () => {
+    const input = [makeDescriptor("X"), makeDescriptor("Y"), makeDescriptor("Z")];
+    const result = sortDocAttributeDescriptors(input);
+
+    expect(result.map((d) => d.title)).toEqual(["X", "Y", "Z"]);
+  });
+
+  it("should not mutate the input array", () => {
+    const input = [makeDescriptor("B", 2), makeDescriptor("A", 1)];
+    const snapshot = input.map((d) => d.title);
+
+    sortDocAttributeDescriptors(input);
+
+    expect(input.map((d) => d.title)).toEqual(snapshot);
+  });
 });

--- a/src/Slices/ServiceInstanceDetails/Test/mockData.ts
+++ b/src/Slices/ServiceInstanceDetails/Test/mockData.ts
@@ -1654,6 +1654,148 @@ export const logsWithDocumentationResponse = {
   },
 };
 
+// --- Multi-documentation fixtures ---
+// Three documentation sections with web_order and web_default_open set, to cover
+// sorting, default-open, and multi-expand behaviour.
+//
+// Declaration order:  topography (order 2) → architecture (order 1) → readme (order -1)
+// Expected sort order: architecture (1) → topography (2) → readme (-1 → last)
+
+export const instanceDataWithMultipleDocumentation: ServiceInstanceModel = {
+  ...instanceData,
+  version: 2,
+  candidate_attributes: {
+    topography: "# Topography\n\nTopography content.",
+    architecture: "# Architecture\n\nArchitecture content.",
+    readme: "# Readme\n\nReadme content.",
+  },
+};
+
+export const serviceModelWithMultipleDocumentation: ServiceModel = {
+  ...serviceModel,
+  attributes: [
+    // declared first, web_order: 2 → renders second after sort
+    {
+      name: "topography",
+      description: "Topography of this instance",
+      modifier: "r",
+      attribute_annotations: {
+        web_icon: "FaBook",
+        web_content_type: "text/markdown",
+        web_title: "Topography",
+        web_presentation: "documentation",
+        web_order: 2,
+      },
+      type: "string",
+      default_value: "# Topography\n\nTopography content.",
+      default_value_set: true,
+      validation_type: null,
+      validation_parameters: null,
+    },
+    // declared second, web_order: 1, web_default_open: true → renders first, expanded by default
+    {
+      name: "architecture",
+      description: "Architecture of this instance",
+      modifier: "r",
+      attribute_annotations: {
+        web_icon: "FaNetworkWired",
+        web_content_type: "text/markdown",
+        web_title: "Architecture",
+        web_presentation: "documentation",
+        web_order: 1,
+        web_default_open: true,
+      },
+      type: "string",
+      default_value: "# Architecture\n\nArchitecture content.",
+      default_value_set: true,
+      validation_type: null,
+      validation_parameters: null,
+    },
+    // web_order: -1 → treated as unordered, sorts to end
+    {
+      name: "readme",
+      description: "Readme for this instance",
+      modifier: "r",
+      attribute_annotations: {
+        web_icon: "FaFileAlt",
+        web_content_type: "text/markdown",
+        web_title: "Readme",
+        web_presentation: "documentation",
+        web_order: -1,
+      },
+      type: "string",
+      default_value: "# Readme\n\nReadme content.",
+      default_value_set: true,
+      validation_type: null,
+      validation_parameters: null,
+    },
+  ],
+};
+
+const historyDataWithMultipleDocumentation: InstanceLog[] = [
+  {
+    service_instance_id: "1d96a1ab",
+    environment: "5bfe1994-365f-49ec-bff1-fed77bbbf8e6",
+    service_entity: "mobileCore",
+    service_entity_version: 0,
+    version: 2,
+    desired_state_version: 2,
+    timestamp: "2022-09-02T12:01:19.626854+00:00",
+    config: {},
+    state: "up",
+    candidate_attributes: {
+      topography: "# Topography\n\nTopography content.",
+      architecture: "# Architecture\n\nArchitecture content.",
+      readme: "# Readme\n\nReadme content.",
+    },
+    active_attributes: null,
+    rollback_attributes: null,
+    created_at: "2022-09-02T11:56:06.852941+00:00",
+    last_updated: "2022-09-02T12:01:19.626854+00:00",
+    callback: [],
+    deleted: false,
+    events: [],
+    service_identity_attribute_value: "core1",
+    transfer_context: "auto",
+  },
+  {
+    service_instance_id: "1d96a1ab",
+    environment: "5bfe1994-365f-49ec-bff1-fed77bbbf8e6",
+    service_entity: "mobileCore",
+    service_entity_version: 0,
+    version: 1,
+    desired_state_version: 1,
+    timestamp: "2022-09-02T11:56:06.852941+00:00",
+    config: {},
+    state: "start",
+    candidate_attributes: {
+      topography: "# Old topography.",
+    },
+    active_attributes: null,
+    rollback_attributes: null,
+    created_at: "2022-09-02T11:56:06.852941+00:00",
+    last_updated: "2022-09-02T11:56:06.852941+00:00",
+    callback: [],
+    deleted: false,
+    events: [],
+    service_identity_attribute_value: "core1",
+    transfer_context: "auto",
+  },
+];
+
+export const logsWithMultipleDocumentationResponse = {
+  data: historyDataWithMultipleDocumentation,
+  links: {
+    self: "/lsm/v1/service_inventory/mobileCore/1d96a1ab/log?limit=50&sort=version.desc",
+  },
+  metadata: {
+    total: 2,
+    before: 0,
+    after: 0,
+    page_size: 50,
+  },
+};
+
 export const JSONSchema = {
   data: {
     $defs: {

--- a/src/Slices/ServiceInstanceDetails/Test/mockServer.ts
+++ b/src/Slices/ServiceInstanceDetails/Test/mockServer.ts
@@ -4,11 +4,14 @@ import {
   logsResponse,
   instanceData,
   instanceDataWithDocumentation,
+  instanceDataWithMultipleDocumentation,
   JSONSchema,
   serviceModel,
   serviceModelWithConfig,
   serviceModelWithDocumentation,
+  serviceModelWithMultipleDocumentation,
   logsWithDocumentationResponse,
+  logsWithMultipleDocumentationResponse,
 } from "./mockData";
 
 const getServiceModel = http.get("/lsm/v1/service_catalog/mobileCore", () => {
@@ -263,6 +266,43 @@ export const serverWithDocumentation = setupServer(
   getServiceModelWithDocumentation,
   getHistoryLogsWithDocumentation,
   getInstanceDataWithDocumentation,
+  getResources
+);
+
+const getServiceModelWithMultipleDocumentation = http.get(
+  "/lsm/v1/service_catalog/mobileCore",
+  async () => {
+    return HttpResponse.json({
+      data: serviceModelWithMultipleDocumentation,
+    });
+  }
+);
+
+const getInstanceDataWithMultipleDocumentation = http.get(
+  "/lsm/v1/service_inventory/mobileCore/1d96a1ab",
+  async () => {
+    return HttpResponse.json({
+      data: instanceDataWithMultipleDocumentation,
+    });
+  }
+);
+
+const getHistoryLogsWithMultipleDocumentation = http.get(
+  "/lsm/v1/service_inventory/mobileCore/1d96a1ab/log",
+  async () => {
+    return HttpResponse.json(logsWithMultipleDocumentationResponse);
+  }
+);
+
+/**
+ * Setup a test server with multiple documentation sections that carry
+ * web_order and web_default_open annotations, used to test sorting,
+ * default-open, and multi-expand behaviour.
+ */
+export const serverWithMultipleDocumentation = setupServer(
+  getServiceModelWithMultipleDocumentation,
+  getHistoryLogsWithMultipleDocumentation,
+  getInstanceDataWithMultipleDocumentation,
   getResources
 );
 

--- a/src/Slices/ServiceInstanceDetails/UI/Tabs/DocumentationTabContent.tsx
+++ b/src/Slices/ServiceInstanceDetails/UI/Tabs/DocumentationTabContent.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from "react";
+import React, { useContext, useMemo, useState } from "react";
 import {
   Accordion,
   AccordionContent,
@@ -24,6 +24,8 @@ export interface DocAttributeDescriptors {
   title: string;
   iconName: string;
   attributeName: string;
+  webOrder?: number;
+  webDefaultOpen?: boolean;
 }
 
 // Interface representing the attributes needed for the markdownCards
@@ -53,11 +55,47 @@ export const DocumentationTabContent: React.FC<Props> = ({
 }) => {
   const { logsQuery, instance } = useContext(InstanceDetailsContext);
   const { environmentHandler } = useContext(DependencyContext);
-  const [expanded, setExpanded] = useState(0);
+  const [expandedSet, setExpandedSet] = useState<Set<number>>(() => {
+    const sorted = sortDocAttributeDescriptors(docAttributeDescriptors);
+    const initial = new Set<number>();
+
+    sorted.forEach((d, i) => {
+      if (d.webDefaultOpen) {
+        initial.add(i);
+      }
+    });
+
+    // Fall back to opening the first item when none are marked as default open
+    if (initial.size === 0 && sorted.length > 1) {
+      initial.add(0);
+    }
+
+    return initial;
+  });
   const navigateTo = useNavigateTo();
 
   const isLatest = selectedVersion === String(instance.version);
-  let selectedSet: InstanceAttributeModel | void;
+
+  const selectedSet = useMemo(() => {
+    if (!isLatest) {
+      if (logsQuery.isLoading || !logsQuery.data) {
+        return undefined;
+      }
+      return getSelectedAttributeSet(logsQuery.data, selectedVersion);
+    } else {
+      return getSelectedAttributeSetFromInstance(instance);
+    }
+  }, [isLatest, logsQuery.data, logsQuery.isLoading, selectedVersion, instance]);
+
+  const sortedDescriptors = useMemo(
+    () => sortDocAttributeDescriptors(docAttributeDescriptors),
+    [docAttributeDescriptors]
+  );
+
+  const sections = useMemo(
+    () => (selectedSet ? getDocumentationSections(sortedDescriptors, selectedSet) : []),
+    [sortedDescriptors, selectedSet]
+  );
 
   if (!isLatest) {
     if (logsQuery.isLoading) {
@@ -75,26 +113,24 @@ export const DocumentationTabContent: React.FC<Props> = ({
         </TabContentWrapper>
       );
     }
-
-    selectedSet = getSelectedAttributeSet(logsQuery.data, selectedVersion);
-  } else {
-    selectedSet = getSelectedAttributeSetFromInstance(instance);
   }
 
-  const sections = selectedSet
-    ? getDocumentationSections(docAttributeDescriptors, selectedSet)
-    : [];
-
   const onToggle = (index: number) => {
-    if (index === expanded) {
-      setExpanded(-1);
-    } else {
-      setExpanded(index);
-    }
+    setExpandedSet((prev) => {
+      const next = new Set(prev);
+
+      if (next.has(index)) {
+        next.delete(index);
+      } else {
+        next.add(index);
+      }
+
+      return next;
+    });
   };
 
   const MarkdownPreviewerButton = () => {
-    if (!environmentHandler.useIsExpertModeEnabled()) {
+    if (!isLatest || !environmentHandler.useIsExpertModeEnabled()) {
       return null;
     }
 
@@ -137,7 +173,7 @@ export const DocumentationTabContent: React.FC<Props> = ({
       <MarkdownPreviewerButton />
       <Accordion asDefinitionList togglePosition="start">
         {sections.map((section, index) => (
-          <AccordionItem isExpanded={expanded === index} key={section.title}>
+          <AccordionItem isExpanded={expandedSet.has(index)} key={section.title}>
             <AccordionToggle
               onClick={() => {
                 onToggle(index);
@@ -150,7 +186,7 @@ export const DocumentationTabContent: React.FC<Props> = ({
               <MarkdownCard
                 attributeValue={section.value}
                 web_title={section.title}
-                isExpanded={expanded === index}
+                isExpanded={expandedSet.has(index)}
               />
             </AccordionContent>
           </AccordionItem>
@@ -161,6 +197,29 @@ export const DocumentationTabContent: React.FC<Props> = ({
       </Accordion>
     </TabContentWrapper>
   );
+};
+
+/**
+ * Sorts documentation attribute descriptors by webOrder ascending.
+ * Descriptors without webOrder or with webOrder === -1 are placed after all
+ * explicitly ordered items, preserving their original relative order.
+ */
+export const sortDocAttributeDescriptors = (
+  descriptors: DocAttributeDescriptors[]
+): DocAttributeDescriptors[] => {
+  return descriptors.slice().sort((a, b) => {
+    const aOrdered = a.webOrder !== undefined && a.webOrder !== -1;
+    const bOrdered = b.webOrder !== undefined && b.webOrder !== -1;
+
+    if (aOrdered && bOrdered) {
+      return (a.webOrder as number) - (b.webOrder as number);
+    } else if (aOrdered) {
+      return -1;
+    } else if (bOrdered) {
+      return 1;
+    }
+    return 0;
+  });
 };
 
 /**

--- a/src/Slices/ServiceInstanceDetails/UI/Tabs/TabView.tsx
+++ b/src/Slices/ServiceInstanceDetails/UI/Tabs/TabView.tsx
@@ -152,6 +152,8 @@ const getDocumentationAttributeDescriptors = (
           title: attribute.attribute_annotations.web_title,
           iconName: attribute.attribute_annotations.web_icon || "FaBook",
           attributeName: attribute.name,
+          webOrder: attribute.attribute_annotations.web_order,
+          webDefaultOpen: attribute.attribute_annotations.web_default_open,
         });
       }
     }


### PR DESCRIPTION
> ISO 8 PR

# Summary


Add two optional annotation properties to Service Instance Details documentation tab collapsibles:

| Property | Type | Behaviour |
|---|---|---|
| `web_order` | `number` (optional) | Sort collapsibles ascending. `-1` or absent → keep declaration order. |
| `web_default_open` | `boolean` (optional) | When `true`, the collapsible is expanded on first render. Absent/`false` → collapsed. If no default item found, expand first one by default. |

Additionally, allow **multiple collapsibles to be open simultaneously** (currently only one at a time is allowed).

closes: 
- #6883