### PR TITLE
Fix DictField JSON editor content color in dark mode

### DIFF
--- a/changelogs/unreleased/6948-dict-field-dark-mode.yml
+++ b/changelogs/unreleased/6948-dict-field-dark-mode.yml
@@ -1,4 +1,4 @@
-description: Fixed JSON and code editors not adapting their content color when switching to dark mode without a page reload.
+description: Fixed an issue where JSON and code editors were not adapting their content color when switching theme without a page reload.
 issue-nr: 6948
 change-type: patch
 destination-branches: [master, iso9]

--- a/changelogs/unreleased/6948-dict-field-dark-mode.yml
+++ b/changelogs/unreleased/6948-dict-field-dark-mode.yml
@@ -1,0 +1,6 @@
+description: Fixed the DictField JSON editor not adapting its content color in dark mode.
+issue-nr: 6948
+change-type: patch
+destination-branches: [master, iso9]
+sections:
+  bugfix: "{{description}}"

--- a/changelogs/unreleased/6948-dict-field-dark-mode.yml
+++ b/changelogs/unreleased/6948-dict-field-dark-mode.yml
@@ -1,4 +1,4 @@
-description: Fixed the DictField JSON editor not adapting its content color in dark mode.
+description: Fixed JSON and code editors not adapting their content color when switching to dark mode without a page reload.
 issue-nr: 6948
 change-type: patch
 destination-branches: [master, iso9]

--- a/src/Slices/Diagnose/UI/Traceback.tsx
+++ b/src/Slices/Diagnose/UI/Traceback.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { CodeEditor, Language } from "@patternfly/react-code-editor";
 import { ExpandableSection } from "@patternfly/react-core";
 import { CodeEditorCopyControl } from "@/UI/Components/CodeEditorControls";
-import { getThemePreference } from "@/UI/Components/DarkmodeOption";
+import { useTheme } from "@/UI/Components/DarkmodeOption";
 import { words } from "@/UI/words";
 
 /**
@@ -12,11 +12,13 @@ import { words } from "@/UI/words";
  * @returns {React.FC} A component that displays a traceback.
  */
 export const Traceback: React.FC<{ trace: string }> = ({ trace }) => {
+  const { isDark } = useTheme();
+
   return (
     <ExpandableSection toggleText={words("diagnose.rejection.traceback")}>
       <CodeEditor
         code={trace}
-        isDarkTheme={getThemePreference() === "dark"}
+        isDarkTheme={isDark}
         language={Language.python}
         isReadOnly
         isDownloadEnabled

--- a/src/Slices/GraphiQL/UI/Page.tsx
+++ b/src/Slices/GraphiQL/UI/Page.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo } from "react";
 import { useLocation } from "react-router";
 import { Fetcher } from "@graphiql/toolkit";
 import { useQueryClient } from "@tanstack/react-query";
@@ -7,7 +7,7 @@ import graphiqlCSS from "graphiql/style.css?inline";
 import styled, { createGlobalStyle } from "styled-components";
 import { useGetGraphQLSchema, usePostGraphQL, graphQLSchemaKey } from "@/Data/Queries";
 import { PageContainer } from "@/UI/Components";
-import { getThemePreference } from "@/UI/Components/DarkmodeOption";
+import { useTheme } from "@/UI/Components/DarkmodeOption";
 import { words } from "@/UI/words";
 
 // ?inline tells Vite to give us the CSS as a plain string instead of injecting
@@ -34,7 +34,7 @@ const DEFAULT_QUERY = `{
  * is ready and shows "error fetching schema".
  *
  * Theme is kept in sync with the app's dark/light mode by observing class
- * changes on <html> (set by setThemePreference) and forwarding the value to
+ * changes on <html> (tracked by useTheme) and forwarding the value to
  * GraphiQL's forcedTheme prop.
  *
  * The sidebar's "Re-fetch schema" button is intercepted via event delegation
@@ -51,11 +51,7 @@ export const Page: React.FC = () => {
     return envParam ?? undefined;
   }, [search]);
 
-  // Mirror the app-wide theme so GraphiQL matches the current dark/light mode.
-  // MutationObserver watches for class changes on <html> made by setThemePreference.
-  const [theme, setTheme] = useState<"dark" | "light">(
-    () => (getThemePreference() ?? "light") as "dark" | "light"
-  );
+  const { theme } = useTheme();
 
   // Inject graphiql's CSS (including its bundled Monaco copy) inside a
   // @layer so it has lower cascade priority than the app's own Monaco styles.
@@ -67,19 +63,6 @@ export const Page: React.FC = () => {
     document.head.appendChild(style);
 
     return () => style.remove();
-  }, []);
-
-  useEffect(() => {
-    const observer = new MutationObserver(() => {
-      setTheme((getThemePreference() ?? "light") as "dark" | "light");
-    });
-
-    observer.observe(document.documentElement, {
-      attributes: true,
-      attributeFilter: ["class"],
-    });
-
-    return () => observer.disconnect();
   }, []);
 
   const queryClient = useQueryClient();

--- a/src/Slices/MarkdownPreviewer/UI/MarkdownPreviewer.tsx
+++ b/src/Slices/MarkdownPreviewer/UI/MarkdownPreviewer.tsx
@@ -4,7 +4,7 @@ import { Flex, FlexItem, Hint, HintTitle, HintBody, Button } from "@patternfly/r
 import { CloseIcon } from "@patternfly/react-icons";
 import { MarkdownCard } from "@/Slices/ServiceInventory/UI/Tabs/MarkdownCard";
 import { PageContainer } from "@/UI/Components";
-import { getThemePreference } from "@/UI/Components/DarkmodeOption";
+import { useTheme } from "@/UI/Components/DarkmodeOption";
 import { words } from "@/UI/words";
 import { MarkdownCodeEditorControls, useDocumentationContent } from ".";
 
@@ -25,6 +25,7 @@ interface Props {
  */
 export const MarkdownPreviewer: React.FC<Props> = ({ service, instance, instanceId }) => {
   const { code: initialCode, pageTitle } = useDocumentationContent({ service, instanceId });
+  const { isDark } = useTheme();
   const [showHint, setShowHint] = useState(true);
   const [markdownContent, setMarkdownContent] = useState(initialCode);
 
@@ -50,7 +51,7 @@ export const MarkdownPreviewer: React.FC<Props> = ({ service, instance, instance
       <Flex direction={{ default: "column" }}>
         <FlexItem flex={{ default: "flex_1" }}>
           <CodeEditor
-            isDarkTheme={getThemePreference() === "dark"}
+            isDarkTheme={isDark}
             isLineNumbersVisible
             isMinimapVisible
             isLanguageLabelVisible

--- a/src/Slices/MarkdownPreviewer/UI/Page.test.tsx
+++ b/src/Slices/MarkdownPreviewer/UI/Page.test.tsx
@@ -2,13 +2,13 @@ import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { instanceData } from "@/Slices/ServiceInstanceDetails/Test/mockData";
 import { defaultServer } from "@/Slices/ServiceInstanceDetails/Test/mockServer";
 import { SetupWrapper } from "@/Slices/ServiceInstanceDetails/Test/mockSetup";
-import { getThemePreference } from "@/UI/Components/DarkmodeOption";
+import { useTheme } from "@/UI/Components/DarkmodeOption";
 import { words } from "@/UI/words";
 import { MarkdownPreviewer } from "./MarkdownPreviewer";
 
-// Mock the getThemePreference function
+// Mock the theme hook
 vi.mock("@/UI/Components/DarkmodeOption", () => ({
-  getThemePreference: vi.fn().mockReturnValue("light"),
+  useTheme: vi.fn(() => ({ isDark: false, theme: "light", setTheme: vi.fn() })),
 }));
 
 // Mock the CodeEditor component to avoid Monaco editor issues
@@ -87,7 +87,7 @@ describe("MarkdownPreviewer", () => {
 
   it("should handle dark theme correctly", async () => {
     // Override the mock to return dark theme
-    (getThemePreference as ReturnType<typeof vi.fn>).mockReturnValue("dark");
+    (useTheme as ReturnType<typeof vi.fn>).mockReturnValue({ isDark: true, theme: "dark", setTheme: vi.fn() });
 
     render(setup());
 

--- a/src/Slices/MarkdownPreviewer/UI/Page.test.tsx
+++ b/src/Slices/MarkdownPreviewer/UI/Page.test.tsx
@@ -87,7 +87,11 @@ describe("MarkdownPreviewer", () => {
 
   it("should handle dark theme correctly", async () => {
     // Override the mock to return dark theme
-    (useTheme as ReturnType<typeof vi.fn>).mockReturnValue({ isDark: true, theme: "dark", setTheme: vi.fn() });
+    (useTheme as ReturnType<typeof vi.fn>).mockReturnValue({
+      isDark: true,
+      theme: "dark",
+      setTheme: vi.fn(),
+    });
 
     render(setup());
 

--- a/src/Slices/OrderDetails/UI/OrderDetailsRow.tsx
+++ b/src/Slices/OrderDetails/UI/OrderDetailsRow.tsx
@@ -14,7 +14,7 @@ import { ServiceOrderItem } from "@/Slices/Orders/Core/Types";
 import { OrderStatusLabel } from "@/Slices/Orders/UI/OrderStatusLabel";
 import { TextWithCopy, Toggle } from "@/UI/Components";
 import { CodeEditorCopyControl } from "@/UI/Components/CodeEditorControls";
-import { getThemePreference } from "@/UI/Components/DarkmodeOption";
+import { useTheme } from "@/UI/Components/DarkmodeOption";
 import { words } from "@/UI/words";
 import { OrderDependencies } from "./OrderDependencies";
 import { OrderStateDetails } from "./OrderStateDetails";
@@ -43,6 +43,8 @@ export const OrderDetailsRow: React.FC<Props> = ({
   onToggle,
   numberOfColumns,
 }) => {
+  const { isDark } = useTheme();
+
   return (
     <>
       <Tr aria-label="ServiceOrderDetailsRow">
@@ -90,7 +92,7 @@ export const OrderDetailsRow: React.FC<Props> = ({
                   {row.config && Object.keys(row.config).length ? (
                     <CodeEditor
                       code={JSON.stringify(row.config, null, 2)}
-                      isDarkTheme={getThemePreference() === "dark"}
+                      isDarkTheme={isDark}
                       language={Language.json}
                       isDownloadEnabled
                       customControls={

--- a/src/Slices/ServiceInstanceDetails/UI/Components/AttributesComponents/AttributesCompare.tsx
+++ b/src/Slices/ServiceInstanceDetails/UI/Components/AttributesComponents/AttributesCompare.tsx
@@ -10,7 +10,7 @@ import {
 } from "@/Slices/ServiceInstanceDetails/Utils";
 import { words } from "@/UI";
 import { SearchSelect } from "@/UI/Components";
-import { getThemePreference } from "@/UI/Components/DarkmodeOption";
+import { useTheme } from "@/UI/Components/DarkmodeOption";
 
 interface Props {
   instanceLogs: InstanceLog[];
@@ -45,7 +45,7 @@ export const AttributesCompare: React.FC<Props> = ({ instanceLogs, selectedVersi
   const [rightSelectedSet, setRightSelectedSet] = useState<AttributeSets>("candidate_attributes");
   const [availableVersions, setAvailableVersions] = useState<string[]>([]);
 
-  const preferredTheme = getThemePreference() || "light";
+  const { theme: preferredTheme } = useTheme();
 
   useEffect(() => {
     if (instanceLogs && instanceLogs.length) {

--- a/src/UI/Components/DarkmodeOption/DarkmodeOption.test.tsx
+++ b/src/UI/Components/DarkmodeOption/DarkmodeOption.test.tsx
@@ -1,51 +1,49 @@
 import { render, fireEvent } from "@testing-library/react";
 import { DarkmodeOption } from "./DarkmodeOption";
+import { useTheme } from "./useTheme";
+
+vi.mock("./useTheme");
 
 describe("DarkmodeOption", () => {
-  beforeEach(() => {
-    localStorage.clear();
-    document.documentElement.classList.remove("pf-v6-theme-dark", "pf-v6-theme-light");
+  afterEach(() => {
+    vi.resetAllMocks();
   });
 
-  it("should render the correct initial theme based on localStorage", () => {
-    localStorage.setItem("theme-preference", "dark");
+  it("renders 'Switch to light mode' when the current theme is dark", () => {
+    vi.mocked(useTheme).mockReturnValue({ isDark: true, theme: "dark", setTheme: vi.fn() });
     const { getByText } = render(<DarkmodeOption />);
 
     expect(getByText("Switch to light mode")).toBeInTheDocument();
   });
 
-  it("should render the correct initial theme based on system preference", () => {
-    window.matchMedia = vi.fn().mockImplementation((query) => {
-      return {
-        matches: query === "(prefers-color-scheme: dark)",
-        addListener: vi.fn(),
-        removeListener: vi.fn(),
-      };
-    });
-
+  it("renders 'Switch to dark mode' when the current theme is light", () => {
+    vi.mocked(useTheme).mockReturnValue({ isDark: false, theme: "light", setTheme: vi.fn() });
     const { getByText } = render(<DarkmodeOption />);
 
-    expect(getByText("Switch to light mode")).toBeInTheDocument();
-  });
-
-  it("should toggle the theme and update localStorage", () => {
-    const { getByText } = render(<DarkmodeOption />);
-    const button = getByText("Switch to light mode");
-
-    fireEvent.click(button);
-    expect(localStorage.getItem("theme-preference")).toBe("light");
-    expect(document.documentElement.classList.contains("pf-v6-theme-light")).toBe(true);
     expect(getByText("Switch to dark mode")).toBeInTheDocument();
   });
 
-  it("should toggle the theme back to light", () => {
-    localStorage.setItem("theme-preference", "dark");
-    const { getByText } = render(<DarkmodeOption />);
-    const button = getByText("Switch to light mode");
+  it("calls setTheme with 'light' when toggled from dark", () => {
+    const setTheme = vi.fn();
 
-    fireEvent.click(button);
-    expect(localStorage.getItem("theme-preference")).toBe("light");
-    expect(document.documentElement.classList.contains("pf-v6-theme-light")).toBe(true);
-    expect(getByText("Switch to dark mode")).toBeInTheDocument();
+    vi.mocked(useTheme).mockReturnValue({ isDark: true, theme: "dark", setTheme });
+    const { getByText } = render(<DarkmodeOption />);
+
+    fireEvent.click(getByText("Switch to light mode"));
+
+    expect(setTheme).toHaveBeenCalledWith("light");
+    expect(setTheme).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls setTheme with 'dark' when toggled from light", () => {
+    const setTheme = vi.fn();
+
+    vi.mocked(useTheme).mockReturnValue({ isDark: false, theme: "light", setTheme });
+    const { getByText } = render(<DarkmodeOption />);
+
+    fireEvent.click(getByText("Switch to dark mode"));
+
+    expect(setTheme).toHaveBeenCalledWith("dark");
+    expect(setTheme).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/UI/Components/DarkmodeOption/DarkmodeOption.tsx
+++ b/src/UI/Components/DarkmodeOption/DarkmodeOption.tsx
@@ -1,60 +1,17 @@
-import React, { useState, useEffect } from "react";
+import React from "react";
 import { DropdownItem } from "@patternfly/react-core";
 import { words } from "@/UI/words";
-
-const storageKey = "theme-preference";
-
-/**
- * Retrieves the user's theme preference from localStorage or the system's color scheme.
- * @returns {string} The theme preference, either 'dark' or 'light'.
- */
-export const getThemePreference = () => {
-  if (localStorage.getItem(storageKey)) {
-    return localStorage.getItem(storageKey);
-  } else {
-    return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
-  }
-};
-
-const loadHighlightTheme = (theme: string) => {
-  // Dynamically import the appropriate highlight.js theme.
-  // We intentionally don't await these imports: they load CSS side effects.
-  if (theme === "dark") {
-    void import("highlight.js/styles/github-dark-dimmed.css");
-  } else {
-    void import("highlight.js/styles/github.css");
-  }
-};
+import { useTheme } from "./useTheme";
 
 /**
- * Sets the user's theme preference in localStorage and updates the document's theme class,
- * and loads the matching highlight.js theme CSS.
- * @param {string} theme - The theme to set, either 'dark' or 'light'.
- */
-export const setThemePreference = (theme: string) => {
-  localStorage.setItem(storageKey, theme);
-  // Target the html tag and update the theme class "pf-v6-theme-dark" / "pf-v6-theme-light" depending on the theme.
-  document.documentElement.classList.remove("pf-v6-theme-dark", "pf-v6-theme-light");
-  document.documentElement.classList.add(`pf-v6-theme-${theme}`);
-  loadHighlightTheme(theme);
-};
-
-/**
- * A React component that provides a dropdown item to toggle between dark and light themes.
- * The user's theme preference is stored in localStorage and applied to the document.
- * @returns {React.FC} The rendered component.
+ * A dropdown item that toggles between dark and light themes.
+ * Theme state is owned by useTheme; this component is a pure UI trigger.
  */
 export const DarkmodeOption: React.FC = () => {
-  const [theme, setTheme] = useState<string>(getThemePreference() || "light");
-
-  useEffect(() => {
-    setThemePreference(theme);
-  }, [theme]);
+  const { theme, setTheme } = useTheme();
 
   const toggleTheme = () => {
-    const newTheme = theme === "dark" ? "light" : "dark";
-
-    setTheme(newTheme);
+    setTheme(theme === "dark" ? "light" : "dark");
   };
 
   return (

--- a/src/UI/Components/DarkmodeOption/index.ts
+++ b/src/UI/Components/DarkmodeOption/index.ts
@@ -1,1 +1,2 @@
 export * from "./DarkmodeOption";
+export * from "./useTheme";

--- a/src/UI/Components/DarkmodeOption/useTheme.test.ts
+++ b/src/UI/Components/DarkmodeOption/useTheme.test.ts
@@ -1,0 +1,213 @@
+import { renderHook, act } from "@testing-library/react";
+import { getThemePreference, setThemePreference, useTheme } from "./useTheme";
+
+// Dynamic CSS imports in loadHighlightTheme are fire-and-forget side effects.
+// Mock them so they don't cause "unknown module" errors in the test environment.
+vi.mock("highlight.js/styles/github-dark-dimmed.css", () => ({}));
+vi.mock("highlight.js/styles/github.css", () => ({}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const setSystemDarkMode = (dark: boolean) => {
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches: dark && query === "(prefers-color-scheme: dark)",
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+  }));
+};
+
+const getThemeAttr = () => document.documentElement.getAttribute("data-theme");
+
+// ---------------------------------------------------------------------------
+// getThemePreference
+// ---------------------------------------------------------------------------
+
+describe("getThemePreference", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    setSystemDarkMode(false);
+  });
+
+  it("returns 'dark' when localStorage contains 'dark'", () => {
+    localStorage.setItem("theme-preference", "dark");
+    expect(getThemePreference()).toBe("dark");
+  });
+
+  it("returns 'light' when localStorage contains 'light'", () => {
+    localStorage.setItem("theme-preference", "light");
+    expect(getThemePreference()).toBe("light");
+  });
+
+  it("falls back to system dark preference when localStorage is empty", () => {
+    setSystemDarkMode(true);
+    expect(getThemePreference()).toBe("dark");
+  });
+
+  it("falls back to system light preference when localStorage is empty", () => {
+    setSystemDarkMode(false);
+    expect(getThemePreference()).toBe("light");
+  });
+
+  it("ignores invalid localStorage values and falls back to system preference", () => {
+    localStorage.setItem("theme-preference", "blue");
+    setSystemDarkMode(false);
+    expect(getThemePreference()).toBe("light");
+  });
+
+  it("localStorage takes priority over system preference", () => {
+    localStorage.setItem("theme-preference", "light");
+    setSystemDarkMode(true); // system says dark, but localStorage says light
+    expect(getThemePreference()).toBe("light");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// setThemePreference
+// ---------------------------------------------------------------------------
+
+describe("setThemePreference", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.removeAttribute("data-theme");
+  });
+
+  it("persists the theme to localStorage", () => {
+    setThemePreference("dark");
+    expect(localStorage.getItem("theme-preference")).toBe("dark");
+  });
+
+  it("sets data-theme to 'dark' on <html>", () => {
+    setThemePreference("dark");
+    expect(getThemeAttr()).toBe("dark");
+  });
+
+  it("sets data-theme to 'light' on <html>", () => {
+    setThemePreference("light");
+    expect(getThemeAttr()).toBe("light");
+  });
+
+  it("overwrites the previous data-theme when switching themes", () => {
+    setThemePreference("dark");
+    setThemePreference("light");
+    expect(getThemeAttr()).toBe("light");
+  });
+
+  it("keeps data-theme in sync with localStorage across multiple switches", () => {
+    setThemePreference("dark");
+    setThemePreference("light");
+    setThemePreference("dark");
+
+    expect(localStorage.getItem("theme-preference")).toBe("dark");
+    expect(getThemeAttr()).toBe("dark");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// useTheme hook
+// ---------------------------------------------------------------------------
+
+describe("useTheme", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.removeAttribute("data-theme");
+    setSystemDarkMode(false);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("initializes as light when no preference is stored and system is light", () => {
+    const { result } = renderHook(() => useTheme());
+
+    expect(result.current.isDark).toBe(false);
+    expect(result.current.theme).toBe("light");
+  });
+
+  it("initializes as dark when localStorage contains 'dark'", () => {
+    localStorage.setItem("theme-preference", "dark");
+    const { result } = renderHook(() => useTheme());
+
+    expect(result.current.isDark).toBe(true);
+    expect(result.current.theme).toBe("dark");
+  });
+
+  it("initializes as dark when system preference is dark", () => {
+    setSystemDarkMode(true);
+    const { result } = renderHook(() => useTheme());
+
+    expect(result.current.isDark).toBe(true);
+    expect(result.current.theme).toBe("dark");
+  });
+
+  it("setTheme persists to localStorage and updates data-theme", () => {
+    const { result } = renderHook(() => useTheme());
+
+    act(() => {
+      result.current.setTheme("dark");
+    });
+
+    expect(localStorage.getItem("theme-preference")).toBe("dark");
+    expect(getThemeAttr()).toBe("dark");
+  });
+
+  it("setTheme updates isDark and theme via MutationObserver", async () => {
+    const { result } = renderHook(() => useTheme());
+
+    expect(result.current.isDark).toBe(false);
+
+    await act(async () => {
+      result.current.setTheme("dark");
+    });
+
+    expect(result.current.isDark).toBe(true);
+    expect(result.current.theme).toBe("dark");
+  });
+
+  it("toggles back from dark to light", async () => {
+    localStorage.setItem("theme-preference", "dark");
+    const { result } = renderHook(() => useTheme());
+
+    expect(result.current.isDark).toBe(true);
+
+    await act(async () => {
+      result.current.setTheme("light");
+    });
+
+    expect(result.current.isDark).toBe(false);
+    expect(result.current.theme).toBe("light");
+  });
+
+  it("reacts to setThemePreference calls made outside the hook", async () => {
+    const { result } = renderHook(() => useTheme());
+
+    expect(result.current.isDark).toBe(false);
+
+    await act(async () => {
+      setThemePreference("dark"); // simulates Root.tsx or any other external caller
+    });
+
+    expect(result.current.isDark).toBe(true);
+    expect(result.current.theme).toBe("dark");
+  });
+
+  it("disconnects the MutationObserver on unmount", () => {
+    const disconnectSpy = vi.spyOn(MutationObserver.prototype, "disconnect");
+    const { unmount } = renderHook(() => useTheme());
+
+    unmount();
+
+    expect(disconnectSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("exposes a stable setTheme reference across re-renders", () => {
+    const { result, rerender } = renderHook(() => useTheme());
+    const firstSetTheme = result.current.setTheme;
+
+    rerender();
+
+    expect(result.current.setTheme).toBe(firstSetTheme);
+  });
+});

--- a/src/UI/Components/DarkmodeOption/useTheme.ts
+++ b/src/UI/Components/DarkmodeOption/useTheme.ts
@@ -1,0 +1,99 @@
+import { useCallback, useEffect, useState } from "react";
+
+const STORAGE_KEY = "theme-preference";
+
+/**
+ * Framework-agnostic attribute set on <html> to signal the active theme.
+ * The MutationObserver watches this instead of any UI-library-specific class,
+ * so the reactive hook stays stable across PatternFly version upgrades.
+ */
+const THEME_ATTR = "data-theme";
+
+/**
+ * PatternFly-specific class names applied alongside data-theme.
+ * When upgrading PatternFly, only these two constants need updating.
+ */
+const PF_DARK_CLASS = "pf-v6-theme-dark";
+const PF_LIGHT_CLASS = "pf-v6-theme-light";
+
+/**
+ * Retrieves the user's theme preference from localStorage or the system's color scheme.
+ * @returns {"dark" | "light"} The resolved theme preference.
+ */
+export const getThemePreference = (): "dark" | "light" => {
+  const stored = localStorage.getItem(STORAGE_KEY);
+
+  if (stored === "dark" || stored === "light") {
+    return stored;
+  }
+
+  return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+};
+
+const loadHighlightTheme = (theme: "dark" | "light"): void => {
+  // Dynamically import the appropriate highlight.js theme.
+  // We intentionally don't await these imports: they load CSS side effects.
+  if (theme === "dark") {
+    void import("highlight.js/styles/github-dark-dimmed.css");
+  } else {
+    void import("highlight.js/styles/github.css");
+  }
+};
+
+/**
+ * Persists the theme preference to localStorage, sets the framework-agnostic
+ * data-theme attribute on <html>, applies the PatternFly theme class, and loads
+ * the matching highlight.js CSS.
+ *
+ * To upgrade PatternFly: update PF_DARK_CLASS / PF_LIGHT_CLASS above — nothing else changes.
+ *
+ * @param {"dark" | "light"} theme - The theme to apply.
+ */
+export const setThemePreference = (theme: "dark" | "light"): void => {
+  localStorage.setItem(STORAGE_KEY, theme);
+  // Stable, framework-agnostic signal — observed by useTheme's MutationObserver.
+  document.documentElement.setAttribute(THEME_ATTR, theme);
+  // PatternFly requires its own class on <html> to apply dark styles.
+  document.documentElement.classList.remove(PF_DARK_CLASS, PF_LIGHT_CLASS);
+  document.documentElement.classList.add(theme === "dark" ? PF_DARK_CLASS : PF_LIGHT_CLASS);
+  loadHighlightTheme(theme);
+};
+
+/**
+ * Reactively tracks and controls the application's dark/light theme.
+ *
+ * Subscribes to changes of the data-theme attribute on <html> via a MutationObserver
+ * so all return values update immediately when the theme is toggled — no page reload
+ * required. Watching data-theme (not the PF class) keeps the hook decoupled from
+ * PatternFly version-specific class names.
+ *
+ * @returns {{ isDark: boolean, theme: "dark" | "light", setTheme: (theme: "dark" | "light") => void }}
+ */
+export const useTheme = (): {
+  isDark: boolean;
+  theme: "dark" | "light";
+  setTheme: (theme: "dark" | "light") => void;
+} => {
+  const [isDark, setIsDark] = useState(() => getThemePreference() === "dark");
+
+  useEffect(() => {
+    const observer = new MutationObserver(() => {
+      setIsDark(getThemePreference() === "dark");
+    });
+
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: [THEME_ATTR],
+    });
+
+    return () => observer.disconnect();
+  }, []);
+
+  const setTheme = useCallback((theme: "dark" | "light"): void => {
+    setThemePreference(theme);
+    // The MutationObserver above picks up the data-theme change and updates
+    // isDark automatically — no manual setState needed here.
+  }, []);
+
+  return { isDark, theme: isDark ? "dark" : "light", setTheme };
+};

--- a/src/UI/Components/DarkmodeOption/useTheme.ts
+++ b/src/UI/Components/DarkmodeOption/useTheme.ts
@@ -1,5 +1,9 @@
 import { useCallback, useEffect, useState } from "react";
 
+/** Application theme variant. */
+type Theme = "dark" | "light";
+
+/** localStorage key for the persisted theme preference. */
 const STORAGE_KEY = "theme-preference";
 
 /**
@@ -18,9 +22,9 @@ const PF_LIGHT_CLASS = "pf-v6-theme-light";
 
 /**
  * Retrieves the user's theme preference from localStorage or the system's color scheme.
- * @returns {"dark" | "light"} The resolved theme preference.
+ * @returns {Theme} The resolved theme preference.
  */
-export const getThemePreference = (): "dark" | "light" => {
+export const getThemePreference = (): Theme => {
   const stored = localStorage.getItem(STORAGE_KEY);
 
   if (stored === "dark" || stored === "light") {
@@ -30,7 +34,7 @@ export const getThemePreference = (): "dark" | "light" => {
   return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
 };
 
-const loadHighlightTheme = (theme: "dark" | "light"): void => {
+const loadHighlightTheme = (theme: Theme): void => {
   // Dynamically import the appropriate highlight.js theme.
   // We intentionally don't await these imports: they load CSS side effects.
   if (theme === "dark") {
@@ -47,9 +51,9 @@ const loadHighlightTheme = (theme: "dark" | "light"): void => {
  *
  * To upgrade PatternFly: update PF_DARK_CLASS / PF_LIGHT_CLASS above — nothing else changes.
  *
- * @param {"dark" | "light"} theme - The theme to apply.
+ * @param {Theme} theme - The theme to apply.
  */
-export const setThemePreference = (theme: "dark" | "light"): void => {
+export const setThemePreference = (theme: Theme): void => {
   localStorage.setItem(STORAGE_KEY, theme);
   // Stable, framework-agnostic signal — observed by useTheme's MutationObserver.
   document.documentElement.setAttribute(THEME_ATTR, theme);
@@ -67,12 +71,12 @@ export const setThemePreference = (theme: "dark" | "light"): void => {
  * required. Watching data-theme (not the PF class) keeps the hook decoupled from
  * PatternFly version-specific class names.
  *
- * @returns {{ isDark: boolean, theme: "dark" | "light", setTheme: (theme: "dark" | "light") => void }}
+ * @returns {{ isDark: boolean, theme: Theme, setTheme: (theme: Theme) => void }}
  */
 export const useTheme = (): {
   isDark: boolean;
-  theme: "dark" | "light";
-  setTheme: (theme: "dark" | "light") => void;
+  theme: Theme;
+  setTheme: (theme: Theme) => void;
 } => {
   const [isDark, setIsDark] = useState(() => getThemePreference() === "dark");
 
@@ -89,7 +93,7 @@ export const useTheme = (): {
     return () => observer.disconnect();
   }, []);
 
-  const setTheme = useCallback((theme: "dark" | "light"): void => {
+  const setTheme = useCallback((theme: Theme): void => {
     setThemePreference(theme);
     // The MutationObserver above picks up the data-theme change and updates
     // isDark automatically — no manual setState needed here.

--- a/src/UI/Components/DesiredStateAttributes/AttributeList.tsx
+++ b/src/UI/Components/DesiredStateAttributes/AttributeList.tsx
@@ -10,7 +10,7 @@ import { OutlinedQuestionCircleIcon } from "@patternfly/react-icons";
 import styled from "styled-components";
 import { TextWithCopy } from "@/UI/Components/TextWithCopy";
 import { CodeEditorCopyControl, CodeEditorHeightToggleControl } from "../CodeEditorControls";
-import { getThemePreference } from "../DarkmodeOption";
+import { useTheme } from "../DarkmodeOption";
 import { ClassifiedAttribute } from "./ClassifiedAttribute";
 import { FileBlock } from "./FileBlock";
 
@@ -46,6 +46,7 @@ const AttributeValue: React.FC<{
   variant?: AttributeTextVariant;
 }> = ({ attribute, variant }) => {
   const [isExpanded, setIsExpanded] = useState(false);
+  const { isDark } = useTheme();
 
   const getEditorHeight = (attribute: ClassifiedAttribute) => {
     return isExpanded ? "calc(100vh - 300px)" : getDefaultHeightEditor(attribute);
@@ -84,7 +85,7 @@ const AttributeValue: React.FC<{
         <CodeEditor
           key={`json-${isExpanded}`}
           isReadOnly
-          isDarkTheme={getThemePreference() === "dark"}
+          isDarkTheme={isDark}
           code={attribute.value}
           isLanguageLabelVisible
           language={Language.json}
@@ -108,7 +109,7 @@ const AttributeValue: React.FC<{
         <CodeEditor
           key={`xml-${isExpanded}`}
           isReadOnly
-          isDarkTheme={getThemePreference() === "dark"}
+          isDarkTheme={isDark}
           code={attribute.value}
           isLanguageLabelVisible
           language={Language.xml}
@@ -131,7 +132,7 @@ const AttributeValue: React.FC<{
         <CodeEditor
           key={`python-${isExpanded}`}
           isReadOnly
-          isDarkTheme={getThemePreference() === "dark"}
+          isDarkTheme={isDark}
           code={attribute.value}
           isLanguageLabelVisible
           language={Language.python}
@@ -154,7 +155,7 @@ const AttributeValue: React.FC<{
         <CodeEditor
           key={`code-${isExpanded}`}
           isReadOnly
-          isDarkTheme={getThemePreference() === "dark"}
+          isDarkTheme={isDark}
           code={attribute.value}
           isDownloadEnabled
           customControls={

--- a/src/UI/Components/JSONEditor/JSONEditor.tsx
+++ b/src/UI/Components/JSONEditor/JSONEditor.tsx
@@ -4,7 +4,7 @@ import { Spinner } from "@patternfly/react-core";
 
 import { useGetJSONSchema } from "@/Data/Queries";
 import { words } from "@/UI";
-import { getThemePreference } from "../DarkmodeOption";
+import { useTheme } from "../DarkmodeOption";
 import { ErrorMessageContainer } from "../ErrorMessageContainer";
 
 interface Props {
@@ -35,7 +35,7 @@ export const JSONEditor: React.FC<Props> = ({
   onChange,
   readOnly = false,
 }) => {
-  const preferedTheme = getThemePreference() || "light";
+  const { theme: preferedTheme } = useTheme();
 
   const [isLoading, setIsLoading] = useState(true);
   const [editorState, setEditorState] = useState<string>(data);

--- a/src/UI/Components/MarkdownContainer/MarkdownContainer.test.tsx
+++ b/src/UI/Components/MarkdownContainer/MarkdownContainer.test.tsx
@@ -3,9 +3,9 @@ import { words } from "@/UI/words";
 import { MarkdownContainer } from "./MarkdownContainer";
 import type { Mock } from "vitest";
 
-// Mock the theme function
+// Mock the theme hook
 vi.mock("../DarkmodeOption", () => ({
-  getThemePreference: vi.fn(() => "default"),
+  useTheme: vi.fn(() => ({ isDark: false, theme: "light", setTheme: vi.fn() })),
 }));
 
 describe("MarkdownContainer", () => {
@@ -82,8 +82,8 @@ describe("MarkdownContainer", () => {
   });
 
   it("applies theme configuration to Mermaid diagrams", async () => {
-    // Set up dark theme in DOM (the implementation checks document.documentElement.classList)
-    document.documentElement.classList.add("pf-v6-theme-dark");
+    // Set up dark theme in DOM (the implementation checks document.documentElement[data-theme])
+    document.documentElement.setAttribute("data-theme", "dark");
 
     // Import the mermaid mock and set up spies before rendering
     const mermaidMock = await import("mermaid");
@@ -117,12 +117,12 @@ describe("MarkdownContainer", () => {
     });
 
     // Clean up
-    document.documentElement.classList.remove("pf-v6-theme-dark");
+    document.documentElement.removeAttribute("data-theme");
   });
 
   it("uses default theme when no theme preference is set", async () => {
     // Ensure dark theme class is not present (the implementation checks document.documentElement.classList)
-    document.documentElement.classList.remove("pf-v6-theme-dark");
+    document.documentElement.removeAttribute("data-theme");
 
     // Import the mermaid mock and set up spies before rendering
     const mermaidMock = await import("mermaid");

--- a/src/UI/Components/MarkdownContainer/MarkdownContainer.tsx
+++ b/src/UI/Components/MarkdownContainer/MarkdownContainer.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useMemo, useRef } from "react";
 import hljs from "highlight.js";
 import markdownit from "markdown-it";
 import { full } from "markdown-it-emoji";
-import { getThemePreference } from "../DarkmodeOption";
+import { useTheme } from "../DarkmodeOption";
 import { renderMermaidBlocks } from "./MermaidHelpers";
 import mermaidPlugin from "./MermaidPlugin";
 import setStatePlugin from "./StateTransferPlugin";
@@ -44,7 +44,7 @@ export const MarkdownContainer: React.FC<Props> = ({
   onSetStateClick,
   isVisible = true,
 }) => {
-  const theme = getThemePreference() || "default";
+  const { theme } = useTheme();
   const containerRef = useRef<HTMLDivElement>(null);
   const lastProcessedText = useRef<string>("");
 

--- a/src/UI/Components/MarkdownContainer/MermaidHelpers.ts
+++ b/src/UI/Components/MarkdownContainer/MermaidHelpers.ts
@@ -167,7 +167,7 @@ export function renderMermaidBlocks(
     return;
   }
 
-  const isDarkTheme = document.documentElement.classList.contains("pf-v6-theme-dark");
+  const isDarkTheme = document.documentElement.getAttribute("data-theme") === "dark";
 
   (Mermaid as any).initialize({
     startOnLoad: false,

--- a/src/UI/Components/ServiceInstanceForm/Components/DictFieldInput/DictFieldInput.tsx
+++ b/src/UI/Components/ServiceInstanceForm/Components/DictFieldInput/DictFieldInput.tsx
@@ -3,6 +3,7 @@ import { CodeEditor, Language } from "@patternfly/react-code-editor";
 import { FormGroup, FormHelperText, HelperText, HelperTextItem } from "@patternfly/react-core";
 import { DictField } from "@/Core";
 import { words } from "@/UI";
+import { getThemePreference } from "@/UI/Components/DarkmodeOption";
 import { DictValue, toDict, toText } from "./helpers";
 
 interface Props {
@@ -77,6 +78,7 @@ export const DictFieldInput: React.FC<Props> = ({ field, value, onChange, readOn
         isReadOnly={readOnly}
         isLineNumbersVisible={false}
         isHeaderPlain
+        isDarkTheme={getThemePreference() === "dark"}
         options={{ scrollBeyondLastLine: false, folding: false }}
         onEditorDidMount={handleEditorDidMount}
         onChange={readOnly ? undefined : handleChange}

--- a/src/UI/Components/ServiceInstanceForm/Components/DictFieldInput/DictFieldInput.tsx
+++ b/src/UI/Components/ServiceInstanceForm/Components/DictFieldInput/DictFieldInput.tsx
@@ -3,7 +3,7 @@ import { CodeEditor, Language } from "@patternfly/react-code-editor";
 import { FormGroup, FormHelperText, HelperText, HelperTextItem } from "@patternfly/react-core";
 import { DictField } from "@/Core";
 import { words } from "@/UI";
-import { getThemePreference } from "@/UI/Components/DarkmodeOption";
+import { useTheme } from "@/UI/Components/DarkmodeOption";
 import { DictValue, toDict, toText } from "./helpers";
 
 interface Props {
@@ -32,6 +32,7 @@ export const DictFieldInput: React.FC<Props> = ({ field, value, onChange, readOn
   const [text, setText] = useState<string>(() => toText(value));
   const [isInvalid, setIsInvalid] = useState(false);
   const [height, setHeight] = useState(100);
+  const { isDark } = useTheme();
 
   // Tracks the serialized form of the last value we emitted via onChange so we
   // can distinguish a parent re-render carrying our own round-tripped value from
@@ -78,7 +79,7 @@ export const DictFieldInput: React.FC<Props> = ({ field, value, onChange, readOn
         isReadOnly={readOnly}
         isLineNumbersVisible={false}
         isHeaderPlain
-        isDarkTheme={getThemePreference() === "dark"}
+        isDarkTheme={isDark}
         options={{ scrollBeyondLastLine: false, folding: false }}
         onEditorDidMount={handleEditorDidMount}
         onChange={readOnly ? undefined : handleChange}


### PR DESCRIPTION
# Description

I know this PR was somewhat out of scope for this ticket but I found these changes to be very necessary for longterm health of the console. 
I will explain what actually happened:

1) I fixed the bug whereby editor content color didn't change immediately into the requested theme. 
In this case DictField but there were some other components that needed this changes as well.
2) Made a useTheme hook to collect all theming logic from the console so it could be used throughout.
3) Adjusted unit tests where needed.

These changes mainly were needed because of the bug of the code editor but also some added benefits now are:

- Improved tests
- Consistent logic, 1 source of truth 
=> useful because of upgrades to PatternFly which might break the current implementation for example.

So all in all not too much work for quite a good change in my opinion.
If you want I can as well adjust the ticket linked to this PR?

closes https://github.com/inmanta/web-console/issues/6948

<img width="493" height="178" alt="Screenshot 2026-06-08 at 11 59 13" src="https://github.com/user-attachments/assets/45d49bea-57a6-4da6-b900-69b80dac3a4c" />
