### PR TITLE
Sort numeric enum selects by value and make long option lists scrollable

### DIFF
--- a/changelogs/unreleased/7037-select-numeric-sort.yml
+++ b/changelogs/unreleased/7037-select-numeric-sort.yml
@@ -1,0 +1,6 @@
+description: Service instance form selects with numeric enum options now sort by value instead of alphabetically (5, 6, ... 128 instead of 10, 128, ... 5), and long option lists are now scrollable.
+issue-nr: 7037
+change-type: patch
+destination-branches: [master, iso9]
+sections:
+  bugfix: "{{description}}"

--- a/src/UI/Components/ServiceInstanceForm/Components/SelectFormInput.tsx
+++ b/src/UI/Components/ServiceInstanceForm/Components/SelectFormInput.tsx
@@ -50,7 +50,9 @@ export const SelectFormInput: React.FC<Props> = ({
 }) => {
   const [isOpen, setIsOpen] = useState(false);
 
-  const selectOptions = Object.keys(options).sort();
+  const selectOptions = Object.keys(options).sort((a, b) =>
+    a.localeCompare(b, undefined, { numeric: true })
+  );
   const formattedOptions = selectOptions.map((option) => {
     return {
       value: options[option],
@@ -118,6 +120,7 @@ export const SelectFormInput: React.FC<Props> = ({
       <Select
         id={`${attributeName}-select`}
         isOpen={isOpen}
+        isScrollable
         selected={selectOptions.length === 1 ? selectOptions[0] : attributeValue}
         onSelect={onSelect}
         onOpenChange={(isOpen) => setIsOpen(isOpen)}


### PR DESCRIPTION
# Description

- Numeric enum options in service instance form selects now sort by value (5, 6, … 128) instead of lexicographically (10, 128, … 5)
- String enum options continue to sort alphabetically
- Long option lists are now scrollable (`isScrollable` on `Select`) so 20+ item enums no longer dominate the screen

closes https://github.com/inmanta/web-console/issues/7037

<img width="1100" height="405" alt="Screenshot 2026-06-24 at 16 16 49" src="https://github.com/user-attachments/assets/7cd85f05-be59-4441-bc3c-d33376d2fdbd" />

Note: Not going to review this one with the skill from Lukas since this is a very small change which has a very limited impact, not much to review here...