### PR TITLE
Remove dead code related to the dict fields

### DIFF
--- a/changelogs/unreleased/remove-dead-code-dict-field.yml
+++ b/changelogs/unreleased/remove-dead-code-dict-field.yml
@@ -1,0 +1,3 @@
+description: Remove dead code related to the dict fields update.
+change-type: patch
+destination-branches: [master, iso9]

--- a/changelogs/unreleased/remove-dead-code-dict-field.yml
+++ b/changelogs/unreleased/remove-dead-code-dict-field.yml
@@ -1,3 +1,3 @@
-description: Remove dead code related to the dict fields update.
+description: Remove dead code related to the dict fields update and stabilize ref codeEditor.
 change-type: patch
 destination-branches: [master, iso9]

--- a/src/UI/Components/ServiceInstanceForm/Components/DictFieldInput/DictFieldInput.tsx
+++ b/src/UI/Components/ServiceInstanceForm/Components/DictFieldInput/DictFieldInput.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentProps, useState } from "react";
+import React, { ComponentProps, useEffect, useRef, useState } from "react";
 import { CodeEditor, Language } from "@patternfly/react-code-editor";
 import { FormGroup, FormHelperText, HelperText, HelperTextItem } from "@patternfly/react-core";
 import { DictField } from "@/Core";
@@ -17,12 +17,12 @@ interface Props {
  *
  * A JSON editor for dictionary-type service instance fields, backed by the
  * PatternFly CodeEditor (Monaco). It auto-resizes line-by-line as content
- * grows (capped at 400 px), validates JSON in real time, and surfaces parse
+ * grows (capped at 350 px), validates JSON in real time, and surfaces parse
  * errors through a helper-text row below the editor.
  *
  * @prop {DictField} field - Field metadata: name, description, isOptional.
- * @prop {unknown} value - Initial value; non-objects are treated as an empty object.
- * @prop {(value: DictValue) => void} onChange - Called with the parsed object on every valid edit.
+ * @prop {unknown} value - Current value; synced into the editor when changed externally (e.g. form reset).
+ * @prop {(value: DictValue | null) => void} onChange - Called with the parsed object on every valid edit.
  * @prop {boolean} [readOnly=false] - Disables editing and marks the editor with aria-disabled.
  *
  * @returns {React.ReactElement} The rendered JSON dictionary editor field.
@@ -32,11 +32,24 @@ export const DictFieldInput: React.FC<Props> = ({ field, value, onChange, readOn
   const [isInvalid, setIsInvalid] = useState(false);
   const [height, setHeight] = useState(100);
 
+  // Tracks the serialized form of the last value we emitted via onChange so we
+  // can distinguish a parent re-render carrying our own round-tripped value from
+  // a genuine external change (e.g. a form reset) that should update the editor.
+  const lastEmittedRef = useRef(toText(value));
+
+  useEffect(() => {
+    const incoming = toText(value);
+
+    if (incoming !== lastEmittedRef.current) {
+      lastEmittedRef.current = incoming;
+      setText(incoming);
+      setIsInvalid(false);
+    }
+  }, [value]);
+
   const handleEditorDidMount: ComponentProps<typeof CodeEditor>["onEditorDidMount"] = (editor) => {
-    // Initial height
     setHeight(Math.min(editor.getContentHeight(), 350));
 
-    // Resize height accordingly
     editor.onDidContentSizeChange((e) => {
       setHeight(Math.min(e.contentHeight, 350));
     });
@@ -45,26 +58,21 @@ export const DictFieldInput: React.FC<Props> = ({ field, value, onChange, readOn
   const handleChange = (val: string) => {
     setText(val);
     const parsed = toDict(val);
-    // toDict returns undefined only on a parse error
     setIsInvalid(parsed === undefined);
+
     if (parsed !== undefined) {
+      lastEmittedRef.current = toText(parsed);
       onChange(parsed);
     }
   };
 
   return (
     <FormGroup isRequired={!field.isOptional} fieldId={field.name} label={field.name}>
-      <FormHelperText>
-        <HelperText>
-          <HelperTextItem>{field.description}</HelperTextItem>
-        </HelperText>
-      </FormHelperText>
       <CodeEditor
         data-testid={`DictInput-${field.name}`}
         aria-disabled={readOnly || undefined}
         code={text}
         language={Language.json}
-        // Explicit height prevents unbounded growth of the Editor
         height={`${height}px`}
         isReadOnly={readOnly}
         isLineNumbersVisible={false}
@@ -75,6 +83,7 @@ export const DictFieldInput: React.FC<Props> = ({ field, value, onChange, readOn
       />
       <FormHelperText>
         <HelperText>
+          <HelperTextItem>{field.description}</HelperTextItem>
           <HelperTextItem variant={isInvalid ? "error" : "indeterminate"}>
             {isInvalid ? words("validation.empty") : words("inventory.form.typeHint.dict")}
           </HelperTextItem>

--- a/src/UI/Components/ServiceInstanceForm/Components/FieldInput.tsx
+++ b/src/UI/Components/ServiceInstanceForm/Components/FieldInput.tsx
@@ -208,11 +208,7 @@ export const FieldInput: React.FC<Props> = ({
           }
           type={field.inputType}
           handleInputChange={(value, _event) => {
-            if (field.type.includes("dict")) {
-              getUpdate(makePath(path, field.name), tryParseJSON(value));
-            } else {
-              getUpdate(makePath(path, field.name), value);
-            }
+            getUpdate(makePath(path, field.name), value);
           }}
           placeholder={getPlaceholderForType(field.type)}
           typeHint={getTypeHintForType(field.type)}


### PR DESCRIPTION
# Description

- Remove dead code related to the dict fields.
- Added a lastEmittedRef to track the serialized form of the last value sent through onChange. A useEffect on value now detects genuine external changes (e.g. form reset) and syncs the editor, while ignoring the component's own round-trips
