### PR TITLE
Allow a custom message on set state and expert set state actions

### DIFF
--- a/changelogs/unreleased/6931-setstate-message.yml
+++ b/changelogs/unreleased/6931-setstate-message.yml
@@ -1,0 +1,6 @@
+description: The set state and expert set state actions on a service instance now let you provide a custom message that is sent with the state transfer.
+issue-nr: 6931
+change-type: patch
+destination-branches: [master, iso9]
+sections:
+  minor-improvement: "{{description}}"

--- a/cypress/e2e/scenario-2.4-expert-mode.cy.js
+++ b/cypress/e2e/scenario-2.4-expert-mode.cy.js
@@ -81,6 +81,9 @@ if (isIso) {
       cy.get('[aria-label="Expert-Actions-Toggle"]').click();
       cy.get('[role="menuitem"]').contains("creating").click();
 
+      // provide a custom message for the state transfer
+      cy.get("#expert-state-transfer-message").clear().type("forced to creating from e2e");
+
       // add an operation to the force state action
       cy.get("#operation-select").select("clear candidate");
       cy.get("button").contains("Yes").click();

--- a/src/Slices/ServiceInstanceDetails/Test/InstanceActions.test.tsx
+++ b/src/Slices/ServiceInstanceDetails/Test/InstanceActions.test.tsx
@@ -1,5 +1,8 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { words } from "@/UI";
+import { instanceData } from "./mockData";
 import { defaultServer, serverFailedActions } from "./mockServer";
 import { setupServiceInstanceDetails } from "./mockSetup";
 
@@ -209,6 +212,92 @@ describe("Page Actions - Success", () => {
 
     expect(screen.queryByRole("dialog")).toBeNull();
     expect(screen.queryByTestId("error-toast-expert-state-message")).toBeNull();
+  });
+
+  it("Normal Instance Actions - sends the user provided message on state transfer", async () => {
+    let capturedBody: Record<string, unknown> | null = null;
+
+    server.use(
+      http.post("/lsm/v1/service_inventory/mobileCore/1d96a1ab/state", async ({ request }) => {
+        capturedBody = (await request.json()) as Record<string, unknown>;
+
+        return HttpResponse.json({ status: 200 });
+      })
+    );
+
+    render(setupServiceInstanceDetails());
+
+    expect(
+      await screen.findByRole("region", { name: "Instance-Details-Success" })
+    ).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "Actions-Toggle" }));
+    await userEvent.click(screen.getByRole("menuitem", { name: /update_start/i }));
+
+    // the message field is prefilled with the default console message
+    const messageField = screen.getByLabelText("state-transfer-message-input");
+
+    expect(messageField).toHaveValue(words("instanceDetails.API.message.update")(null));
+
+    // the user replaces it with a custom message
+    await userEvent.clear(messageField);
+    await userEvent.type(messageField, "Custom transfer reason");
+
+    await userEvent.click(screen.getByRole("button", { name: /yes/i }));
+
+    await waitFor(() => expect(capturedBody).not.toBeNull());
+
+    expect(capturedBody).toEqual({
+      message: "Custom transfer reason",
+      current_version: instanceData.version,
+      target_state: "update_start",
+    });
+  });
+
+  it("Expert actions - sends the user provided message on force state", async () => {
+    let capturedBody: Record<string, unknown> | null = null;
+
+    server.use(
+      http.post(
+        "/lsm/v1/service_inventory/mobileCore/1d96a1ab/expert/state",
+        async ({ request }) => {
+          capturedBody = (await request.json()) as Record<string, unknown>;
+
+          return HttpResponse.json({ status: 200 });
+        }
+      )
+    );
+
+    render(setupServiceInstanceDetails(true));
+
+    expect(
+      await screen.findByRole("region", { name: "Instance-Details-Success" })
+    ).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "Expert-Actions-Toggle" }));
+    await userEvent.click(screen.getByRole("menuitem", { name: "up" }));
+
+    // the message field is prefilled with the default console message
+    const messageField = screen.getByLabelText("expert-state-transfer-message-input");
+
+    expect(messageField).toHaveValue(words("instanceDetails.API.message.update")(null));
+
+    // the user provides a custom message and selects an operation
+    await userEvent.clear(messageField);
+    await userEvent.type(messageField, "Forcing back up");
+
+    await userEvent.selectOptions(screen.getByRole("combobox"), "clear candidate");
+
+    await userEvent.click(screen.getByRole("button", { name: /yes/i }));
+
+    await waitFor(() => expect(capturedBody).not.toBeNull());
+
+    expect(capturedBody).toEqual({
+      message: "Forcing back up",
+      current_version: instanceData.version,
+      target_state: "up",
+      operation: "clear candidate",
+    });
   });
 });
 

--- a/src/Slices/ServiceInstanceDetails/UI/Components/InstanceActions/Actions/ExpertStateTransfer.tsx
+++ b/src/Slices/ServiceInstanceDetails/UI/Components/InstanceActions/Actions/ExpertStateTransfer.tsx
@@ -6,6 +6,7 @@ import {
   FormGroup,
   FormSelect,
   FormSelectOption,
+  TextArea,
   Content,
   Spinner,
   Button,
@@ -137,7 +138,9 @@ const ModalContent: React.FC<ModalContentProps> = ({
   const { authHelper } = useContext(DependencyContext);
   const { notifyError } = useAppAlert();
   const username = authHelper.getUser();
-  const message = words("instanceDetails.API.message.update")(username);
+  const [message, setMessage] = useState<string>(
+    words("instanceDetails.API.message.update")(username)
+  );
 
   const { mutate, isError, error, isSuccess, isPending } = usePostExpertStateTransfer(
     instance_id,
@@ -200,6 +203,18 @@ const ModalContent: React.FC<ModalContentProps> = ({
               <FormSelectOption key={index} value={operation} label={operation} />
             ))}
           </FormSelect>
+        </FormGroup>
+        <FormGroup
+          label={words("instanceDetails.stateTransfer.messageLabel")}
+          fieldId="expert-state-transfer-message"
+        >
+          <TextArea
+            id="expert-state-transfer-message"
+            value={message}
+            onChange={(_event, value) => setMessage(value)}
+            aria-label="expert-state-transfer-message-input"
+            data-testid={`${instance_display_identity}-state-message`}
+          />
         </FormGroup>
       </Form>
       <br />

--- a/src/Slices/ServiceInstanceDetails/UI/Components/InstanceActions/Actions/StateTransferModalContent.tsx
+++ b/src/Slices/ServiceInstanceDetails/UI/Components/InstanceActions/Actions/StateTransferModalContent.tsx
@@ -1,5 +1,14 @@
-import React, { useCallback, useContext } from "react";
-import { Content, Button, Spinner, Flex, FlexItem } from "@patternfly/react-core";
+import React, { useCallback, useContext, useState } from "react";
+import {
+  Content,
+  Button,
+  Spinner,
+  Flex,
+  FlexItem,
+  Form,
+  FormGroup,
+  TextArea,
+} from "@patternfly/react-core";
 import { ParsedNumber } from "@/Core";
 import { usePostStateTransfer } from "@/Data/Queries";
 import { DependencyContext, words } from "@/UI";
@@ -30,6 +39,9 @@ export const StateTransferModalContent: React.FC<StateTransferModalContentProps>
   const username = authHelper.getUser();
   const { notifyError } = useAppAlert();
   const { closeModal } = useContext(ModalContext);
+  const [message, setMessage] = useState<string>(
+    words("instanceDetails.API.message.update")(username)
+  );
 
   const { mutate, isPending } = usePostStateTransfer(instance_id, service_entity, {
     onSuccess: () => {
@@ -49,8 +61,6 @@ export const StateTransferModalContent: React.FC<StateTransferModalContentProps>
    * @returns {Promise<void>} A Promise that resolves when the operation is complete.
    */
   const onSubmit = async (): Promise<void> => {
-    const message = words("instanceDetails.API.message.update")(username);
-
     mutate({
       message: message,
       current_version: version,
@@ -71,6 +81,20 @@ export const StateTransferModalContent: React.FC<StateTransferModalContentProps>
       <Content component="p">
         {words("inventory.statustab.confirmMessage")(instance_display_identity, targetState)}
       </Content>
+      <Form>
+        <FormGroup
+          label={words("instanceDetails.stateTransfer.messageLabel")}
+          fieldId="state-transfer-message"
+        >
+          <TextArea
+            id="state-transfer-message"
+            value={message}
+            onChange={(_event, value) => setMessage(value)}
+            aria-label="state-transfer-message-input"
+            data-testid={`${instance_display_identity}-state-message`}
+          />
+        </FormGroup>
+      </Form>
       <br />
       <Flex>
         <FlexItem>

--- a/src/UI/words.tsx
+++ b/src/UI/words.tsx
@@ -307,6 +307,7 @@ const dict = {
   "instanceDetails.setState.label": "Set state",
   "instanceDetails.forceState.label": "Force state",
   "instanceDetails.stateTransfer.confirmTitle": "Confirm set state transfer",
+  "instanceDetails.stateTransfer.messageLabel": "Message",
   "instanceDetails.expertActions": "Expert Actions",
   "instanceDetails.actions": "Actions",
   "instanceDetails.expert.transfer.options": "Select Operation",


### PR DESCRIPTION
# Description:

- Added an editable Message field to the set-state confirmation modal, prefilled with the default console message
- Added the same Message field to the expert force-state modal (alongside the operation select)
- Both modals now send the user-entered message in the state / expert/state request body instead of the hard-coded one
- Adjusted tests

Closes: https://github.com/inmanta/web-console/issues/6931

<img width="573" height="475" alt="Screenshot 2026-06-15 at 11 24 30" src="https://github.com/user-attachments/assets/c5b17372-7f4c-4d90-ba27-d486a0f7d0a5" />

<img width="590" height="284" alt="Screenshot 2026-06-15 at 11 24 37" src="https://github.com/user-attachments/assets/c806e9fd-a950-45fa-96e0-6d85de970667" />
