### PR TITLE
Bugfix - React Diffviewer breaking app

### DIFF
--- a/changelogs/unreleased/bugfix-diffviewer.yml
+++ b/changelogs/unreleased/bugfix-diffviewer.yml
@@ -1,0 +1,5 @@
+description: |
+  Fixed an issue where the DiffViewer component was not rendering due to an import error caused by a CJS interop bug in Vite 8 / Rollup. 
+  Updated the import statement to handle both default and named exports correctly, ensuring that the DiffViewer component renders as expected.
+change-type: patch
+destination-branches: [master, iso9]

--- a/src/UI/Components/DiffWizard/ItemList/Entry/DiffView.tsx
+++ b/src/UI/Components/DiffWizard/ItemList/Entry/DiffView.tsx
@@ -1,25 +1,40 @@
 import React from "react";
-import ReactDiffViewer, { DiffMethod } from "react-diff-viewer-continued";
+import _ReactDiffViewer, { DiffMethod } from "react-diff-viewer-continued";
 import { Diff } from "@/Core";
 
-export const DiffView: React.FC<Diff.Values> = ({ from, to }) => (
-  <ReactDiffViewer
-    showDiffOnly={false}
-    styles={{
-      marker: { display: "none" },
-      wordDiff: { padding: 0 },
-      contentText: { lineHeight: "29px !important" },
-      line: { display: "flex" },
-      content: {
-        overflowWrap: "anywhere",
-        padding: "0 4px",
-      },
-    }}
-    compareMethod={isMultiLine(from) || isMultiLine(to) ? DiffMethod.WORDS : DiffMethod.CHARS}
-    oldValue={from}
-    newValue={to}
-    hideLineNumbers={true}
-  />
-);
+// react-diff-viewer-continued is a CJS-only package (no ESM entry). Vite 8 /
+// rolldown pre-bundles it as `export default require_src()`, where require_src()
+// returns the raw CJS exports object: { __esModule: true, default: DiffViewer, … }.
+// Vite marks the package needsInterop: true and is supposed to rewrite the
+// default import to extract .default, but that rewrite is not applied when
+// CDN-intercept plugins alter the module processing pipeline. The result is that
+// _ReactDiffViewer receives the exports namespace instead of the class, and React
+// throws "Element type is invalid" when it tries to render it.
+// Named imports (DiffMethod) are resolved separately and are unaffected.
+const ReactDiffViewer = (
+  typeof _ReactDiffViewer === "function" ? _ReactDiffViewer : (_ReactDiffViewer as any).default
+) as typeof _ReactDiffViewer;
+
+export const DiffView: React.FC<Diff.Values> = ({ from, to }) => {
+  return (
+    <ReactDiffViewer
+      showDiffOnly={false}
+      styles={{
+        marker: { display: "none" },
+        wordDiff: { padding: 0 },
+        contentText: { lineHeight: "29px !important" },
+        line: { display: "flex" },
+        content: {
+          overflowWrap: "anywhere",
+          padding: "0 4px",
+        },
+      }}
+      compareMethod={isMultiLine(from) || isMultiLine(to) ? DiffMethod.WORDS : DiffMethod.CHARS}
+      oldValue={from}
+      newValue={to}
+      hideLineNumbers={true}
+    />
+  );
+};
 
 const isMultiLine = (value: string): boolean => value.indexOf("\n") >= 0;

--- a/src/UI/Components/DiffWizard/ItemList/Entry/DiffView.tsx
+++ b/src/UI/Components/DiffWizard/ItemList/Entry/DiffView.tsx
@@ -11,10 +11,10 @@ import { Diff } from "@/Core";
 // _ReactDiffViewer receives the exports namespace instead of the class, and React
 // throws "Element type is invalid" when it tries to render it.
 // Named imports (DiffMethod) are resolved separately and are unaffected.
-const ReactDiffViewer = (
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  typeof _ReactDiffViewer === "function" ? _ReactDiffViewer : (_ReactDiffViewer as any).default
-) as typeof _ReactDiffViewer;
+const ReactDiffViewer = // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (
+    typeof _ReactDiffViewer === "function" ? _ReactDiffViewer : (_ReactDiffViewer as any).default
+  ) as typeof _ReactDiffViewer;
 
 export const DiffView: React.FC<Diff.Values> = ({ from, to }) => {
   return (

--- a/src/UI/Components/DiffWizard/ItemList/Entry/DiffView.tsx
+++ b/src/UI/Components/DiffWizard/ItemList/Entry/DiffView.tsx
@@ -11,10 +11,11 @@ import { Diff } from "@/Core";
 // _ReactDiffViewer receives the exports namespace instead of the class, and React
 // throws "Element type is invalid" when it tries to render it.
 // Named imports (DiffMethod) are resolved separately and are unaffected.
-const ReactDiffViewer = // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (
-    typeof _ReactDiffViewer === "function" ? _ReactDiffViewer : (_ReactDiffViewer as any).default
-  ) as typeof _ReactDiffViewer;
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const ReactDiffViewer = (
+  typeof _ReactDiffViewer === "function" ? _ReactDiffViewer : (_ReactDiffViewer as any).default
+) as typeof _ReactDiffViewer;
+/* eslint-enable @typescript-eslint/no-explicit-any */
 
 export const DiffView: React.FC<Diff.Values> = ({ from, to }) => {
   return (

--- a/src/UI/Components/DiffWizard/ItemList/Entry/DiffView.tsx
+++ b/src/UI/Components/DiffWizard/ItemList/Entry/DiffView.tsx
@@ -11,8 +11,8 @@ import { Diff } from "@/Core";
 // _ReactDiffViewer receives the exports namespace instead of the class, and React
 // throws "Element type is invalid" when it tries to render it.
 // Named imports (DiffMethod) are resolved separately and are unaffected.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const ReactDiffViewer = (
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   typeof _ReactDiffViewer === "function" ? _ReactDiffViewer : (_ReactDiffViewer as any).default
 ) as typeof _ReactDiffViewer;
 

--- a/src/UI/Components/DiffWizard/ItemList/Entry/DiffView.tsx
+++ b/src/UI/Components/DiffWizard/ItemList/Entry/DiffView.tsx
@@ -11,6 +11,7 @@ import { Diff } from "@/Core";
 // _ReactDiffViewer receives the exports namespace instead of the class, and React
 // throws "Element type is invalid" when it tries to render it.
 // Named imports (DiffMethod) are resolved separately and are unaffected.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const ReactDiffViewer = (
   typeof _ReactDiffViewer === "function" ? _ReactDiffViewer : (_ReactDiffViewer as any).default
 ) as typeof _ReactDiffViewer;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -444,6 +444,7 @@ export default defineConfig({
       "@patternfly/react-styles",
       "nullthrows",
       "picomatch-browser",
+      "react-diff-viewer-continued",
     ],
     exclude: ["@joint/core", "monaco-graphql"],
     force: true,


### PR DESCRIPTION
# Description

Fix `DiffView` crash ("Element type is invalid") caused by a Vite 8 / rolldown
  CJS interop bug: when CDN-intercept plugins alter the module processing pipeline,
  `react-diff-viewer-continued`'s default import receives the raw CJS exports
  namespace instead of the component class. Added a runtime type-guard that
  extracts `.default` when needed.

https://github.com/user-attachments/assets/7274f8b4-e373-4c69-bc28-e09fa49cd645



