### PR TITLE
Fix heading-order axe violation in toast alerts

### DIFF
--- a/changelogs/unreleased/6785-toast-alert-heading-order.yml
+++ b/changelogs/unreleased/6785-toast-alert-heading-order.yml
@@ -1,0 +1,5 @@
+description: Fix heading-order axe violation in toast alerts by rendering the title as a div instead of h4
+issue-nr: 6785
+change-type: patch
+destination-branches: [master, iso9]
+sections: {}

--- a/src/Slices/Status/UI/Page.test.tsx
+++ b/src/Slices/Status/UI/Page.test.tsx
@@ -208,7 +208,7 @@ describe("StatusPage", () => {
     expect(within(errorContainer).getByText("error")).toBeVisible();
 
     await act(async () => {
-      const results = await axe(document.body, {});
+      const results = await axe(document.body);
 
       expect(results).toHaveNoViolations();
     });

--- a/src/Slices/Status/UI/Page.test.tsx
+++ b/src/Slices/Status/UI/Page.test.tsx
@@ -208,12 +208,7 @@ describe("StatusPage", () => {
     expect(within(errorContainer).getByText("error")).toBeVisible();
 
     await act(async () => {
-      const results = await axe(document.body, {
-        // See ticket #6785
-        rules: {
-          "heading-order": { enabled: false },
-        },
-      });
+      const results = await axe(document.body, {});
 
       expect(results).toHaveNoViolations();
     });

--- a/src/UI/Root/Components/AppAlertProvider/AppAlertProvider.tsx
+++ b/src/UI/Root/Components/AppAlertProvider/AppAlertProvider.tsx
@@ -83,6 +83,7 @@ export const AppAlertProvider: React.FC<PropsWithChildren> = ({ children }) => {
         {alerts?.map(({ id, ...rest }) => (
           <AppAlertComponent
             key={id}
+            component="div"
             //custom but can be overwritten
             timeout={8000}
             onClose={() => remove(id)}


### PR DESCRIPTION
# Description

Toast alerts in `AppAlertProvider` rendered their title as `h4` (PatternFly's default), which caused an axe `heading-order` violation when the page already had an `h1`. Fixed by setting `component="div"` on toast alerts — the title is not a document heading, and the live region already handles screen reader announcements. The suppression rule in the Status page test is removed.

closes https://github.com/inmanta/web-console/issues/6785
