### PR TITLE
Remove unmodified filter option compliance/compare

### DIFF
--- a/changelogs/unreleased/6929-unmodified-filtering.yml
+++ b/changelogs/unreleased/6929-unmodified-filtering.yml
@@ -1,0 +1,6 @@
+description: Showing unmodified resources on the Compliance Check and Desired State Compare pages is no longer possible in the web-console.
+issue-nr: 6929
+change-type: minor
+destination-branches: [master, iso9]
+sections:
+  deprecation-note: "{{description}}"

--- a/cypress/e2e/scenario-4-desired-state.cy.js
+++ b/cypress/e2e/scenario-4-desired-state.cy.js
@@ -287,32 +287,6 @@ describe("Scenario 4 Desired State", () => {
     cy.get('[aria-label="ReportListSelect"]').contains("No Dry runs exist").should("be.visible");
     cy.get(".pf-v6-c-button").contains("Perform dry run").click();
 
-    cy.get('[aria-label="StatusFilter"]').click();
-    cy.get('[role="option"]').contains("unmodified").click();
-    cy.get('[aria-label="StatusFilter"]').click();
-
-    cy.get('[aria-label="DiffItemList"]', { timeout: 20000 }).should("be.visible");
-
-    // dynamically click all details rows
-    cy.get('[aria-label="Details"]', { timeout: 20000 })
-      .should("have.length", isIso ? 2 : 5)
-      .then(($details) => {
-        const detailsCount = $details.length;
-
-        $details.each((_i, el) => {
-          cy.wrap(el).click();
-        });
-
-        // dynamically assert expandable content matches number of details
-        cy.get(".pf-v6-c-card__expandable-content").should(($rows) => {
-          expect($rows.length).to.equal(detailsCount);
-
-          $rows.each((_i, row) => {
-            expect(row).to.have.text("This resource has not been modified.");
-          });
-        });
-      });
-
     // go back to desired state page
     cy.get('[aria-label="Sidebar-Navigation-Item"]').contains("Desired State").click();
 
@@ -333,30 +307,6 @@ describe("Scenario 4 Desired State", () => {
     // perform dry-run
     cy.get(".pf-v6-c-button").contains("Perform dry run").click();
 
-    cy.get('[aria-label="StatusFilter"]').click();
-    cy.get('[role="option"]').contains("unmodified").click();
-    cy.get('[aria-label="StatusFilter"]').click();
-
-    // dynamically expand all detail rows again
-    cy.get('[aria-label="Details"]', { timeout: 20000 })
-      .should("have.length", isIso ? 2 : 5)
-      .then(($details) => {
-        const detailsCount = $details.length;
-        $details.each((_i, el) => cy.wrap(el).click());
-
-        cy.get(".pf-v6-c-card__expandable-content").should(($rows) => {
-          expect($rows.length).to.equal(detailsCount);
-          $rows.each((_i, row) => expect(row).to.have.text("This resource has not been modified."));
-        });
-      });
-
-    // click on filter by status dropdown
-    cy.get('[aria-label="StatusFilter"]').click();
-
-    // uncheck unmodified option
-    cy.get('[role="option"]').contains("unmodified").click();
-    cy.get('[aria-label="StatusFilter"]').click();
-
     // go back to desired state
     cy.get('[aria-label="Sidebar-Navigation-Item"]').contains("Desired State").click();
 
@@ -365,30 +315,6 @@ describe("Scenario 4 Desired State", () => {
 
     // select again compare with current state
     cy.get('[role="menuitem"]').contains("Compare with current state").click();
-
-    cy.get('[aria-label="StatusFilter"]').click();
-    cy.get('[role="option"]').contains("unmodified").click();
-    cy.get('[aria-label="StatusFilter"]').click();
-
-    // dynamically expand all details inside DiffItemList
-    cy.get('[aria-label="DiffItemList"]', { timeout: 20000 }).within(() => {
-      cy.get('[aria-label="Details"]')
-        .should("have.length", isIso ? 2 : 5)
-        .then(($details) => {
-          const detailsCount = $details.length;
-
-          // click every Details row
-          $details.each((_i, el) => cy.wrap(el).click());
-
-          // dynamically assert expandable content matches number of details
-          cy.get(".pf-v6-c-card__expandable-content").should(($rows) => {
-            expect($rows.length).to.equal(detailsCount);
-            $rows.each((_i, row) => {
-              expect(row).to.have.text("This resource has not been modified.");
-            });
-          });
-        });
-    });
 
     // click on Perform dry run
     cy.get(".pf-v6-c-button").contains("Perform dry run").click();

--- a/cypress/e2e/scenario-5-compile-reports.cy.js
+++ b/cypress/e2e/scenario-5-compile-reports.cy.js
@@ -20,7 +20,9 @@ describe("5 Compile reports", () => {
     cy.get('[aria-label="Sidebar-Navigation-Item"]').contains("Compile Reports").click();
 
     // store initial row count
-    cy.get("tbody tr", { timeout: 30000 }).its("length").as("initialRowCount");
+    cy.get("tbody tr").then(($rows) => {
+      cy.wrap($rows.length).as("initialRowCount");
+    });
 
     // validate initial top row
     cy.get("tbody tr")
@@ -41,7 +43,7 @@ describe("5 Compile reports", () => {
 
     // verify a row was added
     cy.get("@initialRowCount").then((initialRowCount) => {
-      cy.get("tbody tr").should("have.length.at.least", initialRowCount + 1);
+      cy.get("tbody tr").should("have.length", initialRowCount + 1);
     });
 
     cy.get("tbody tr").first().should("contain", "Compile triggered from the console");
@@ -58,7 +60,7 @@ describe("5 Compile reports", () => {
 
     // First assert the table has grown by 1, ensuring the new row is present
     cy.get("@initialRowCount").then((initialRowCount) => {
-      cy.get("tbody tr").should("have.length", initialRowCount + 1);
+      cy.get("tbody tr", { timeout: 15000 }).should("have.length", initialRowCount + 2);
     });
 
     // Assert the new top row content

--- a/src/Slices/ComplianceCheck/UI/Page.test.tsx
+++ b/src/Slices/ComplianceCheck/UI/Page.test.tsx
@@ -203,9 +203,7 @@ describe("ComplianceCheck page", () => {
 
     const statusOptions = screen.getAllByRole("option");
 
-    expect(statusOptions).toHaveLength(7);
-
-    await userEvent.click(screen.getByRole("button", { name: words("showAll") }));
+    expect(statusOptions).toHaveLength(6);
 
     await userEvent.click(screen.getByRole("button", { name: words("hideAll") }));
 

--- a/src/Slices/DesiredStateCompare/UI/Page.test.tsx
+++ b/src/Slices/DesiredStateCompare/UI/Page.test.tsx
@@ -123,9 +123,7 @@ describe("DesiredStateCompare", () => {
 
     const statusOptions = screen.getAllByRole("option");
 
-    expect(statusOptions).toHaveLength(7);
-
-    await userEvent.click(screen.getByRole("button", { name: words("showAll") }));
+    expect(statusOptions).toHaveLength(6);
 
     await userEvent.click(screen.getByRole("button", { name: words("hideAll") }));
 

--- a/src/UI/Components/DiffWizard/DiffPageFilter/DiffPageFilter.test.tsx
+++ b/src/UI/Components/DiffWizard/DiffPageFilter/DiffPageFilter.test.tsx
@@ -18,6 +18,24 @@ describe("DiffPageFilter", () => {
     expect(container).toBeDefined();
   });
 
+  it("does not show unmodified as a filter option", () => {
+    render(
+      <DiffPageFilter
+        statuses={Diff.defaultStatuses}
+        setStatuses={() => {}}
+        setSearchFilter={() => {}}
+        searchFilter=""
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "StatusFilter" }));
+
+    expect(screen.queryByRole("option", { name: "unmodified" })).toBeNull();
+    Diff.defaultStatuses.forEach((status) => {
+      expect(screen.getByRole("option", { name: status })).toBeInTheDocument();
+    });
+  });
+
   it("updates search filter correctly", () => {
     const setSearchFilterMock = vi.fn();
 

--- a/src/UI/Components/DiffWizard/DiffPageFilter/DiffPageFilter.tsx
+++ b/src/UI/Components/DiffWizard/DiffPageFilter/DiffPageFilter.tsx
@@ -27,9 +27,9 @@ export const DiffPageFilter: React.FC<Props> = ({
   };
 
   const [allLabel, allCallback] =
-    statuses.length === Diff.statuses.length
+    statuses.length === Diff.defaultStatuses.length
       ? [words("hideAll"), () => setStatuses([])]
-      : [words("showAll"), () => setStatuses(Diff.statuses)];
+      : [words("showAll"), () => setStatuses(Diff.defaultStatuses)];
 
   return (
     <ToolbarGroup align={{ default: "alignStart" }}>
@@ -48,7 +48,7 @@ export const DiffPageFilter: React.FC<Props> = ({
               </Button>
             </MenuFooter>
           }
-          options={Diff.statuses.map((option: Diff.Status) => {
+          options={Diff.defaultStatuses.map((option: Diff.Status) => {
             return {
               value: option,
               children: option,


### PR DESCRIPTION
# Description

As requested, the option to show unmodified resources on the Compliance/Compare pages was removed. The API still can return those, which is why I did not remove the `unmodified` status from our typing and mock data. Since the filtering is client-side, we need the mockdata to be matching what the API could return to prevent regressions in the future.

Additionally, I resolved a flake in the e2e test of the compile reports where the table length tracking wasn't always consistently working as intended. 

closes :
- #6926 

<img width="329" height="374" alt="image" src="https://github.com/user-attachments/assets/832762b0-532f-4fb0-913e-e5e1421d2793" />
