### PR TITLE
Fixed an issue where the discovery resource URI was not correctly gen…

### DIFF
--- a/changelogs/unreleased/6963-bugfix-discovery-resource-uri.yml
+++ b/changelogs/unreleased/6963-bugfix-discovery-resource-uri.yml
@@ -1,0 +1,6 @@
+description: Fixed an issue where the discovery resource URI was not correctly generated, leading to failed API calls in certain scenarios.
+issue-nr: 6963
+change-type: patch
+destination-branches: [master, iso9, iso8]
+sections:
+  bugfix: "{{description}}"

--- a/changelogs/unreleased/6963-bugfix-discovery-resource-uri.yml
+++ b/changelogs/unreleased/6963-bugfix-discovery-resource-uri.yml
@@ -1,6 +1,6 @@
 description: Fixed an issue where the discovery resource URI was not correctly generated, leading to failed API calls in certain scenarios.
 issue-nr: 6963
 change-type: patch
-destination-branches: [master, iso9, iso8]
+destination-branches: [iso8]
 sections:
   bugfix: "{{description}}"

--- a/src/Data/Queries/Slices/DiscoveredResources/useGetDiscoveredResources.ts
+++ b/src/Data/Queries/Slices/DiscoveredResources/useGetDiscoveredResources.ts
@@ -19,6 +19,8 @@ export interface DiscoveredResourceFilter {
 
 export interface DiscoveredResource {
   discovered_resource_id: string;
+  discovery_resource_id: string | null;
+  managed_resource_id: string | null;
   managed_resource_uri: string | null;
   discovery_resource_uri: string | null;
   values: unknown;

--- a/src/Slices/ResourceDiscovery/Data/Mock.ts
+++ b/src/Slices/ResourceDiscovery/Data/Mock.ts
@@ -2,6 +2,8 @@ export const response = {
   data: [
     {
       discovered_resource_id: "vcenter::VirtualMachine[lab,name=acisim]",
+      discovery_resource_id: "vcenter::VirtualMachine[lab,name=acisim]",
+      managed_resource_id: "vcenter::VirtualMachine[lab,name=acisim]",
       managed_resource_uri:
         "/api/v2/resource/cloudflare::dns_record::CnameRecord[https://api.cloudflare.com/client/v4/,name=artifacts.ssh.inmanta.com]",
       discovery_resource_uri:
@@ -38,6 +40,8 @@ export const response = {
     },
     {
       discovered_resource_id: "vcenter::VirtualMachine[lab,name=acisim-5.2-7f]",
+      discovery_resource_id: null,
+      managed_resource_id: null,
       managed_resource_uri: null,
       discovery_resource_uri: null,
       values: {
@@ -72,6 +76,8 @@ export const response = {
     },
     {
       discovered_resource_id: "vcenter::VirtualMachine[lab,name=acisim-5.7]",
+      discovery_resource_id: "vcenter::VirtualMachine[lab,name=acisim-5.7]",
+      managed_resource_id: "vcenter::VirtualMachine[lab,name=acisim-5.7]",
       managed_resource_uri: "invalid/uri1/",
       discovery_resource_uri: "invalid/uri1/",
       values: {
@@ -106,6 +112,8 @@ export const response = {
     },
     {
       discovered_resource_id: "vcenter::VirtualMachine[lab,name=CentOS7Template]",
+      discovery_resource_id: "",
+      managed_resource_id: "",
       managed_resource_uri: "",
       discovery_resource_uri: "",
       values: {
@@ -134,6 +142,8 @@ export const response = {
     },
     {
       discovered_resource_id: "vcenter::VirtualMachine[lab,name=CentOS7TestNfvApiTemplate]",
+      discovery_resource_id: null,
+      managed_resource_id: null,
       managed_resource_uri: null,
       discovery_resource_uri: null,
       values: {
@@ -162,6 +172,8 @@ export const response = {
     },
     {
       discovered_resource_id: "vcenter::VirtualMachine[lab,name=ma-test-1705069110.4363039_1]",
+      discovery_resource_id: null,
+      managed_resource_id: null,
       managed_resource_uri: null,
       discovery_resource_uri: null,
       values: {
@@ -196,6 +208,8 @@ export const response = {
     },
     {
       discovered_resource_id: "vcenter::VirtualMachine[lab,name=rocky-8]",
+      managed_resource_id: null,
+      discovery_resource_id: null,
       managed_resource_uri: null,
       discovery_resource_uri: null,
       values: {
@@ -224,9 +238,10 @@ export const response = {
     },
     {
       discovered_resource_id: "vcenter::VirtualMachine[lab,name=t160_srv_example]",
+      managed_resource_id: null,
+      discovery_resource_id: null,
       managed_resource_uri: null,
       discovery_resource_uri: null,
-
       values: {
         name: "t160_srv_example",
         path: "/bedc/vm/test_lab_root/t160_srv_example",
@@ -246,6 +261,8 @@ export const response = {
     },
     {
       discovered_resource_id: "vcenter::VirtualMachine[lab,name=t160_srv_example_2]",
+      discovery_resource_id: null,
+      managed_resource_id: null,
       managed_resource_uri: null,
       discovery_resource_uri: null,
       values: {
@@ -267,6 +284,8 @@ export const response = {
     },
     {
       discovered_resource_id: "vcenter::VirtualMachine[lab,name=test]",
+      discovery_resource_id: null,
+      managed_resource_id: null,
       managed_resource_uri: null,
       discovery_resource_uri: null,
       values: {
@@ -295,6 +314,8 @@ export const response = {
     },
     {
       discovered_resource_id: "vcenter::VirtualMachine[lab,name=ubuntu-18.04.6]",
+      discovery_resource_id: null,
+      managed_resource_id: null,
       managed_resource_uri: null,
       discovery_resource_uri: null,
       values: {
@@ -329,6 +350,8 @@ export const response = {
     },
     {
       discovered_resource_id: "vcenter::VirtualMachine[lab,name=ubuntu-22.04]",
+      discovery_resource_id: null,
+      managed_resource_id: null,
       managed_resource_uri: null,
       discovery_resource_uri: null,
       values: {
@@ -358,6 +381,8 @@ export const response = {
     {
       discovered_resource_id:
         "vcenter::VirtualMachine[lab,name=vCLS-8d6212c5-a9be-40a9-a99e-f8b563a6f284]",
+      discovery_resource_id: null,
+      managed_resource_id: null,
       managed_resource_uri: null,
       discovery_resource_uri: null,
       values: {
@@ -380,6 +405,8 @@ export const response = {
     {
       discovered_resource_id:
         "vcenter::VirtualMachine[lab,name=vCLS-a11c52cf-ce5c-438b-a4dc-40ef661f16c3]",
+      managed_resource_id: null,
+      discovery_resource_id: null,
       managed_resource_uri: null,
       discovery_resource_uri: null,
       values: {
@@ -402,6 +429,8 @@ export const response = {
     {
       discovered_resource_id:
         "vcenter::VirtualMachine[lab,name=VMware_Cloud_Director-10.5.1.10593-22821417_OVF10]",
+      discovery_resource_id: null,
+      managed_resource_id: null,
       managed_resource_uri: null,
       discovery_resource_uri: null,
       values: {
@@ -436,6 +465,8 @@ export const response = {
     },
     {
       discovered_resource_id: "vcenter::VirtualMachine[lab,name=VMware vCenter Server 8]",
+      discovery_resource_id: null,
+      managed_resource_id: null,
       managed_resource_uri: null,
       discovery_resource_uri: null,
       values: {
@@ -464,6 +495,8 @@ export const response = {
     },
     {
       discovered_resource_id: "vcenter::VirtualMachine[lab,name=WindowsServer2016Template]",
+      discovery_resource_id: null,
+      managed_resource_id: null,
       managed_resource_uri: null,
       discovery_resource_uri: null,
       values: {

--- a/src/Slices/ResourceDiscovery/UI/Components/ManagedResourceLink.tsx
+++ b/src/Slices/ResourceDiscovery/UI/Components/ManagedResourceLink.tsx
@@ -3,41 +3,27 @@ import { words } from "@/UI";
 import { ResourceLink } from "@/UI/Components";
 
 interface Props {
-  resourceUri: string | null;
+  resourceId: string | null;
   type: "managed" | "discovery";
 }
 
 /**
  * @Component that renders a link to the managed or the discovery resource
- * or a "-" if the resourceUri is null or empty.
+ * if the resourceId is not null or empty.
  *
- * uris comes in format : /api/v2/resource/<rid>
- *
- * @param resourceUri : API URI of the managed/discovery resource
+ * @param resourceId : Id of the managed/discovery resource
  *
  * @returns DiscoveredResourceLink component
  */
-export const DiscoveredResourceLink: React.FC<Props> = ({ resourceUri, type }) => {
-  if (!resourceUri) {
-    return <></>;
-  }
-
-  const rid = extractResourceLink(resourceUri);
-
-  if (!rid) {
+export const DiscoveredResourceLink: React.FC<Props> = ({ resourceId, type }) => {
+  if (!resourceId) {
     return <></>;
   }
 
   return (
-    <ResourceLink resourceId={rid} linkText={words(`discovered_resources.show_resource.${type}`)} />
+    <ResourceLink
+      resourceId={resourceId}
+      linkText={words(`discovered_resources.show_resource.${type}`)}
+    />
   );
-};
-
-// example url : /api/v2/resource/cloudflare::dns_record::CnameRecord[https://api.cloudflare.com/client/v4/,name=artifacts.ssh.inmanta.com]
-// We only want to keep the adress to the resource, which is everything that comes after /api/v2/resource/
-const extractResourceLink = (uri: string): string | null => {
-  const regex = /\/api\/v2\/resource\/(.+)/;
-  const match = uri.match(regex);
-
-  return match ? match[1] : null;
 };

--- a/src/Slices/ResourceDiscovery/UI/DiscoveredResourcesRow.tsx
+++ b/src/Slices/ResourceDiscovery/UI/DiscoveredResourcesRow.tsx
@@ -50,14 +50,14 @@ export const DiscoveredResourceRow: React.FC<Props> = ({
           data-testid={words("discovered.column.managed_resource")}
           width={15}
         >
-          <DiscoveredResourceLink resourceUri={row.managed_resource_uri} type="managed" />
+          <DiscoveredResourceLink resourceId={row.managed_resource_id} type="managed" />
         </Td>
         <Td
           dataLabel={words("discovered.column.discovery_resource")}
           data-testid={words("discovered.column.discovery_resource")}
           width={20}
         >
-          <DiscoveredResourceLink resourceUri={row.discovery_resource_uri} type="discovery" />
+          <DiscoveredResourceLink resourceId={row.discovery_resource_id} type="discovery" />
         </Td>
       </Tr>
       {isExpanded && (

--- a/src/Slices/ResourceDiscovery/UI/Page.test.tsx
+++ b/src/Slices/ResourceDiscovery/UI/Page.test.tsx
@@ -70,7 +70,7 @@ describe("DiscoveredResourcesPage", () => {
 
     expect(within(rowWithManagedResource).getByRole("link")).toHaveAttribute(
       "href",
-      "/resources/cloudflare%3A%3Adns_record%3A%3ACnameRecord%5Bhttps%3A%2F%2Fapi.cloudflare.com%2Fclient%2Fv4%2F%2Cname%3Dartifacts.ssh.inmanta.com%5D"
+      "/resources/vcenter%3A%3AVirtualMachine%5Blab%2Cname%3Dacisim%5D"
     );
 
     // with correct uri to discovery resource
@@ -82,16 +82,12 @@ describe("DiscoveredResourcesPage", () => {
 
     expect(within(rowWithDiscoveryResource).getByRole("link")).toHaveAttribute(
       "href",
-      "/resources/cloudflare%3A%3Adns_record%3A%3ACnameRecord%5Bhttps%3A%2F%2Fapi.cloudflare.com%2Fclient%2Fv4%2F%2Cname%3Dartifacts.ssh.inmanta.com%5D"
+      "/resources/vcenter%3A%3AVirtualMachine%5Blab%2Cname%3Dacisim%5D"
     );
 
     // uri is null
     expect(within(rows[1]).getByTestId("Managed resource")).toHaveTextContent("");
     expect(within(rows[1]).getByTestId("Discovery resource")).toHaveTextContent("");
-
-    // uri doesn't have a rid
-    expect(within(rows[2]).getByTestId("Managed resource")).toHaveTextContent("");
-    expect(within(rows[2]).getByTestId("Discovery resource")).toHaveTextContent("");
 
     // uri is an empty string
     expect(within(rows[3]).getByTestId("Managed resource")).toHaveTextContent("");


### PR DESCRIPTION
# ISO-8 pr

Replace the rid extraction with the resource id now that it is provided. When the page was initially developped, those fields weren't there yet, and we weren't informed after they were added.

closes :
- #6963

