### PR TITLE
Buildmaster: manual sizeToFit on CodeEditors

### DIFF
--- a/changelogs/unreleased/buildmaster-post-pf-upgrade-conflicts.yml
+++ b/changelogs/unreleased/buildmaster-post-pf-upgrade-conflicts.yml
@@ -1,0 +1,4 @@
+description: On PF 6.5 the codeEditor sizeToFit is broken. Workaround was implemented to set the height manually.
+issue-nr: 6814
+change-type: patch
+destination-branches: [master]

--- a/src/UI/Components/DesiredStateAttributes/AttributeList.test.tsx
+++ b/src/UI/Components/DesiredStateAttributes/AttributeList.test.tsx
@@ -35,7 +35,7 @@ test("Given the getHeightEditor function When called with different attribute ty
         key: "jsonShort",
         value: '{\n  "name": "test",\n  "value": 123\n}',
       },
-      expected: "sizeToFit",
+      expected: "76px",
     },
     {
       type: "Json",
@@ -55,7 +55,7 @@ test("Given the getHeightEditor function When called with different attribute ty
         key: "xmlShort",
         value: "<root>\n  <element>value</element>\n</root>",
       },
-      expected: "sizeToFit",
+      expected: "57px",
     },
     {
       type: "Xml",
@@ -75,7 +75,7 @@ test("Given the getHeightEditor function When called with different attribute ty
         key: "pythonShort",
         value: "def hello():\n  print('Hello, world!')\n\nhello()",
       },
-      expected: "sizeToFit",
+      expected: "76px",
     },
     {
       type: "Python",
@@ -95,7 +95,7 @@ test("Given the getHeightEditor function When called with different attribute ty
         key: "codeShort",
         value: "function test() {\n  return true;\n}",
       },
-      expected: "sizeToFit",
+      expected: "57px",
     },
     {
       type: "Code",
@@ -115,7 +115,7 @@ test("Given the getHeightEditor function When called with different attribute ty
         key: "text",
         value: "This is just a regular text value",
       },
-      expected: "sizeToFit",
+      expected: "19px",
     },
   ];
 

--- a/src/UI/Components/DesiredStateAttributes/AttributeList.tsx
+++ b/src/UI/Components/DesiredStateAttributes/AttributeList.tsx
@@ -188,9 +188,16 @@ const TextContainer = styled.span<{ $variant?: AttributeTextVariant }>`
 `;
 
 /**
- * Determines the height for code editors based on content length
- * @param attribute The attribute to determine height for
- * @returns "300px" if lines > 15, otherwise "sizeToFit"
+ * Determines the height for code editors based on content length.
+ * Uses explicit px values instead of "sizeToFit" because PatternFly's sizeToFit
+ * calls editor.layout() but never updates the container's CSS height, leaving
+ * the container at 0px (invalid CSS value) while Monaco overflows it.
+ *
+ * Monaco line height: Math.round(GOLDEN_LINE_HEIGHT_RATIO * fontSize)
+ *   Windows/Linux: Math.round(1.35 * 14) = 19px
+ *   macOS:         Math.round(1.5  * 12) = 18px
+ * Using 19px covers both platforms (slightly tall on macOS — better than too short).
+ * The height prop targets the Monaco container only; the toolbar sits outside it.
  */
 export const getDefaultHeightEditor = (attribute: ClassifiedAttribute): string => {
   if (
@@ -200,9 +207,8 @@ export const getDefaultHeightEditor = (attribute: ClassifiedAttribute): string =
     attribute.kind === "Code"
   ) {
     const lineCount = attribute.value.split("\n").length;
-
-    return lineCount > 15 ? "300px" : "sizeToFit";
+    return `${Math.min(lineCount * 19, 300)}px`;
   }
 
-  return "sizeToFit";
+  return "19px";
 };

--- a/src/UI/Components/DesiredStateAttributes/AttributeList.tsx
+++ b/src/UI/Components/DesiredStateAttributes/AttributeList.tsx
@@ -207,6 +207,7 @@ export const getDefaultHeightEditor = (attribute: ClassifiedAttribute): string =
     attribute.kind === "Code"
   ) {
     const lineCount = attribute.value.split("\n").length;
+
     return `${Math.min(lineCount * 19, 300)}px`;
   }
 


### PR DESCRIPTION
# Description

Manually calculate the height based on amount of lines, capping at 300. Users can expand the full editor when needing more space to read the data.

A ticket was opened on PF repo to report the bug.

<img width="960" height="166" alt="image" src="https://github.com/user-attachments/assets/26d67c78-d514-4897-a2e4-51a85f50096d" />
