### PR TITLE
Replace purged and isDeploying Switch filters with OptionalToggleGroup

### DIFF
--- a/changelogs/unreleased/6970-purged-isdeploying-toggle-group.yml
+++ b/changelogs/unreleased/6970-purged-isdeploying-toggle-group.yml
@@ -1,0 +1,6 @@
+description: The "purged" and "isDeploying" Switch filters on the Resources page have been replaced with the ToggleButtonGroup for boolean filters, adding include/exclude support.
+issue-nr: 6970
+change-type: patch
+destination-branches: [master, iso9]
+sections:
+  minor-improvement: "{{description}}"

--- a/cypress/e2e/scenario-6-resources.cy.js
+++ b/cypress/e2e/scenario-6-resources.cy.js
@@ -387,7 +387,7 @@ describe("Scenario 6 : Resources", () => {
 
       // Purged filter
       cy.get("button").contains("Resource").click();
-      cy.get('label[for="purged"]').click();
+      cy.get("#purged-include").click();
       expectFilteredLessThan("initialRowCount");
       cy.get('[aria-label="Close purged"]').click();
       expectRowCountRestored("initialRowCount");
@@ -420,7 +420,7 @@ describe("Scenario 6 : Resources", () => {
       expectRowCountRestored("initialRowCount");
 
       // Is Deploying toggle filter
-      cy.get('label[for="is-deploying"]').click();
+      cy.get("#isDeploying-include").click();
       expectFilteredLessThan("initialRowCount");
       cy.get('[aria-label="Close isDeploying"]').click();
       expectRowCountRestored("initialRowCount");

--- a/src/Slices/Resource/UI/ResourcesPage/Components/FilterWidget/FilterWidgetComponent.test.tsx
+++ b/src/Slices/Resource/UI/ResourcesPage/Components/FilterWidget/FilterWidgetComponent.test.tsx
@@ -160,7 +160,7 @@ describe("FilterWidgetComponent", () => {
     expect(setFilter).toHaveBeenNthCalledWith(9, {});
   });
 
-  it("toggles the purged status via the switch in the resource tab", async () => {
+  it("toggles the purged status via the toggle button in the resource tab", async () => {
     const Wrapper = () => {
       const [filter, setFilter] = useState<Resource.Filter>({});
 
@@ -175,16 +175,22 @@ describe("FilterWidgetComponent", () => {
 
     renderWithDrawer(<Wrapper />);
 
-    const purgedSwitch = screen.getByRole("switch", {
-      name: words("resources.filters.desiredState.purged"),
-    });
+    const purgedInclude = screen.getByRole("button", { name: words("include") });
+    const purgedExclude = screen.getByRole("button", { name: words("exclude") });
 
-    expect(purgedSwitch).not.toBeChecked();
+    expect(purgedInclude).toHaveAttribute("aria-pressed", "false");
+    expect(purgedExclude).toHaveAttribute("aria-pressed", "false");
 
-    await userEvent.click(purgedSwitch);
-    expect(purgedSwitch).toBeChecked();
+    await userEvent.click(purgedInclude);
+    expect(purgedInclude).toHaveAttribute("aria-pressed", "true");
+    expect(purgedExclude).toHaveAttribute("aria-pressed", "false");
 
-    await userEvent.click(purgedSwitch);
-    expect(purgedSwitch).not.toBeChecked();
+    await userEvent.click(purgedExclude);
+    expect(purgedInclude).toHaveAttribute("aria-pressed", "false");
+    expect(purgedExclude).toHaveAttribute("aria-pressed", "true");
+
+    await userEvent.click(purgedExclude);
+    expect(purgedInclude).toHaveAttribute("aria-pressed", "false");
+    expect(purgedExclude).toHaveAttribute("aria-pressed", "false");
   });
 });

--- a/src/Slices/Resource/UI/ResourcesPage/Components/FilterWidget/ResourceFilterForm.tsx
+++ b/src/Slices/Resource/UI/ResourcesPage/Components/FilterWidget/ResourceFilterForm.tsx
@@ -1,8 +1,9 @@
 import { useMemo, useState } from "react";
-import { Stack, StackItem, Switch, Title } from "@patternfly/react-core";
+import { FormGroup, Stack, StackItem, Title } from "@patternfly/react-core";
 import { Resource } from "@/Core";
 import { useGetAgents } from "@/Data/Queries";
 import { useDebounce } from "@/UI";
+import { OptionalToggleGroup } from "@/UI/Components";
 import { words } from "@/UI/words";
 import { AddableSelectInput, SelectOption } from "./AddableSelectInput";
 import { AddableTextInput } from "./AddableTextInput";
@@ -56,14 +57,6 @@ export const ResourceFilterForm: React.FC<ResourceFilterFormProps> = ({
       }))
     );
   }, [data]);
-
-  const handlePurgedChange = (hasChanged: boolean) => {
-    const current = filter.status ?? [];
-
-    const updated = hasChanged ? [...current, "purged"] : current.filter((s) => s !== "purged");
-
-    onChangeStatus(updated);
-  };
 
   return (
     <>
@@ -129,12 +122,24 @@ export const ResourceFilterForm: React.FC<ResourceFilterFormProps> = ({
           </Title>
         </StackItem>
         <StackItem>
-          <Switch
-            id="purged"
-            label={words("resources.filters.desiredState.purged")}
-            isChecked={filter.status?.includes("purged") ?? false}
-            onChange={(_event, hasChanged) => handlePurgedChange(hasChanged)}
-          />
+          <FormGroup label={words("resources.filters.desiredState.purged")}>
+            <OptionalToggleGroup
+              selected={filter.status ?? []}
+              onChange={onChangeStatus}
+              options={[
+                {
+                  label: words("include"),
+                  value: "purged",
+                  buttonId: "purged-include",
+                },
+                {
+                  label: words("exclude"),
+                  value: "!purged",
+                  buttonId: "purged-exclude",
+                },
+              ]}
+            />
+          </FormGroup>
         </StackItem>
       </Stack>
     </>

--- a/src/Slices/Resource/UI/ResourcesPage/Components/FilterWidget/StatusFilterSelect.test.tsx
+++ b/src/Slices/Resource/UI/ResourcesPage/Components/FilterWidget/StatusFilterSelect.test.tsx
@@ -172,17 +172,27 @@ describe("StatusFilterSelect", () => {
     expect(blockedExcludeActive).toBeVisible();
   });
 
-  it("toggles the isDeploying switch on and off", async () => {
-    render(<StatusFilterHarness />);
+  it("isDeploying toggles are mutually exclusive and deselecting clears the filter", async () => {
+    render(<StatusFilterHarness initial={["!isDeploying"]} />);
 
-    const isDeployingSwitch = screen.getByRole("switch", { name: "Is Deploying" });
-    expect(isDeployingSwitch).not.toBeChecked();
+    // Initial state: Exclude active
+    expect(document.getElementById("isDeploying-include")).toHaveAttribute("aria-pressed", "false");
+    expect(document.getElementById("isDeploying-exclude")).toHaveAttribute("aria-pressed", "true");
 
-    await userEvent.click(isDeployingSwitch);
-    expect(isDeployingSwitch).toBeChecked();
+    // Selecting Include clears Exclude
+    await userEvent.click(getById("isDeploying-include"));
+    expect(document.getElementById("isDeploying-include")).toHaveAttribute("aria-pressed", "true");
+    expect(document.getElementById("isDeploying-exclude")).toHaveAttribute("aria-pressed", "false");
 
-    await userEvent.click(isDeployingSwitch);
-    expect(isDeployingSwitch).not.toBeChecked();
+    // Selecting Exclude clears Include
+    await userEvent.click(getById("isDeploying-exclude"));
+    expect(document.getElementById("isDeploying-include")).toHaveAttribute("aria-pressed", "false");
+    expect(document.getElementById("isDeploying-exclude")).toHaveAttribute("aria-pressed", "true");
+
+    // Clicking the active toggle deselects it — no filter
+    await userEvent.click(getById("isDeploying-exclude"));
+    expect(document.getElementById("isDeploying-include")).toHaveAttribute("aria-pressed", "false");
+    expect(document.getElementById("isDeploying-exclude")).toHaveAttribute("aria-pressed", "false");
   });
 
   it("orphaned toggles are mutually exclusive and deselecting clears the filter", async () => {

--- a/src/Slices/Resource/UI/ResourcesPage/Components/FilterWidget/StatusFilterSelect.tsx
+++ b/src/Slices/Resource/UI/ResourcesPage/Components/FilterWidget/StatusFilterSelect.tsx
@@ -1,4 +1,4 @@
-import { FormGroup, Stack, StackItem, Switch } from "@patternfly/react-core";
+import { FormGroup, Stack, StackItem } from "@patternfly/react-core";
 import { Resource, toggleValueInList } from "@/Core";
 import { uniq } from "@/Core/Language/collection";
 import { OptionalToggleGroup } from "@/UI/Components";
@@ -27,14 +27,6 @@ export const StatusFilterSelect: React.FC<StatusFilterSelectProps> = ({
     const currentStatuses = selectedStatuses ?? [];
     const safeSelectedStates = removeInvertedSelection(selection, currentStatuses);
     const updatedSelection = uniq(toggleValueInList(selection, safeSelectedStates));
-    onChange(updatedSelection);
-  };
-
-  const handleIsDeploying = (hasChanged: boolean) => {
-    const currentStatuses = selectedStatuses ?? [];
-    const updatedSelection = hasChanged
-      ? [...currentStatuses, "isDeploying"]
-      : currentStatuses.filter((s) => s !== "isDeploying");
     onChange(updatedSelection);
   };
 
@@ -80,12 +72,12 @@ export const StatusFilterSelect: React.FC<StatusFilterSelectProps> = ({
             onChange={onChange}
             options={[
               {
-                label: words("resources.filters.status.orphaned.include"),
+                label: words("include"),
                 value: "orphaned",
                 buttonId: "orphaned-include",
               },
               {
-                label: words("resources.filters.status.orphaned.exclude"),
+                label: words("exclude"),
                 value: "!orphaned",
                 buttonId: "orphaned-exclude",
               },
@@ -94,12 +86,24 @@ export const StatusFilterSelect: React.FC<StatusFilterSelectProps> = ({
         </FormGroup>
       </StackItem>
       <StackItem>
-        <Switch
-          id="is-deploying"
-          label={words("resources.filters.status.isDeploying")}
-          isChecked={selectedStatuses?.includes("isDeploying") ?? false}
-          onChange={(_event, hasChanged) => handleIsDeploying(hasChanged)}
-        />
+        <FormGroup label={words("resources.filters.status.isDeploying")}>
+          <OptionalToggleGroup
+            selected={selectedStatuses ?? []}
+            onChange={onChange}
+            options={[
+              {
+                label: words("include"),
+                value: "isDeploying",
+                buttonId: "isDeploying-include",
+              },
+              {
+                label: words("exclude"),
+                value: "!isDeploying",
+                buttonId: "isDeploying-exclude",
+              },
+            ]}
+          />
+        </FormGroup>
       </StackItem>
     </Stack>
   );

--- a/src/UI/words.tsx
+++ b/src/UI/words.tsx
@@ -54,6 +54,8 @@ const dict = {
   "success.title": "Success",
   "info.title": "Info",
   noResults: "No results found",
+  include: "Include",
+  exclude: "Exclude",
 
   /**
    * Error related text
@@ -563,8 +565,6 @@ const dict = {
   "resources.popover.requirements": "Requirements",
   "resources.filters.status.isDeploying": "Is Deploying",
   "resources.filters.status.orphaned.label": "Orphaned",
-  "resources.filters.status.orphaned.include": "Include",
-  "resources.filters.status.orphaned.exclude": "Exclude",
   "resources.filters.status.blocked.label": "Blocked state(s)",
   "resources.filters.status.blocked.placeholder": "Filter by blocked state",
   "resources.filters.status.compliance.label": "Compliance state(s)",


### PR DESCRIPTION
What happened in this PR:
- Purged and isDeploying switches were replaced by the new ToggleButtonGroup which makes it possible to include and exclude both of those statuses.
- Unit and e2e test adjustments.

Closes: https://github.com/inmanta/web-console/issues/6930

https://github.com/user-attachments/assets/76f9f02f-99ba-4ad3-9993-5c70ca7f5300