### PR TITLE
Dependabot configuration grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,3 +19,10 @@ updates:
     ignore:
       - dependency-name: "madge"
         update-types: ["version-update:semver-major"]
+    groups:
+      patternfly:
+        patterns:
+          - "@patternfly/*"
+      jointjs:
+        patterns:
+          - "@joint/*"

--- a/changelogs/unreleased/group-dependabot-config.yml
+++ b/changelogs/unreleased/group-dependabot-config.yml
@@ -1,0 +1,3 @@
+description: Dependabot configuration has been updated to group updates for PatternFly and JointJS dependencies together.
+change-type: patch
+destination-branches: [master]


### PR DESCRIPTION
# Description

New attempt to group dependencies for the automatic dependabot updates. 
for more documentation about the groupings: see: https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#groups--
