### PR TITLE
Fix notification badge flicker on initial load

### DIFF
--- a/changelogs/unreleased/7025-notification-badge-flicker.yml
+++ b/changelogs/unreleased/7025-notification-badge-flicker.yml
@@ -1,6 +1,6 @@
 description: The notification badge no longer flashes from a disabled to an active state on initial load.
 issue-nr: 7025
 change-type: patch
-destination-branches: [master, iso9]
+destination-branches: [master, iso9, iso8]
 sections:
   bugfix: "{{description}}"

--- a/changelogs/unreleased/7025-notification-badge-flicker.yml
+++ b/changelogs/unreleased/7025-notification-badge-flicker.yml
@@ -1,0 +1,6 @@
+description: The notification badge no longer flashes from a disabled to an active state on initial load.
+issue-nr: 7025
+change-type: patch
+destination-branches: [master, iso9]
+sections:
+  bugfix: "{{description}}"

--- a/src/Slices/Notification/UI/Badge/Badge.test.tsx
+++ b/src/Slices/Notification/UI/Badge/Badge.test.tsx
@@ -1,6 +1,6 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen, waitFor } from "@testing-library/react";
-import { delay, graphql, HttpResponse } from "msw";
+import { graphql, HttpResponse } from "msw";
 import { setupServer } from "msw/node";
 import { NotificationsResponse } from "@/Data/Queries";
 import { MockedDependencyProvider } from "@/Test";
@@ -24,7 +24,7 @@ function setup() {
     </QueryClientProvider>
   );
 
-  return { component };
+  return { component, queryClient };
 }
 const server = setupServer();
 
@@ -61,7 +61,7 @@ describe("Badge", () => {
           });
         })
       );
-      const { component } = setup();
+      const { component, queryClient } = setup();
 
       render(component);
 
@@ -70,36 +70,25 @@ describe("Badge", () => {
       });
 
       expect(button).toBeVisible();
-      // The badge renders immediately in the neutral `read` state while loading, so wait
-      // for it to settle on the variant derived from the resolved notifications.
+      // Wait for the query to settle first — otherwise the `read` rows pass on the
+      // identical loading default before the response is processed.
+      await waitFor(() => expect(queryClient.isFetching()).toBe(0));
       await waitFor(() => expect(button).toHaveAttribute("data-variant", variant));
     }
   );
 
   test("Given Badge WHEN request is loading THEN an enabled read badge is shown", () => {
     server.use(
-      queryBase.operation(() => {
-        delay(100);
-
-        return HttpResponse.json<{ data: NotificationsResponse }>({
-          data: {
-            data: {
-              notifications: {
-                edges: [],
-              },
-            },
-            errors: [],
-            extensions: {},
-          },
-        });
-      })
+      queryBase.operation(() =>
+        HttpResponse.json<{ data: NotificationsResponse }>({
+          data: { data: { notifications: { edges: [] } }, errors: [], extensions: {} },
+        })
+      )
     );
     const { component } = setup();
-
     render(component);
 
     const badge = screen.getByRole("button", { name: "Badge-Success" });
-
     expect(badge).toBeVisible();
     expect(badge).toBeEnabled();
     expect(badge).toHaveAttribute("data-variant", "read");

--- a/src/Slices/Notification/UI/Badge/Badge.test.tsx
+++ b/src/Slices/Notification/UI/Badge/Badge.test.tsx
@@ -1,6 +1,5 @@
-import React from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { delay, graphql, HttpResponse } from "msw";
 import { setupServer } from "msw/node";
 import { NotificationsResponse } from "@/Data/Queries";
@@ -71,11 +70,13 @@ describe("Badge", () => {
       });
 
       expect(button).toBeVisible();
-      expect(button).toHaveAttribute("data-variant", variant);
+      // The badge renders immediately in the neutral `read` state while loading, so wait
+      // for it to settle on the variant derived from the resolved notifications.
+      await waitFor(() => expect(button).toHaveAttribute("data-variant", variant));
     }
   );
 
-  test("Given Badge WHEN request is loading THEN variant is not shown and badge is disabled", () => {
+  test("Given Badge WHEN request is loading THEN an enabled read badge is shown", () => {
     server.use(
       queryBase.operation(() => {
         delay(100);
@@ -97,11 +98,11 @@ describe("Badge", () => {
 
     render(component);
 
-    const badge = screen.getByRole("button", { name: "Badge" });
+    const badge = screen.getByRole("button", { name: "Badge-Success" });
 
     expect(badge).toBeVisible();
-    expect(badge).toBeDisabled();
-    expect(badge).not.toHaveAttribute("data-variant");
+    expect(badge).toBeEnabled();
+    expect(badge).toHaveAttribute("data-variant", "read");
   });
 
   test("Given Badge WHEN request fails THEN error is shown", async () => {

--- a/src/Slices/Notification/UI/Badge/Badge.tsx
+++ b/src/Slices/Notification/UI/Badge/Badge.tsx
@@ -60,8 +60,8 @@ export const Badge: React.FC<{ onClick(): void }> = ({ onClick }) => {
     );
   }
 
-  // While the first request is in flight, default to the neutral `read` variant and keep
-  // the badge enabled, so it doesn't flash from disabled to active on initial load.
+  // While a request is in flight (initial load or after an environment switch), default to the
+  // neutral `read` variant and keep the badge enabled, so it doesn't flash from disabled to active.
   const variant = getVariantFromNotifications(data?.notifications ?? []);
 
   return (

--- a/src/Slices/Notification/UI/Badge/Badge.tsx
+++ b/src/Slices/Notification/UI/Badge/Badge.tsx
@@ -45,31 +45,32 @@ export const Badge: React.FC<{ onClick(): void }> = ({ onClick }) => {
 
   if (hasErrors) {
     return (
-      <>
-        <NotificationBadge
-          aria-label="Badge-Error"
-          variant={NotificationBadgeVariant.read}
-          isDisabled
-        />
-      </>
-    );
-  }
-
-  if (isSuccess) {
-    const variant = getVariantFromNotifications(data.notifications);
-
-    return (
       <NotificationBadge
-        aria-label="Badge-Success"
-        data-variant={variant}
-        variant={variant}
-        onClick={onClick}
+        aria-label="Badge-Error"
+        variant={NotificationBadgeVariant.read}
+        isDisabled
       />
     );
   }
 
+  // No environment selected yet: there is nothing to fetch, so show a disabled placeholder.
+  if (!envID) {
+    return (
+      <NotificationBadge aria-label="Badge" variant={NotificationBadgeVariant.read} isDisabled />
+    );
+  }
+
+  // While the first request is in flight, default to the neutral `read` variant and keep
+  // the badge enabled, so it doesn't flash from disabled to active on initial load.
+  const variant = getVariantFromNotifications(data?.notifications ?? []);
+
   return (
-    <NotificationBadge aria-label="Badge" variant={NotificationBadgeVariant.read} isDisabled />
+    <NotificationBadge
+      aria-label="Badge-Success"
+      data-variant={variant}
+      variant={variant}
+      onClick={onClick}
+    />
   );
 };
 


### PR DESCRIPTION
# Description

- Render the notification badge enabled in the neutral `read` variant while the first request is in flight, so it no longer flashes from disabled to active on initial load
- Reserve the disabled placeholder badge for the genuine "no environment selected" case
- Update Badge tests: loading now asserts an enabled `read` badge, and variant cases wait for the resolved value

=> this is for iso 8 (most likely will need to make separate pr for this), 9 and 10

closes https://github.com/inmanta/web-console/issues/7025

https://github.com/user-attachments/assets/57beac34-84e1-4212-b247-a218b5e133ea
