### PR TITLE
Fix heading-order axe violation in toast alerts (#6962)

### DIFF
--- a/changelogs/unreleased/6785-toast-alert-heading-order.yml
+++ b/changelogs/unreleased/6785-toast-alert-heading-order.yml
@@ -1,0 +1,5 @@
+description: Fix heading-order axe violation in toast alerts by rendering the title as a div instead of h4
+issue-nr: 6785
+change-type: patch
+destination-branches: [master, iso9]
+sections: {}

--- a/src/Slices/Status/UI/Page.test.tsx
+++ b/src/Slices/Status/UI/Page.test.tsx
@@ -208,12 +208,7 @@ describe("StatusPage", () => {
     expect(within(errorContainer).getByText("error")).toBeVisible();
 
     await act(async () => {
-      const results = await axe(document.body, {
-        // See ticket #6785
-        rules: {
-          "heading-order": { enabled: false },
-        },
-      });
+      const results = await axe(document.body);
 
       expect(results).toHaveNoViolations();
     });

--- a/src/UI/Root/Components/AppAlertProvider/AppAlertProvider.tsx
+++ b/src/UI/Root/Components/AppAlertProvider/AppAlertProvider.tsx
@@ -83,6 +83,7 @@ export const AppAlertProvider: React.FC<PropsWithChildren> = ({ children }) => {
         {alerts?.map(({ id, ...rest }) => (
           <AppAlertComponent
             key={id}
+            component="div"
             //custom but can be overwritten
             timeout={8000}
             onClose={() => remove(id)}


### PR DESCRIPTION
Pull request opened by the merge tool on behalf of #6962