### PR TITLE
Replace PATCH v2 with PUT for edit instance (#6903)

### DIFF
--- a/changelogs/unreleased/6903-put-edit-instance.yml
+++ b/changelogs/unreleased/6903-put-edit-instance.yml
@@ -1,4 +1,4 @@
-description: Edit instance now uses PUT /api/v1/service_inventory with ignore_read_only_attributes instead of PATCH v2 for services with strict modifier enforcement.
+description: Edit instance now uses PUT /lsm/v1/service_inventory with ignore_read_only_attributes instead of PATCH v2 for services with strict modifier enforcement.
 issue-nr: 6903
 change-type: patch
 destination-branches: [master, iso9]

--- a/changelogs/unreleased/6903-put-edit-instance.yml
+++ b/changelogs/unreleased/6903-put-edit-instance.yml
@@ -1,0 +1,4 @@
+description: Edit instance now uses PUT /api/v1/service_inventory with ignore_read_only_attributes instead of PATCH v2 for services with strict modifier enforcement.
+issue-nr: 6903
+change-type: minor
+destination-branches: [master, iso9]

--- a/changelogs/unreleased/6903-put-edit-instance.yml
+++ b/changelogs/unreleased/6903-put-edit-instance.yml
@@ -1,4 +1,4 @@
 description: Edit instance now uses PUT /api/v1/service_inventory with ignore_read_only_attributes instead of PATCH v2 for services with strict modifier enforcement.
 issue-nr: 6903
-change-type: minor
+change-type: patch
 destination-branches: [master, iso9]

--- a/src/Data/Queries/Helpers/useQueries.ts
+++ b/src/Data/Queries/Helpers/useQueries.ts
@@ -237,6 +237,47 @@ export const usePostWithoutEnv = (options?: { message?: string }) => {
 /**
  * Custom hook to create a PUT request function.
  *
+ * @param {string} env - The environment Id to be used in the request headers.
+ * @param {Object} [options] - Optional configuration for the PUT request.
+ * @param {string} [options.message] - Optional message to include in the request headers.
+ *
+ * @returns {Function(path: string, body: Body): Promise<Response>} - A function that performs a PUT request.
+ *
+ * @template Body - The type of the request body.
+ */
+export const usePut = (env: string, options?: { message?: string }) => {
+  const baseUrlManager = new PrimaryBaseUrlManager(
+    globalThis.location.origin,
+    globalThis.location.pathname
+  );
+  const baseUrl = baseUrlManager.getBaseUrl();
+  const { createHeaders, handleErrors } = useFetchHelpers();
+  const headers = createHeaders({ env, message: options?.message });
+
+  return async <Body>(path: string, body: Body) => {
+    try {
+      const response = await fetch(`${baseUrl}${path}`, {
+        method: "PUT",
+        headers,
+        body: JSON.stringify(body),
+      });
+
+      await handleErrors(response);
+
+      const text = await response.text();
+
+      if (text) {
+        return JSON.parse(text);
+      }
+    } catch (error) {
+      throw error;
+    }
+  };
+};
+
+/**
+ * Custom hook to create a PUT request function.
+ *
  * @param {Object} [options] - Optional configuration for the PUT request.
  * @param {string} [options.message] - Optional message to include in the request headers.
  *

--- a/src/Data/Queries/Slices/ServiceInstance/PatchAttributes/helpers.test.ts
+++ b/src/Data/Queries/Slices/ServiceInstance/PatchAttributes/helpers.test.ts
@@ -1,5 +1,5 @@
 import { Field } from "@/Test";
-import { getBodyV1, getBodyV2 } from "./helpers";
+import { getBodyV1 } from "./helpers";
 
 const currentAttributes = { attr1: "some value", attr2: "", attr3: null };
 
@@ -42,36 +42,4 @@ test("GIVEN getBodyV1 WHEN changing optional attributes THEN generates correct b
   expect(body.attributes.attr2).toBeNull();
   expect(body.attributes.attr3).toBeTruthy();
   expect(body.attributes.attr4).toEqual(42);
-});
-
-//TODO make PATCH V2 ready
-test("GIVEN getBodyV2 WHEN changing optional attributes THEN generates correct body", () => {
-  const service_entity = "test-entity";
-  const service_version = 4;
-
-  const fields = [
-    { ...Field.text, name: "attr1", isOptional: false, type: "string" },
-    { ...Field.text, name: "attr2", isOptional: true, type: "string?" },
-    { ...Field.bool, name: "attr3", isOptional: true, type: "bool?" },
-    { ...Field.number, name: "attr4", isOptional: true, type: "int?" },
-  ];
-
-  const attributes = {
-    attr1: "some value",
-    attr3: true,
-    attr4: "42",
-  };
-
-  const body = getBodyV2(fields, attributes, service_entity, service_version);
-
-  expect(body.edit[0]).toEqual({
-    edit_id: "test-entity_version=4",
-    operation: "replace",
-    target: ".",
-    value: {
-      attr1: "some value",
-      attr3: true,
-      attr4: 42,
-    },
-  });
 });

--- a/src/Data/Queries/Slices/ServiceInstance/PatchAttributes/helpers.ts
+++ b/src/Data/Queries/Slices/ServiceInstance/PatchAttributes/helpers.ts
@@ -1,75 +1,31 @@
-import { v4 as uuidv4 } from "uuid";
-import { Field, InstanceAttributeModel, ParsedNumber, PatchField } from "@/Core";
+import { Field, InstanceAttributeModel } from "@/Core";
 import { AttributeResultConverterImpl, sanitizeAttributes } from "@/Data/Common";
 
 export interface BodyV1 {
   attributes: InstanceAttributeModel;
 }
 
-export interface BodyV2 {
-  edit: Array<PatchField>;
-  patch_id: string;
-}
-
 /**
- * Generates the request body for version 1 of the API.
+ * Generates the request body for the PATCH v1 endpoint.
  *
- * This function takes the fields, current attributes, and updated attributes,
- * sanitizes the updated attributes, and calculates the difference between the
- * current and updated attributes. The resulting difference is returned as the
- * request body.
+ * Sanitizes the updated attributes and calculates only the diff against the current
+ * attributes so that unchanged values are not sent to the server.
  *
  * @param {Field[]} fields - The list of fields that define the structure of the attributes.
- * @param {InstanceAttributeModel | null} currentAttributes - The current attributes of the instance, or null if there are none.
+ * @param {InstanceAttributeModel | null} currentAttributes - The current attributes of the instance.
  * @param {InstanceAttributeModel} updatedAttributes - The updated attributes of the instance.
- * @returns The request body containing the attribute differences.
+ * @returns {BodyV1} The request body containing only the changed attributes.
  */
 export const getBodyV1 = (
   fields: Field[],
   currentAttributes: InstanceAttributeModel | null,
   updatedAttributes: InstanceAttributeModel
 ): BodyV1 => {
-  // Make sure correct types are used
   const parsedAttributes = sanitizeAttributes(fields, updatedAttributes);
-  // Only the difference should be sent
   const attributeDiff = new AttributeResultConverterImpl().calculateDiff(
     parsedAttributes,
     currentAttributes
   );
 
   return { attributes: attributeDiff };
-};
-
-/**
- * Generates the request body for version 2 of the API.
- *
- * This function takes the fields, updated attributes, service ID, and version,
- * sanitizes the updated attributes, and constructs the patch data. The resulting
- * patch data and a unique patch ID are returned as the request body.
- *
- * @param {Field[]}  fields - The list of fields that define the structure of the attributes.
- * @param {InstanceAttributeModel} updatedAttributes - The updated attributes of the instance.
- * @param {string} service_id - The ID of the service instance.
- * @param {string} version - The version number of the service instance.
- * @returns The request body containing the patch data and a unique patch ID.
- */
-export const getBodyV2 = (
-  fields: Field[],
-  updatedAttributes: InstanceAttributeModel,
-  service_id: string,
-  version: ParsedNumber
-): BodyV2 => {
-  // Make sure correct types are used
-  const parsedAttributes = sanitizeAttributes(fields, updatedAttributes);
-
-  const patchData = [
-    {
-      edit_id: `${service_id}_version=${version}`,
-      operation: "replace",
-      target: ".",
-      value: parsedAttributes,
-    },
-  ];
-
-  return { edit: patchData, patch_id: uuidv4() };
 };

--- a/src/Data/Queries/Slices/ServiceInstance/PutAttributes/helpers.test.ts
+++ b/src/Data/Queries/Slices/ServiceInstance/PutAttributes/helpers.test.ts
@@ -8,6 +8,7 @@ test("GIVEN getBodyPut WHEN attributes contain numeric strings THEN sanitizes ty
     { ...Field.bool, name: "attr3", isOptional: true, type: "bool?" },
     { ...Field.number, name: "attr4", isOptional: true, type: "int?" },
   ];
+
   const attributes = {
     attr1: "some value",
     attr3: true,
@@ -28,6 +29,7 @@ test("GIVEN getBodyPut WHEN all attributes provided THEN sends all attributes wi
     { ...Field.text, name: "attr1", isOptional: false, type: "string" },
     { ...Field.text, name: "attr2", isOptional: false, type: "string" },
   ];
+
   const attributes = {
     attr1: "value1",
     attr2: "value2",

--- a/src/Data/Queries/Slices/ServiceInstance/PutAttributes/helpers.test.ts
+++ b/src/Data/Queries/Slices/ServiceInstance/PutAttributes/helpers.test.ts
@@ -14,11 +14,13 @@ test("GIVEN getBodyPut WHEN attributes contain numeric strings THEN sanitizes ty
     attr4: "42",
   };
 
-  const body = getBodyPut(fields, attributes);
+  const body = getBodyPut(fields, attributes, 3);
 
   expect(body.attributes.attr1).toEqual("some value");
   expect(body.attributes.attr3).toBe(true);
   expect(body.attributes.attr4).toEqual(42);
+  expect(body.current_version).toEqual(3);
+  expect(body.ignore_read_only_attributes).toBe(true);
 });
 
 test("GIVEN getBodyPut WHEN all attributes provided THEN sends all attributes without diffing", () => {
@@ -31,7 +33,7 @@ test("GIVEN getBodyPut WHEN all attributes provided THEN sends all attributes wi
     attr2: "value2",
   };
 
-  const body = getBodyPut(fields, attributes);
+  const body = getBodyPut(fields, attributes, 1);
 
   expect(body.attributes.attr1).toEqual("value1");
   expect(body.attributes.attr2).toEqual("value2");
@@ -41,8 +43,8 @@ test("GIVEN getBodyPut THEN generates a unique put_id on each call", () => {
   const fields = [{ ...Field.text, name: "attr1", isOptional: false, type: "string" }];
   const attributes = { attr1: "value" };
 
-  const body1 = getBodyPut(fields, attributes);
-  const body2 = getBodyPut(fields, attributes);
+  const body1 = getBodyPut(fields, attributes, 1);
+  const body2 = getBodyPut(fields, attributes, 1);
 
   expect(typeof body1.put_id).toBe("string");
   expect(body1.put_id.length).toBeGreaterThan(0);

--- a/src/Data/Queries/Slices/ServiceInstance/PutAttributes/helpers.test.ts
+++ b/src/Data/Queries/Slices/ServiceInstance/PutAttributes/helpers.test.ts
@@ -1,0 +1,50 @@
+import { Field } from "@/Test";
+import { getBodyPut } from "./helpers";
+
+test("GIVEN getBodyPut WHEN attributes contain numeric strings THEN sanitizes types correctly", () => {
+  const fields = [
+    { ...Field.text, name: "attr1", isOptional: false, type: "string" },
+    { ...Field.text, name: "attr2", isOptional: true, type: "string?" },
+    { ...Field.bool, name: "attr3", isOptional: true, type: "bool?" },
+    { ...Field.number, name: "attr4", isOptional: true, type: "int?" },
+  ];
+  const attributes = {
+    attr1: "some value",
+    attr3: true,
+    attr4: "42",
+  };
+
+  const body = getBodyPut(fields, attributes);
+
+  expect(body.attributes.attr1).toEqual("some value");
+  expect(body.attributes.attr3).toBe(true);
+  expect(body.attributes.attr4).toEqual(42);
+});
+
+test("GIVEN getBodyPut WHEN all attributes provided THEN sends all attributes without diffing", () => {
+  const fields = [
+    { ...Field.text, name: "attr1", isOptional: false, type: "string" },
+    { ...Field.text, name: "attr2", isOptional: false, type: "string" },
+  ];
+  const attributes = {
+    attr1: "value1",
+    attr2: "value2",
+  };
+
+  const body = getBodyPut(fields, attributes);
+
+  expect(body.attributes.attr1).toEqual("value1");
+  expect(body.attributes.attr2).toEqual("value2");
+});
+
+test("GIVEN getBodyPut THEN generates a unique put_id on each call", () => {
+  const fields = [{ ...Field.text, name: "attr1", isOptional: false, type: "string" }];
+  const attributes = { attr1: "value" };
+
+  const body1 = getBodyPut(fields, attributes);
+  const body2 = getBodyPut(fields, attributes);
+
+  expect(typeof body1.put_id).toBe("string");
+  expect(body1.put_id.length).toBeGreaterThan(0);
+  expect(body1.put_id).not.toEqual(body2.put_id);
+});

--- a/src/Data/Queries/Slices/ServiceInstance/PutAttributes/helpers.ts
+++ b/src/Data/Queries/Slices/ServiceInstance/PutAttributes/helpers.ts
@@ -4,7 +4,9 @@ import { sanitizeAttributes } from "@/Data/Common";
 
 export interface BodyPut {
   put_id: string;
+  current_version: number;
   attributes: InstanceAttributeModel;
+  ignore_read_only_attributes: boolean;
   comment?: string;
 }
 
@@ -12,15 +14,25 @@ export interface BodyPut {
  * Generates the request body for the PUT service instance endpoint.
  *
  * Sanitizes the updated attributes to ensure correct types and wraps them with a
- * unique `put_id` for idempotency. All attributes are sent (no diff), because the
- * server-side `ignore_read_only_attributes` flag safely discards read-only fields.
+ * unique `put_id` for idempotency. All attributes are sent (no diff), because
+ * `ignore_read_only_attributes: true` instructs the server to safely discard read-only fields.
  *
  * @param {Field[]} fields - The list of fields that define the attribute structure.
  * @param {InstanceAttributeModel} updatedAttributes - The updated attributes of the instance.
- * @returns {BodyPut} The request body containing `put_id` and sanitized `attributes`.
+ * @param {number} version - The current version of the instance (for optimistic concurrency).
+ * @returns {BodyPut} The request body.
  */
-export const getBodyPut = (fields: Field[], updatedAttributes: InstanceAttributeModel): BodyPut => {
+export const getBodyPut = (
+  fields: Field[],
+  updatedAttributes: InstanceAttributeModel,
+  version: number
+): BodyPut => {
   const parsedAttributes = sanitizeAttributes(fields, updatedAttributes);
 
-  return { put_id: uuidv4(), attributes: parsedAttributes };
+  return {
+    put_id: uuidv4(),
+    current_version: version,
+    attributes: parsedAttributes,
+    ignore_read_only_attributes: true,
+  };
 };

--- a/src/Data/Queries/Slices/ServiceInstance/PutAttributes/helpers.ts
+++ b/src/Data/Queries/Slices/ServiceInstance/PutAttributes/helpers.ts
@@ -1,0 +1,26 @@
+import { v4 as uuidv4 } from "uuid";
+import { Field, InstanceAttributeModel } from "@/Core";
+import { sanitizeAttributes } from "@/Data/Common";
+
+export interface BodyPut {
+  put_id: string;
+  attributes: InstanceAttributeModel;
+  comment?: string;
+}
+
+/**
+ * Generates the request body for the PUT service instance endpoint.
+ *
+ * Sanitizes the updated attributes to ensure correct types and wraps them with a
+ * unique `put_id` for idempotency. All attributes are sent (no diff), because the
+ * server-side `ignore_read_only_attributes` flag safely discards read-only fields.
+ *
+ * @param {Field[]} fields - The list of fields that define the attribute structure.
+ * @param {InstanceAttributeModel} updatedAttributes - The updated attributes of the instance.
+ * @returns {BodyPut} The request body containing `put_id` and sanitized `attributes`.
+ */
+export const getBodyPut = (fields: Field[], updatedAttributes: InstanceAttributeModel): BodyPut => {
+  const parsedAttributes = sanitizeAttributes(fields, updatedAttributes);
+
+  return { put_id: uuidv4(), attributes: parsedAttributes };
+};

--- a/src/Data/Queries/Slices/ServiceInstance/PutAttributes/index.ts
+++ b/src/Data/Queries/Slices/ServiceInstance/PutAttributes/index.ts
@@ -1,0 +1,1 @@
+export * from "./usePutAttributes";

--- a/src/Data/Queries/Slices/ServiceInstance/PutAttributes/usePutAttributes.ts
+++ b/src/Data/Queries/Slices/ServiceInstance/PutAttributes/usePutAttributes.ts
@@ -1,13 +1,12 @@
 import { useContext } from "react";
 import { UseMutationOptions, UseMutationResult, useMutation } from "@tanstack/react-query";
 import { Config, Field, InstanceAttributeModel } from "@/Core";
-import { usePatch } from "@/Data/Queries";
+import { usePut } from "@/Data/Queries";
 import { DependencyContext } from "@/UI";
-import { BodyV1, getBodyV1 } from "./helpers";
+import { BodyPut, getBodyPut } from "./helpers";
 
 interface MutationBody {
   fields: Field[];
-  currentAttributes: InstanceAttributeModel | null;
   updatedAttributes: InstanceAttributeModel;
 }
 
@@ -16,14 +15,15 @@ interface Response {
 }
 
 /**
- * React Query hook for patching instance attributes via PATCH v1.
+ * React Query hook for updating instance attributes via PUT.
  *
- * Sends only the changed attributes (diff against current state) to
- * PATCH /lsm/v1/service_inventory/{service_entity}/{id}.
+ * Uses PUT /api/v1/service_inventory/{service_entity}/{id} with
+ * `ignore_read_only_attributes=true` so the server safely ignores any read-only
+ * fields present in the payload.
  *
  * @returns {UseMutationResult<Response, Error, MutationBody, unknown>} The mutation object.
  */
-export const usePatchAttributes = (
+export const usePutAttributes = (
   service_entity: string,
   id: string,
   version: number,
@@ -31,13 +31,12 @@ export const usePatchAttributes = (
 ): UseMutationResult<Response, Error, MutationBody, unknown> => {
   const { environmentHandler } = useContext(DependencyContext);
   const env = environmentHandler.useId();
-  const url = `/lsm/v1/service_inventory/${service_entity}/${id}?current_version=${version}`;
-  const patch = usePatch(env)<BodyV1>;
+  const url = `/api/v1/service_inventory/${service_entity}/${id}?current_version=${version}&ignore_read_only_attributes=true`;
+  const put = usePut(env)<BodyPut>;
 
   return useMutation({
-    mutationFn: ({ fields, currentAttributes, updatedAttributes }) =>
-      patch(url, getBodyV1(fields, currentAttributes, updatedAttributes)),
-    mutationKey: ["post_instance_config", service_entity, id, version, env],
+    mutationFn: ({ fields, updatedAttributes }) => put(url, getBodyPut(fields, updatedAttributes)),
+    mutationKey: ["put_instance_attributes", service_entity, id, version, env],
     ...options,
   });
 };

--- a/src/Data/Queries/Slices/ServiceInstance/PutAttributes/usePutAttributes.ts
+++ b/src/Data/Queries/Slices/ServiceInstance/PutAttributes/usePutAttributes.ts
@@ -17,9 +17,8 @@ interface Response {
 /**
  * React Query hook for updating instance attributes via PUT.
  *
- * Uses PUT /api/v1/service_inventory/{service_entity}/{id} with
- * `ignore_read_only_attributes=true` so the server safely ignores any read-only
- * fields present in the payload.
+ * Uses PUT /api/v1/service_inventory/{service_entity}/{id}.
+ * `current_version` and `ignore_read_only_attributes` are sent in the request body.
  *
  * @returns {UseMutationResult<Response, Error, MutationBody, unknown>} The mutation object.
  */
@@ -31,11 +30,12 @@ export const usePutAttributes = (
 ): UseMutationResult<Response, Error, MutationBody, unknown> => {
   const { environmentHandler } = useContext(DependencyContext);
   const env = environmentHandler.useId();
-  const url = `/lsm/v1/service_inventory/${service_entity}/${id}?current_version=${version}&ignore_read_only_attributes=true`;
+  const url = `/api/v1/service_inventory/${service_entity}/${id}`;
   const put = usePut(env)<BodyPut>;
 
   return useMutation({
-    mutationFn: ({ fields, updatedAttributes }) => put(url, getBodyPut(fields, updatedAttributes)),
+    mutationFn: ({ fields, updatedAttributes }) =>
+      put(url, getBodyPut(fields, updatedAttributes, version)),
     mutationKey: ["put_instance_attributes", service_entity, id, version, env],
     ...options,
   });

--- a/src/Data/Queries/Slices/ServiceInstance/PutAttributes/usePutAttributes.ts
+++ b/src/Data/Queries/Slices/ServiceInstance/PutAttributes/usePutAttributes.ts
@@ -17,7 +17,7 @@ interface Response {
 /**
  * React Query hook for updating instance attributes via PUT.
  *
- * Uses PUT /api/v1/service_inventory/{service_entity}/{id}.
+ * Uses PUT /lsm/v1/service_inventory/{service_entity}/{id}.
  * `current_version` and `ignore_read_only_attributes` are sent in the request body.
  *
  * @returns {UseMutationResult<Response, Error, MutationBody, unknown>} The mutation object.
@@ -30,7 +30,7 @@ export const usePutAttributes = (
 ): UseMutationResult<Response, Error, MutationBody, unknown> => {
   const { environmentHandler } = useContext(DependencyContext);
   const env = environmentHandler.useId();
-  const url = `/api/v1/service_inventory/${service_entity}/${id}`;
+  const url = `/lsm/v1/service_inventory/${service_entity}/${id}`;
   const put = usePut(env)<BodyPut>;
 
   return useMutation({

--- a/src/Data/Queries/Slices/ServiceInstance/PutAttributes/usePutAttributes.ts
+++ b/src/Data/Queries/Slices/ServiceInstance/PutAttributes/usePutAttributes.ts
@@ -31,7 +31,7 @@ export const usePutAttributes = (
 ): UseMutationResult<Response, Error, MutationBody, unknown> => {
   const { environmentHandler } = useContext(DependencyContext);
   const env = environmentHandler.useId();
-  const url = `/api/v1/service_inventory/${service_entity}/${id}?current_version=${version}&ignore_read_only_attributes=true`;
+  const url = `/lsm/v1/service_inventory/${service_entity}/${id}?current_version=${version}&ignore_read_only_attributes=true`;
   const put = usePut(env)<BodyPut>;
 
   return useMutation({

--- a/src/Data/Queries/Slices/ServiceInstance/index.ts
+++ b/src/Data/Queries/Slices/ServiceInstance/index.ts
@@ -15,6 +15,7 @@ export * from "./PatchAttributesExpert";
 export * from "./PostExpertStateTransfer";
 export * from "./PostMetadata";
 export * from "./PatchAttributes";
+export * from "./PutAttributes";
 export * from "./PostStateTransfer";
 export * from "./PostInstance";
 export * from "./PostInstanceConfig";

--- a/src/Slices/EditInstance/UI/EditForm.tsx
+++ b/src/Slices/EditInstance/UI/EditForm.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useContext, useState } from "react";
 import { useNavigate } from "react-router";
 import { InstanceAttributeModel, ServiceInstanceModel, ServiceModel } from "@/Core";
 import { AttributeInputConverterImpl } from "@/Data";
-import { usePatchAttributes } from "@/Data/Queries";
+import { usePatchAttributes, usePutAttributes } from "@/Data/Queries";
 import { FieldCreator, ServiceInstanceForm, EditModifierHandler } from "@/UI/Components";
 import { DependencyContext } from "@/UI/Dependency";
 import { useAppAlert } from "@/UI/Root/Components/AppAlertProvider";
@@ -16,6 +16,10 @@ interface Props {
 /**
  * EditForm component allows users to edit the attributes of a service instance.
  * It provides a form with fields based on the service entity and handles form submission.
+ *
+ * When `strict_modifier_enforcement` is true, the form submits via
+ * PUT /api/v1/service_inventory with `ignore_read_only_attributes=true`.
+ * Otherwise it submits via PATCH /lsm/v1/service_inventory (diff only).
  *
  * @props {Props} props - The properties for the EditForm component.
  * @prop {ServiceModel} props.serviceEntity - The service entity model containing the service details.
@@ -44,25 +48,35 @@ export const EditForm: React.FC<Props> = ({ serviceEntity, instance }) => {
   const attributeInputConverter = new AttributeInputConverterImpl();
   const currentAttributes = attributeInputConverter.getCurrentAttributes(instance);
 
-  const apiVersion = serviceEntity.strict_modifier_enforcement ? "v2" : "v1";
+  const isStrictEnforcement = serviceEntity.strict_modifier_enforcement ?? false;
 
-  const { mutate } = usePatchAttributes(
-    apiVersion,
+  // "v2" form behavior: form state is initialised with all original attributes so that
+  // read-only fields are visible (but disabled), matching the PUT full-attribute payload.
+  const formApiVersion = isStrictEnforcement ? "v2" : "v1";
+
+  const onMutationError = (error: Error) => {
+    setIsDirty(true);
+    notifyError({
+      title: words("inventory.editInstance.failed"),
+      message: error.message,
+    });
+  };
+
+  const onMutationSuccess = () => handleRedirect();
+
+  // Both hooks are always called (React rules of hooks). Only the relevant mutate is used.
+  const { mutate: patchMutate } = usePatchAttributes(
     serviceEntity.name,
     instance.id,
     Number(instance.version),
-    {
-      onError: (error) => {
-        setIsDirty(true);
-        notifyError({
-          title: words("inventory.editInstance.failed"),
-          message: error.message,
-        });
-      },
-      onSuccess: () => {
-        handleRedirect();
-      },
-    }
+    { onError: onMutationError, onSuccess: onMutationSuccess }
+  );
+
+  const { mutate: putMutate } = usePutAttributes(
+    serviceEntity.name,
+    instance.id,
+    Number(instance.version),
+    { onError: onMutationError, onSuccess: onMutationSuccess }
   );
 
   const onSubmit = async (
@@ -71,7 +85,11 @@ export const EditForm: React.FC<Props> = ({ serviceEntity, instance }) => {
   ) => {
     //as setState used in setIsDirty doesn't change immediately we cannot use it only before handleRedirect() as it would trigger prompt from ServiceInstanceForm
     setIsDirty(false);
-    mutate({ fields, currentAttributes, updatedAttributes });
+    if (isStrictEnforcement) {
+      putMutate({ fields, updatedAttributes });
+    } else {
+      patchMutate({ fields, currentAttributes, updatedAttributes });
+    }
   };
 
   return (
@@ -84,7 +102,7 @@ export const EditForm: React.FC<Props> = ({ serviceEntity, instance }) => {
         onCancel={handleRedirect}
         isSubmitDisabled={isHalted}
         originalAttributes={currentAttributes ? currentAttributes : undefined}
-        apiVersion={apiVersion}
+        apiVersion={formApiVersion}
         isDirty={isDirty}
         setIsDirty={setIsDirty}
       />

--- a/src/Slices/EditInstance/UI/EditInstancePage.test.tsx
+++ b/src/Slices/EditInstance/UI/EditInstancePage.test.tsx
@@ -136,7 +136,7 @@ describe("EditInstancePage", () => {
       }
     ),
     http.patch("/lsm/v1/service_inventory/service_name_a/service_instance_id_a", async () => {}),
-    http.put("/api/v1/service_inventory/service_name_d/service_instance_id_a", async () => {})
+    http.put("/lsm/v1/service_inventory/service_name_d/service_instance_id_a", async () => {})
   );
 
   beforeAll(() => {
@@ -278,7 +278,7 @@ describe("EditInstancePage", () => {
     };
 
     expect(mockPutFn).toHaveBeenCalledWith(
-      "/api/v1/service_inventory/service_name_d/service_instance_id_a",
+      "/lsm/v1/service_inventory/service_name_d/service_instance_id_a",
       body
     );
 

--- a/src/Slices/EditInstance/UI/EditInstancePage.test.tsx
+++ b/src/Slices/EditInstance/UI/EditInstancePage.test.tsx
@@ -14,14 +14,16 @@ import { words } from "@/UI";
 import { TestMemoryRouter } from "@/UI/Routing/TestMemoryRouter";
 import { Page } from "./Page";
 
-// Mock usePatch before the test
+// Mock usePatch and usePut before the test
 const mockPatchFn = vi.fn();
+const mockPutFn = vi.fn();
 vi.mock("@/Data/Queries/Helpers/useQueries", async (importActual) => {
   const actual = await importActual<typeof import("@/Data/Queries/Helpers/useQueries")>();
 
   return {
     ...actual,
     usePatch: () => mockPatchFn,
+    usePut: () => mockPutFn,
   };
 });
 
@@ -134,7 +136,7 @@ describe("EditInstancePage", () => {
       }
     ),
     http.patch("/lsm/v1/service_inventory/service_name_a/service_instance_id_a", async () => {}),
-    http.patch("/lsm/v2/service_inventory/service_name_d/service_instance_id_a", async () => {})
+    http.put("/api/v1/service_inventory/service_name_d/service_instance_id_a", async () => {})
   );
 
   beforeAll(() => {
@@ -143,6 +145,7 @@ describe("EditInstancePage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockPatchFn.mockClear();
+    mockPutFn.mockClear();
   });
 
   afterAll(() => {
@@ -231,7 +234,7 @@ describe("EditInstancePage", () => {
     });
   });
 
-  test("Given the EditInstance View When changing a v2 embedded entity Then the correct request  with correct body is fired", async () => {
+  test("Given the EditInstance View When changing a strict-enforcement embedded entity Then the correct PUT request with correct body is fired", async () => {
     mockedUseParams.mockReturnValue({ service: "service_name_d", instance });
 
     const { component } = setup();
@@ -268,19 +271,12 @@ describe("EditInstancePage", () => {
     expectedInstance.bandwidth = "24";
 
     const body = {
-      edit: [
-        {
-          edit_id: "service_instance_id_a_version=3",
-          operation: "replace",
-          target: ".",
-          value: expectedInstance,
-        },
-      ],
-      patch_id: expect.any(String),
+      put_id: expect.any(String),
+      attributes: expectedInstance,
     };
 
-    expect(mockPatchFn).toHaveBeenCalledWith(
-      "/lsm/v2/service_inventory/service_name_d/service_instance_id_a?current_version=3",
+    expect(mockPutFn).toHaveBeenCalledWith(
+      "/api/v1/service_inventory/service_name_d/service_instance_id_a?current_version=3&ignore_read_only_attributes=true",
       body
     );
 

--- a/src/Slices/EditInstance/UI/EditInstancePage.test.tsx
+++ b/src/Slices/EditInstance/UI/EditInstancePage.test.tsx
@@ -272,11 +272,13 @@ describe("EditInstancePage", () => {
 
     const body = {
       put_id: expect.any(String),
+      current_version: 3,
       attributes: expectedInstance,
+      ignore_read_only_attributes: true,
     };
 
     expect(mockPutFn).toHaveBeenCalledWith(
-      "/api/v1/service_inventory/service_name_d/service_instance_id_a?current_version=3&ignore_read_only_attributes=true",
+      "/api/v1/service_inventory/service_name_d/service_instance_id_a",
       body
     );
 


### PR DESCRIPTION
# Description

## Summary

  - Replaces `PATCH /lsm/v2/service_inventory/<entity>/<id>` (used when `strict_modifier_enforcement = true`) with `PUT
  /api/v1/service_inventory/<entity>/<id>?current_version=<v>&ignore_read_only_attributes=true`
  - Adds a new `usePut` (env-aware) HTTP primitive to the query helpers layer
  - Introduces a `PutAttributes` data module (`usePutAttributes` hook + `getBodyPut` helper) with body shape: `{ put_id: <uuid>, attributes: <all sanitized
  attributes> }`
  - Cleans up all dead PATCH v2 code (`BodyV2`, `getBodyV2`, `apiVersion` branching in `usePatchAttributes`)
  - `EditForm` calls `usePutAttributes` for strict-enforcement services and `usePatchAttributes` (v1, diff-only) for all others — both hooks called unconditionally
   per React rules

closes:
- 6903

_Changes made in collaboration with Claude_