### PR TITLE
Support label/value pairs in service instance form suggestions

### DIFF
--- a/changelogs/unreleased/7008-suggestion-label-value.yml
+++ b/changelogs/unreleased/7008-suggestion-label-value.yml
@@ -1,4 +1,4 @@
-description: Service instance form suggestions now support `{ label, value }` pairs, showing a human-friendly label while submitting the underlying value.
+description: Service instance form suggestions now support "label/value pairs", showing a human-friendly label while submitting the underlying value.
 issue-nr: 7008
 change-type: minor
 destination-branches: [master, iso9]

--- a/changelogs/unreleased/7008-suggestion-label-value.yml
+++ b/changelogs/unreleased/7008-suggestion-label-value.yml
@@ -1,0 +1,6 @@
+description: Service instance form suggestions now support `{ label, value }` pairs, showing a human-friendly label while submitting the underlying value.
+issue-nr: 7008
+change-type: minor
+destination-branches: [master, iso9]
+sections:
+  minor-improvement: "{{description}}"

--- a/src/Core/Domain/ServiceInstanceModel.ts
+++ b/src/Core/Domain/ServiceInstanceModel.ts
@@ -83,11 +83,27 @@ export interface FormAttributeResult {
 }
 
 /**
+ * Interface representing a single suggestion.
+ *
+ * The `label` is shown to the user and searched on, while the `value` is what
+ * gets submitted to the API. A plain string suggestion normalizes to a pair
+ * where `label === value`.
+ */
+export interface SuggestionValue {
+  label: string;
+  value: string;
+}
+
+/**
  * Interface representing a suggestions that are stored in the web_suggested_values.
+ *
+ * A suggestion entry can be a plain string (label and value are identical) or a
+ * `{ label, value }` pair where the displayed/searched label differs from the
+ * submitted value.
  */
 export interface FormSuggestion {
   type: FormSuggestionType;
-  values?: string[];
+  values?: (string | SuggestionValue)[];
   parameter_name?: string;
 }
 

--- a/src/Core/Domain/ServiceInstanceModel.ts
+++ b/src/Core/Domain/ServiceInstanceModel.ts
@@ -87,7 +87,7 @@ export interface FormAttributeResult {
  *
  * This is the shape the form actually consumes: the `label` is shown to the user
  * and searched on, while the `value` is what gets submitted to the API. Both are
- * always strings — `normalizeSuggestions` coerces every raw entry (see
+ * always strings - `normalizeSuggestions` coerces every raw entry (see
  * {@link RawFormSuggestion}) into this shape. A plain string suggestion
  * normalizes to a pair where `label === value`.
  */

--- a/src/Core/Domain/ServiceInstanceModel.ts
+++ b/src/Core/Domain/ServiceInstanceModel.ts
@@ -83,11 +83,13 @@ export interface FormAttributeResult {
 }
 
 /**
- * Interface representing a single suggestion.
+ * Interface representing a single, normalized suggestion.
  *
- * The `label` is shown to the user and searched on, while the `value` is what
- * gets submitted to the API. A plain string suggestion normalizes to a pair
- * where `label === value`.
+ * This is the shape the form actually consumes: the `label` is shown to the user
+ * and searched on, while the `value` is what gets submitted to the API. Both are
+ * always strings — `normalizeSuggestions` coerces every raw entry (see
+ * {@link RawFormSuggestion}) into this shape. A plain string suggestion
+ * normalizes to a pair where `label === value`.
  */
 export interface SuggestionValue {
   label: string;
@@ -95,15 +97,29 @@ export interface SuggestionValue {
 }
 
 /**
- * Interface representing a suggestions that are stored in the web_suggested_values.
+ * A suggestion entry exactly as it arrives in `web_suggested_values` (or a
+ * parameter's metadata), before normalization.
  *
- * A suggestion entry can be a plain string (label and value are identical) or a
- * `{ label, value }` pair where the displayed/searched label differs from the
- * submitted value.
+ * It can be a bare scalar or an explicit `{ label, value }` pair, and either
+ * form may be a string or a number (numeric attributes). Every variant is
+ * coerced to a string-only {@link SuggestionValue} by `normalizeSuggestions`
+ * before the form uses it.
+ */
+export type RawFormSuggestion =
+  | string
+  | number
+  | { label: string | number; value: string | number };
+
+/**
+ * Interface representing the suggestions that are stored in the web_suggested_values.
+ *
+ * `values` holds the raw entries (see {@link RawFormSuggestion}): each is a plain
+ * scalar (label and value are identical) or a `{ label, value }` pair where the
+ * displayed/searched label differs from the submitted value.
  */
 export interface FormSuggestion {
   type: FormSuggestionType;
-  values?: (string | SuggestionValue)[];
+  values?: RawFormSuggestion[];
   parameter_name?: string;
 }
 

--- a/src/Data/Queries/Slices/ServiceInstance/FormSuggestions/helpers.test.ts
+++ b/src/Data/Queries/Slices/ServiceInstance/FormSuggestions/helpers.test.ts
@@ -1,5 +1,5 @@
 import { SuggestionValue } from "@/Core";
-import { normalizeSuggestions } from "./useSuggestions";
+import { normalizeSuggestions } from "./helpers";
 
 describe("normalizeSuggestions", () => {
   it("normalizes a bare string to a { label, value } pair where label === value", () => {

--- a/src/Data/Queries/Slices/ServiceInstance/FormSuggestions/helpers.ts
+++ b/src/Data/Queries/Slices/ServiceInstance/FormSuggestions/helpers.ts
@@ -1,0 +1,56 @@
+import { SuggestionValue } from "@/Core";
+
+/**
+ * Type guard for a string or number scalar.
+ *
+ * @param value - The value to check.
+ * @returns Whether the value is a string or a number.
+ */
+const isStringOrNumber = (value: unknown): value is string | number =>
+  typeof value === "string" || typeof value === "number";
+
+/**
+ * Type guard for an explicit `{ label, value }` suggestion pair.
+ *
+ * Both fields may be a string or a number (e.g. numeric attributes); they are
+ * coerced to strings when normalized.
+ *
+ * @param entry - The raw entry to check.
+ * @returns Whether the entry is a `{ label, value }` pair of scalars.
+ */
+const isLabelValuePair = (
+  entry: unknown
+): entry is { label: string | number; value: string | number } =>
+  typeof entry === "object" &&
+  entry !== null &&
+  "label" in entry &&
+  "value" in entry &&
+  isStringOrNumber(entry.label) &&
+  isStringOrNumber(entry.value);
+
+/**
+ * Normalizes a raw list of suggestion entries into a single `{ label, value }[]` shape.
+ *
+ * Every flavor (literal, parameters, ...) is reduced to this shape so the rest
+ * of the form only deals with one contract. A bare scalar normalizes to a pair
+ * where `label === value`; an explicit pair has its (possibly numeric) fields
+ * coerced to strings; anything else is dropped.
+ *
+ * @param values - The raw values, of unknown shape.
+ * @returns The normalized suggestions, or null when `values` is not an array.
+ */
+export const normalizeSuggestions = (values: unknown): SuggestionValue[] | null => {
+  if (!Array.isArray(values)) {
+    return null;
+  }
+
+  return values.reduce<SuggestionValue[]>((acc, entry) => {
+    if (isStringOrNumber(entry)) {
+      acc.push({ label: String(entry), value: String(entry) });
+    } else if (isLabelValuePair(entry)) {
+      acc.push({ label: String(entry.label), value: String(entry.value) });
+    }
+
+    return acc;
+  }, []);
+};

--- a/src/Data/Queries/Slices/ServiceInstance/FormSuggestions/useSuggestions.test.ts
+++ b/src/Data/Queries/Slices/ServiceInstance/FormSuggestions/useSuggestions.test.ts
@@ -24,11 +24,7 @@ describe("normalizeSuggestions", () => {
 
   it("coerces numeric scalars and pair fields to strings", () => {
     expect(
-      normalizeSuggestions([
-        100,
-        { label: "10 Gbps", value: 10000 },
-        { label: 1, value: 2 },
-      ])
+      normalizeSuggestions([100, { label: "10 Gbps", value: 10000 }, { label: 1, value: 2 }])
     ).toEqual([
       { label: "100", value: "100" },
       { label: "10 Gbps", value: "10000" },

--- a/src/Data/Queries/Slices/ServiceInstance/FormSuggestions/useSuggestions.test.ts
+++ b/src/Data/Queries/Slices/ServiceInstance/FormSuggestions/useSuggestions.test.ts
@@ -1,0 +1,59 @@
+import { SuggestionValue } from "@/Core";
+import { normalizeSuggestions } from "./useSuggestions";
+
+describe("normalizeSuggestions", () => {
+  it("normalizes a bare string to a { label, value } pair where label === value", () => {
+    expect(normalizeSuggestions(["10 Gbps", "1 Gbps"])).toEqual([
+      { label: "10 Gbps", value: "10 Gbps" },
+      { label: "1 Gbps", value: "1 Gbps" },
+    ]);
+  });
+
+  it("keeps a { label, value } pair as-is", () => {
+    const pair: SuggestionValue = { label: "Production network", value: "9f3c1b2a" };
+
+    expect(normalizeSuggestions([pair])).toEqual([pair]);
+  });
+
+  it("normalizes a mix of strings and pairs into a single shape", () => {
+    expect(normalizeSuggestions(["plain", { label: "10 Gbps", value: "10000" }])).toEqual([
+      { label: "plain", value: "plain" },
+      { label: "10 Gbps", value: "10000" },
+    ]);
+  });
+
+  it("coerces numeric scalars and pair fields to strings", () => {
+    expect(
+      normalizeSuggestions([
+        100,
+        { label: "10 Gbps", value: 10000 },
+        { label: 1, value: 2 },
+      ])
+    ).toEqual([
+      { label: "100", value: "100" },
+      { label: "10 Gbps", value: "10000" },
+      { label: "1", value: "2" },
+    ]);
+  });
+
+  it("drops entries that are neither a scalar nor a valid { label, value } pair", () => {
+    expect(
+      normalizeSuggestions([
+        "ok",
+        { label: "missing value" },
+        { value: "missing label" },
+        { label: "x", value: true },
+        { label: {}, value: "y" },
+        null,
+        undefined,
+        true,
+      ])
+    ).toEqual([{ label: "ok", value: "ok" }]);
+  });
+
+  it("returns null when the input is not an array", () => {
+    expect(normalizeSuggestions(undefined)).toBeNull();
+    expect(normalizeSuggestions(null)).toBeNull();
+    expect(normalizeSuggestions("not-an-array")).toBeNull();
+  });
+});

--- a/src/Data/Queries/Slices/ServiceInstance/FormSuggestions/useSuggestions.ts
+++ b/src/Data/Queries/Slices/ServiceInstance/FormSuggestions/useSuggestions.ts
@@ -1,67 +1,13 @@
 import { useContext, useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { FormSuggestion, SuggestionValue } from "@/Core";
+import { FormSuggestion } from "@/Core";
 import { useGet, getParametersKey } from "@/Data/Queries";
 import { DependencyContext } from "@/UI/Dependency";
+import { normalizeSuggestions } from "./helpers";
 
 interface ResponseData {
   parameter?: { metadata?: { values?: unknown } };
 }
-
-/**
- * Type guard for a string or number scalar.
- *
- * @param value - The value to check.
- * @returns Whether the value is a string or a number.
- */
-const isStringOrNumber = (value: unknown): value is string | number =>
-  typeof value === "string" || typeof value === "number";
-
-/**
- * Type guard for an explicit `{ label, value }` suggestion pair.
- *
- * Both fields may be a string or a number (e.g. numeric attributes); they are
- * coerced to strings when normalized.
- *
- * @param entry - The raw entry to check.
- * @returns Whether the entry is a `{ label, value }` pair of scalars.
- */
-const isLabelValuePair = (
-  entry: unknown
-): entry is { label: string | number; value: string | number } =>
-  typeof entry === "object" &&
-  entry !== null &&
-  "label" in entry &&
-  "value" in entry &&
-  isStringOrNumber(entry.label) &&
-  isStringOrNumber(entry.value);
-
-/**
- * Normalizes a raw list of suggestion entries into a single `{ label, value }[]` shape.
- *
- * Every flavor (literal, parameters, ...) is reduced to this shape so the rest
- * of the form only deals with one contract. A bare scalar normalizes to a pair
- * where `label === value`; an explicit pair has its (possibly numeric) fields
- * coerced to strings; anything else is dropped.
- *
- * @param values - The raw values, of unknown shape.
- * @returns The normalized suggestions, or null when `values` is not an array.
- */
-export const normalizeSuggestions = (values: unknown): SuggestionValue[] | null => {
-  if (!Array.isArray(values)) {
-    return null;
-  }
-
-  return values.reduce<SuggestionValue[]>((acc, entry) => {
-    if (isStringOrNumber(entry)) {
-      acc.push({ label: String(entry), value: String(entry) });
-    } else if (isLabelValuePair(entry)) {
-      acc.push({ label: String(entry.label), value: String(entry.value) });
-    }
-
-    return acc;
-  }, []);
-};
 
 /**
  * React Query hook to handle suggested values for a parameter.

--- a/src/Data/Queries/Slices/ServiceInstance/FormSuggestions/useSuggestions.ts
+++ b/src/Data/Queries/Slices/ServiceInstance/FormSuggestions/useSuggestions.ts
@@ -1,17 +1,73 @@
-import { useContext } from "react";
+import { useContext, useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { FormSuggestion } from "@/Core";
+import { FormSuggestion, SuggestionValue } from "@/Core";
 import { useGet, getParametersKey } from "@/Data/Queries";
 import { DependencyContext } from "@/UI/Dependency";
 
 interface ResponseData {
-  parameter: Record<string, Record<string, unknown>>;
+  parameter?: { metadata?: { values?: unknown } };
 }
 
 /**
+ * Type guard for a string or number scalar.
+ *
+ * @param value - The value to check.
+ * @returns Whether the value is a string or a number.
+ */
+const isStringOrNumber = (value: unknown): value is string | number =>
+  typeof value === "string" || typeof value === "number";
+
+/**
+ * Type guard for an explicit `{ label, value }` suggestion pair.
+ *
+ * Both fields may be a string or a number (e.g. numeric attributes); they are
+ * coerced to strings when normalized.
+ *
+ * @param entry - The raw entry to check.
+ * @returns Whether the entry is a `{ label, value }` pair of scalars.
+ */
+const isLabelValuePair = (
+  entry: unknown
+): entry is { label: string | number; value: string | number } =>
+  typeof entry === "object" &&
+  entry !== null &&
+  "label" in entry &&
+  "value" in entry &&
+  isStringOrNumber(entry.label) &&
+  isStringOrNumber(entry.value);
+
+/**
+ * Normalizes a raw list of suggestion entries into a single `{ label, value }[]` shape.
+ *
+ * Every flavor (literal, parameters, ...) is reduced to this shape so the rest
+ * of the form only deals with one contract. A bare scalar normalizes to a pair
+ * where `label === value`; an explicit pair has its (possibly numeric) fields
+ * coerced to strings; anything else is dropped.
+ *
+ * @param values - The raw values, of unknown shape.
+ * @returns The normalized suggestions, or null when `values` is not an array.
+ */
+export const normalizeSuggestions = (values: unknown): SuggestionValue[] | null => {
+  if (!Array.isArray(values)) {
+    return null;
+  }
+
+  return values.reduce<SuggestionValue[]>((acc, entry) => {
+    if (isStringOrNumber(entry)) {
+      acc.push({ label: String(entry), value: String(entry) });
+    } else if (isLabelValuePair(entry)) {
+      acc.push({ label: String(entry.label), value: String(entry.value) });
+    }
+
+    return acc;
+  }, []);
+};
+
+/**
  * React Query hook to handle suggested values for a parameter.
- * If the suggestions are literal, it will return the values directly.
- * If the suggestions are parameters, it will fetch the parameter from the API.
+ * Every flavor is normalized to a single `{ label, value }[]` shape:
+ * If the suggestions are literal, it normalizes the inline values.
+ * If the suggestions are parameters, it fetches the parameter from the API and normalizes its values.
  * if the suggestions are null or undefined, it will return null as data, and a success status.
  *
  * @param suggestions - The suggestions for the parameter.
@@ -34,8 +90,12 @@ export const useSuggestedValues = (suggestions: FormSuggestion | null | undefine
   if (suggestions.type === "literal") {
     return {
       useOneTime: () => {
+        // A field's literal values are static for its lifetime, so memoizing
+        // once keeps the normalized array referentially stable across renders.
+        const data = useMemo(() => normalizeSuggestions(suggestions.values), []);
+
         return {
-          data: suggestions.values,
+          data,
           status: "success",
           error: null,
           isLoading: false,
@@ -47,13 +107,13 @@ export const useSuggestedValues = (suggestions: FormSuggestion | null | undefine
   return {
     /**
      * Custom hook to fetch the parameter from the API once.
-     * @returns The result of the query, including the parameter data.
+     * @returns The result of the query, including the normalized suggestions.
      */
     useOneTime: () =>
       useQuery({
         queryKey: getParametersKey.single(suggestions.parameter_name || "no_parameter", [env]),
         queryFn: () => get(`/api/v1/parameter/${suggestions.parameter_name}`),
-        select: (data) => data.parameter,
+        select: (data) => normalizeSuggestions(data.parameter?.metadata?.values),
       }),
   };
 };

--- a/src/Data/Queries/Slices/ServiceInstance/PostInstance/helper.test.ts
+++ b/src/Data/Queries/Slices/ServiceInstance/PostInstance/helper.test.ts
@@ -44,3 +44,11 @@ it("GIVEN prepBody without initial_state THEN body does not include initial_stat
   expect(body.attributes.string_attribute).toEqual("lorem ipsum");
   expect(body).not.toHaveProperty("initial_state");
 });
+
+it("GIVEN prepBody WHEN a numeric field holds a string value (e.g. a suggestion) THEN it is sanitized to a number", () => {
+  const fields = [{ ...Field.number, name: "bandwidth", isOptional: false, type: "int" }];
+  const body = prepBody(fields, { bandwidth: "10000" });
+
+  expect(body.attributes.bandwidth).toBe(10000);
+  expect(typeof body.attributes.bandwidth).toBe("number");
+});

--- a/src/UI/Components/ServiceInstanceForm/Components/FieldInput.tsx
+++ b/src/UI/Components/ServiceInstanceForm/Components/FieldInput.tsx
@@ -2,7 +2,14 @@ import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { Button, FormFieldGroupExpandable, FormFieldGroupHeader } from "@patternfly/react-core";
 import { PlusIcon } from "@patternfly/react-icons";
 import { v4 as uuidv4 } from "uuid";
-import { InstanceAttributeModel, DictListField, Field, NestedField, FormSuggestion } from "@/Core";
+import {
+  InstanceAttributeModel,
+  DictListField,
+  Field,
+  NestedField,
+  FormSuggestion,
+  SuggestionValue,
+} from "@/Core";
 import { get } from "@/Core/Language/collection";
 import { toOptionalBoolean } from "@/Data";
 import { useSuggestedValues } from "@/Data/Queries";
@@ -70,7 +77,8 @@ export const FieldInput: React.FC<Props> = ({
   suggestions,
 }) => {
   const { data, isLoading, error } = useSuggestedValues(suggestions).useOneTime();
-  const [suggestionsList, setSuggestionsList] = useState<string[] | null>(null);
+  // Already normalized to { label, value }[] by useSuggestedValues; just forward it.
+  const suggestionsList: SuggestionValue[] | null = !isLoading && !error ? (data ?? null) : null;
 
   // Get the controlled value for the field
   // If the value is an object or an array, it needs to be converted.
@@ -93,26 +101,6 @@ export const FieldInput: React.FC<Props> = ({
     },
     [getUpdate, path, field.name]
   );
-
-  useEffect(() => {
-    if (!isLoading && !error) {
-      // if the data is of type array, we can use it directly
-      if (Array.isArray(data)) {
-        setSuggestionsList(data);
-      } else if (
-        data &&
-        data.metadata &&
-        data.metadata.values &&
-        Array.isArray(data.metadata.values) &&
-        // TODO: remove this when the API returns a fixed format.
-        data.metadata.values.every((value) => typeof value === "string")
-      ) {
-        setSuggestionsList(data.metadata.values);
-      }
-    } else {
-      setSuggestionsList(null);
-    }
-  }, [suggestions, data, isLoading, error]);
 
   switch (field.kind) {
     case "Boolean":

--- a/src/UI/Components/ServiceInstanceForm/Components/SuggestionsPopover.test.tsx
+++ b/src/UI/Components/ServiceInstanceForm/Components/SuggestionsPopover.test.tsx
@@ -1,65 +1,61 @@
 import React, { RefObject } from "react";
 import { Button } from "@patternfly/react-core";
 import { fireEvent, render, screen } from "@testing-library/react";
+import { SuggestionValue } from "@/Core";
 import { SuggestionsPopover } from "./SuggestionsPopover";
 
 describe("SuggestionsPopover", () => {
-  const suggestions = ["apple", "banana", "cherry"];
+  const suggestions: SuggestionValue[] = [
+    { label: "apple", value: "apple" },
+    { label: "banana", value: "banana" },
+    { label: "cherry", value: "cherry" },
+  ];
   const handleSuggestionClick = vi.fn();
   const filter = "a";
-  const setIsOpen = vi.fn();
+  const close = vi.fn();
   const isOpen = true;
   const ref: RefObject<HTMLInputElement | null> = React.createRef();
 
-  it("renders the popover component", () => {
-    render(
-      <SuggestionsPopover
-        suggestions={suggestions}
-        handleSuggestionClick={handleSuggestionClick}
-        filter={filter}
-        setIsOpen={setIsOpen}
-        isOpen={isOpen}
-        ref={ref}
-      />
-    );
+  it("shows the label, filters on the label, and submits the value when label differs from value", () => {
+    const labeled: SuggestionValue[] = [
+      { label: "Production network", value: "9f3c1b2a-prod" },
+      { label: "Staging network", value: "00000000-stag" },
+    ];
 
-    // Assert that the popover component is rendered
-    expect(screen.getByText("apple")).toBeInTheDocument();
-    expect(screen.getByText("banana")).toBeInTheDocument();
-    // the filter contains 'a' so 'cherry' should not be rendered
-    expect(screen.queryByText("cherry")).not.toBeInTheDocument();
-  });
-
-  it("calls handleSuggestionClick when a suggestion is clicked", () => {
     render(
       <>
         <input ref={ref} />
         <SuggestionsPopover
-          suggestions={suggestions}
+          suggestions={labeled}
           handleSuggestionClick={handleSuggestionClick}
-          filter={filter}
-          setIsOpen={setIsOpen}
+          filter="production"
+          close={close}
           isOpen={isOpen}
           ref={ref}
         />
       </>
     );
 
-    // Simulate a click on the 'apple' suggestion
-    fireEvent.click(screen.getByLabelText("apple"));
+    // The human-friendly label is shown, the raw value is not.
+    expect(screen.getByText(labeled[0].label)).toBeInTheDocument();
+    expect(screen.queryByText(labeled[0].value)).not.toBeInTheDocument();
+    // Filtering matches the label, so the non-matching suggestion is hidden.
+    expect(screen.queryByText(labeled[1].label)).not.toBeInTheDocument();
 
-    // Assert that handleSuggestionClick is called with the correct suggestion
-    expect(handleSuggestionClick).toHaveBeenCalledWith("apple");
+    fireEvent.click(screen.getByText(labeled[0].label));
+
+    // Clicking submits the value, not the displayed label.
+    expect(handleSuggestionClick).toHaveBeenCalledWith(labeled[0].value);
   });
 
-  it("calls setIsOpen when the popover is closed", () => {
+  it("calls close when the popover is closed", () => {
     render(
       <>
         <SuggestionsPopover
           suggestions={suggestions}
           handleSuggestionClick={handleSuggestionClick}
           filter={filter}
-          setIsOpen={setIsOpen}
+          close={close}
           isOpen={isOpen}
           ref={ref}
         />
@@ -71,8 +67,8 @@ describe("SuggestionsPopover", () => {
     // Simulate a click outside the popover
     fireEvent.click(screen.getByText("Some button"));
 
-    // Assert that setIsOpen is called with false
-    expect(setIsOpen).toHaveBeenCalledWith(false);
+    // Assert that the popover closes
+    expect(close).toHaveBeenCalled();
   });
 
   it("handles menu key events", () => {
@@ -83,7 +79,7 @@ describe("SuggestionsPopover", () => {
           suggestions={suggestions}
           handleSuggestionClick={handleSuggestionClick}
           filter={filter}
-          setIsOpen={setIsOpen}
+          close={close}
           isOpen={isOpen}
           ref={ref}
         />
@@ -96,25 +92,25 @@ describe("SuggestionsPopover", () => {
     fireEvent.keyDown(input, { key: "ArrowDown" });
 
     // Assert that the first suggestion is focused
-    expect(screen.getByRole("menuitem", { name: "apple" })).toHaveFocus();
+    expect(screen.getByRole("menuitem", { name: suggestions[0].label })).toHaveFocus();
 
     // simulate pressing the escape key
     fireEvent.keyDown(input, { key: "Escape" });
 
-    // Assert that setIsOpen is called with false
-    expect(setIsOpen).toHaveBeenCalledWith(false);
+    // Assert that the popover closes
+    expect(close).toHaveBeenCalled();
 
     // simulate clicking on the input after the popover is closed
     fireEvent.click(input);
 
     // Assert that the popover is opened
-    expect(screen.getByText("apple")).toBeInTheDocument();
+    expect(screen.getByText(suggestions[0].label)).toBeInTheDocument();
 
     // simulate pressing the up tab key
     fireEvent.keyDown(input, { key: "Tab" });
 
     // Assert that the popover is closed
-    expect(setIsOpen).toHaveBeenCalledWith(false);
+    expect(close).toHaveBeenCalled();
 
     // simulate clicking on the input after the popover is closed
     fireEvent.click(input);
@@ -123,11 +119,11 @@ describe("SuggestionsPopover", () => {
     fireEvent.keyDown(input, { key: "ArrowDown" });
 
     // simulate pressing the enter key on the focused suggestion
-    const firstOption = screen.getByText("apple");
+    const firstOption = screen.getByText(suggestions[0].label);
 
     fireEvent.keyDown(firstOption, { key: "Enter" });
 
-    // Assert that handleSuggestionClick is called with the correct suggestion
-    expect(handleSuggestionClick).toHaveBeenCalledWith("apple");
+    // Assert that handleSuggestionClick is called with the correct suggestion value
+    expect(handleSuggestionClick).toHaveBeenCalledWith(suggestions[0].value);
   });
 });

--- a/src/UI/Components/ServiceInstanceForm/Components/SuggestionsPopover.tsx
+++ b/src/UI/Components/ServiceInstanceForm/Components/SuggestionsPopover.tsx
@@ -57,7 +57,10 @@ export const SuggestionsPopover = forwardRef<NonNullable<HTMLInputElement>, Prop
      * @param {SuggestionValue} suggestion - The clicked suggestion.
      * @returns {void}
      */
-    const handleSuggestionClickInternal = (event, suggestion: SuggestionValue) => {
+    const handleSuggestionClickInternal = (
+      event: React.MouseEvent,
+      suggestion: SuggestionValue
+    ) => {
       event.stopPropagation();
       handleSuggestionClick(suggestion.value);
       close();

--- a/src/UI/Components/ServiceInstanceForm/Components/SuggestionsPopover.tsx
+++ b/src/UI/Components/ServiceInstanceForm/Components/SuggestionsPopover.tsx
@@ -1,13 +1,14 @@
 import React, { useEffect, forwardRef } from "react";
 import { Menu, MenuContent, MenuGroup, MenuItem, MenuList, Popper } from "@patternfly/react-core";
 import styled from "styled-components";
+import { SuggestionValue } from "@/Core";
 
 interface Props {
-  suggestions: string[];
+  suggestions: SuggestionValue[];
   filter: string;
-  handleSuggestionClick: (suggestion: string) => void;
+  handleSuggestionClick: (value: string) => void;
   isOpen: boolean;
-  setIsOpen: (isOpen: boolean) => void;
+  close: () => void;
 }
 
 /**
@@ -17,25 +18,25 @@ interface Props {
  * @example
  * // Usage
  * <SuggestionsPopover
- *   suggestions={["apple", "banana", "cherry"]}
- *   handleSuggestionClick={(suggestion) => console.log(suggestion)}
+ *   suggestions={[{ label: "apple", value: "apple" }, { label: "10 Gbps", value: "10000" }]}
+ *   handleSuggestionClick={(value) => console.log(value)}
  *   filter="a"
- *   setIsOpen={setIsOpen}
+ *   close={close}
  *   isOpen={isOpen}
  *   ref={inputRef}
  * />
  *
  * @param {Object} props - The component props.
- * @param {string[]} props.suggestions - The list of suggestions to display.
- * @param {Function} props.handleSuggestionClick - The callback function to handle suggestion click events.
- * @param {string} props.filter - The filter string to match suggestions.
- * @param {Function} props.setIsOpen - The callback function to set the open state of the popover.
+ * @param {SuggestionValue[]} props.suggestions - The list of suggestions to display. Each carries a `label` (shown + searched) and a `value` (submitted).
+ * @param {Function} props.handleSuggestionClick - The callback invoked with the selected suggestion's `value`.
+ * @param {string} props.filter - The filter string matched against each suggestion's `label`.
+ * @param {Function} props.close - Callback to close the popover (selection, click-outside, keyboard dismiss).
  * @param {boolean} props.isOpen - The current open state of the popover.
  * @param {React.RefObject<NonNullable<HTMLInputElement>>} props.ref - The ref for the input element.
  * @returns {React.FC} The rendered SuggestionsPopover component.
  */
 export const SuggestionsPopover = forwardRef<NonNullable<HTMLInputElement>, Props>(
-  ({ suggestions, handleSuggestionClick, filter, setIsOpen, isOpen }, ref) => {
+  ({ suggestions, handleSuggestionClick, filter, close, isOpen }, ref) => {
     if (!ref) {
       throw new Error("You need to define a ref for the SuggestionsPopover component.");
     }
@@ -43,20 +44,23 @@ export const SuggestionsPopover = forwardRef<NonNullable<HTMLInputElement>, Prop
     const reference = ref as React.RefObject<NonNullable<HTMLInputElement>>;
     const parentCurrent = reference?.current;
 
-    const [autocompleteOptions, setAutocompleteOptions] = React.useState<string[]>([]);
     const autocompleteRef = React.useRef<HTMLDivElement>(null);
+
+    const autocompleteOptions = suggestions.filter((suggestion) =>
+      suggestion.label.toLowerCase().includes(filter.toLowerCase())
+    );
 
     /**
      * Handles the suggestion click event.
      *
      * @param {React.MouseEvent} event - The click event.
-     * @param {string} suggestion - The suggestion value.
+     * @param {SuggestionValue} suggestion - The clicked suggestion.
      * @returns {void}
      */
-    const handleSuggestionClickInternal = (event, suggestion) => {
+    const handleSuggestionClickInternal = (event, suggestion: SuggestionValue) => {
       event.stopPropagation();
-      handleSuggestionClick(suggestion);
-      setIsOpen(false);
+      handleSuggestionClick(suggestion.value);
+      close();
     };
 
     /**
@@ -73,7 +77,7 @@ export const SuggestionsPopover = forwardRef<NonNullable<HTMLInputElement>, Prop
         !autocompleteRef.current.contains(event.target) &&
         !parentCurrent?.contains(event.target)
       ) {
-        setIsOpen(false);
+        close();
       }
     };
 
@@ -103,17 +107,17 @@ export const SuggestionsPopover = forwardRef<NonNullable<HTMLInputElement>, Prop
             break;
           // the escape key will close the menu and return browser focus to the input.
           case "Escape":
-            setIsOpen(false);
+            close();
             reference.current && reference.current.focus();
             // the tab, and enter keys will close the menu, and the tab key will move browser
             // focus forward one element (by default)
             break;
           case "Enter":
             event.preventDefault();
-            setIsOpen(false);
+            close();
             break;
           case "Tab":
-            setIsOpen(false);
+            close();
             break;
           default:
             break;
@@ -127,7 +131,7 @@ export const SuggestionsPopover = forwardRef<NonNullable<HTMLInputElement>, Prop
         event.key === "Tab"
       ) {
         event.preventDefault();
-        setIsOpen(false);
+        close();
         reference.current && reference.current.focus();
       }
     };
@@ -139,11 +143,11 @@ export const SuggestionsPopover = forwardRef<NonNullable<HTMLInputElement>, Prop
             <MenuList>
               {autocompleteOptions.map((suggestion) => (
                 <MenuItem
-                  aria-label={suggestion}
-                  key={suggestion}
+                  aria-label={suggestion.label}
+                  key={`${suggestion.label}::${suggestion.value}`}
                   onClick={(event) => handleSuggestionClickInternal(event, suggestion)}
                 >
-                  {suggestion}
+                  {suggestion.label}
                 </MenuItem>
               ))}
             </MenuList>
@@ -151,14 +155,6 @@ export const SuggestionsPopover = forwardRef<NonNullable<HTMLInputElement>, Prop
         </MenuContent>
       </Menu>
     );
-
-    useEffect(() => {
-      const filteredOptions: string[] = suggestions.filter((suggestion) =>
-        suggestion.toLowerCase().includes(filter.toLowerCase())
-      );
-
-      setAutocompleteOptions(filteredOptions);
-    }, [filter, suggestions]);
 
     useEffect(() => {
       window.addEventListener("keydown", handleMenuKeys);

--- a/src/UI/Components/ServiceInstanceForm/Components/TextFormInput.test.tsx
+++ b/src/UI/Components/ServiceInstanceForm/Components/TextFormInput.test.tsx
@@ -1,0 +1,172 @@
+import { act, useState } from "react";
+import { TextInputTypes } from "@patternfly/react-core";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { SuggestionValue } from "@/Core";
+import { TextFormInput } from "./TextFormInput";
+
+describe("TextFormInput", () => {
+  const setup = (
+    suggestions: SuggestionValue[],
+    { attributeValue = "", handleInputChange = vi.fn(), type = TextInputTypes.text } = {}
+  ) => {
+    render(
+      <TextFormInput
+        attributeName="text_field"
+        attributeValue={attributeValue}
+        description="a text input field"
+        isOptional
+        type={type}
+        handleInputChange={handleInputChange}
+        suggestions={suggestions}
+      />
+    );
+
+    return { handleInputChange };
+  };
+
+  it("displays the label but submits the value when a suggestion is selected", async () => {
+    const suggestions: SuggestionValue[] = [{ label: "10 Gbps", value: "10000" }];
+    const { handleInputChange } = setup(suggestions);
+
+    const input = screen.getByRole("textbox");
+
+    await act(async () => {
+      fireEvent.focus(input);
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText(suggestions[0].label));
+    });
+
+    // The field shows the human-friendly label...
+    expect(input).toHaveValue(suggestions[0].label);
+    // ...while the value is what gets submitted.
+    expect(handleInputChange).toHaveBeenCalledWith(suggestions[0].value, null);
+  });
+
+  it("submits a plain string suggestion unchanged (label === value)", async () => {
+    const suggestions: SuggestionValue[] = [{ label: "apple", value: "apple" }];
+    const { handleInputChange } = setup(suggestions);
+
+    const input = screen.getByRole("textbox");
+
+    await act(async () => {
+      fireEvent.focus(input);
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText(suggestions[0].label));
+    });
+
+    expect(input).toHaveValue("apple");
+    expect(handleInputChange).toHaveBeenCalledWith("apple", null);
+  });
+
+  it("submits the value when typed text exactly matches a suggestion label", async () => {
+    const suggestions: SuggestionValue[] = [{ label: "10 Gbps", value: "10000" }];
+    const { handleInputChange } = setup(suggestions);
+
+    const input = screen.getByRole("textbox");
+
+    await act(async () => {
+      fireEvent.change(input, { target: { value: "10 Gbps" } });
+    });
+
+    // Typing the label exactly links to the value behind it, without picking from the list.
+    expect(input).toHaveValue("10 Gbps");
+    expect(handleInputChange).toHaveBeenCalledWith("10000", null);
+  });
+
+  it("shows the typed value while editing and resolves it to the label on blur", async () => {
+    const suggestions: SuggestionValue[] = [{ label: "10 Gbps", value: "10000" }];
+
+    // Feeds the submitted value back as attributeValue, like the real form does.
+    const Controlled = () => {
+      const [value, setValue] = useState("");
+
+      return (
+        <TextFormInput
+          attributeName="text_field"
+          attributeValue={value}
+          description=""
+          isOptional
+          type={TextInputTypes.text}
+          handleInputChange={(submitted) => setValue(submitted ?? "")}
+          suggestions={suggestions}
+        />
+      );
+    };
+
+    render(<Controlled />);
+
+    const input = screen.getByRole("textbox");
+
+    await act(async () => {
+      fireEvent.change(input, { target: { value: "10000" } });
+    });
+
+    // While editing, the raw value stays visible — it must not flip mid-typing.
+    expect(input).toHaveValue("10000");
+
+    // Leaving the field is the commit point: the value resolves to its label.
+    await act(async () => {
+      fireEvent.blur(input);
+    });
+    expect(input).toHaveValue("10 Gbps");
+  });
+
+  it("maps a stored value back to its label on load (edit round-trip)", () => {
+    const suggestions: SuggestionValue[] = [{ label: "10 Gbps", value: "10000" }];
+
+    setup(suggestions, { attributeValue: "10000" });
+
+    // The field shows the label for the previously-saved value.
+    expect(screen.getByRole("textbox")).toHaveValue("10 Gbps");
+  });
+
+  it("resolves a loaded value to its label once async suggestions arrive (parameters round-trip)", () => {
+    const suggestions: SuggestionValue[] = [{ label: "10 Gbps", value: "10000" }];
+    const props = {
+      attributeName: "text_field",
+      attributeValue: "10000",
+      description: "",
+      isOptional: true,
+      type: TextInputTypes.text,
+      handleInputChange: vi.fn(),
+    };
+
+    // The parameters flavor loads suggestions asynchronously: at first there are none.
+    const { rerender } = render(<TextFormInput {...props} suggestions={[]} />);
+
+    expect(screen.getByRole("textbox")).toHaveValue("10000");
+
+    // Once they arrive, the effect re-derives the label for the loaded value.
+    rerender(<TextFormInput {...props} suggestions={suggestions} />);
+
+    expect(screen.getByRole("textbox")).toHaveValue("10 Gbps");
+  });
+
+  it("renders a numeric field with suggestions as text so a non-numeric label can show", async () => {
+    const suggestions: SuggestionValue[] = [{ label: "10 Gbps", value: "10000" }];
+    const { handleInputChange } = setup(suggestions, { type: TextInputTypes.number });
+
+    // A native number input (role "spinbutton") could not display "10 Gbps", so
+    // suggestion fields render as text (role "textbox").
+    const input = screen.getByRole("textbox");
+
+    expect(screen.queryByRole("spinbutton")).not.toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.focus(input);
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText(suggestions[0].label));
+    });
+
+    // The label is shown while the (string) value is submitted; the numeric type
+    // is enforced later by sanitizeAttributes at submit time.
+    expect(input).toHaveValue(suggestions[0].label);
+    expect(handleInputChange).toHaveBeenCalledWith(suggestions[0].value, null);
+  });
+});

--- a/src/UI/Components/ServiceInstanceForm/Components/TextFormInput.tsx
+++ b/src/UI/Components/ServiceInstanceForm/Components/TextFormInput.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import {
   Button,
   FormGroup,
@@ -11,7 +11,9 @@ import {
   TextInputTypes,
 } from "@patternfly/react-core";
 import { HelpIcon } from "@patternfly/react-icons";
+import { SuggestionValue } from "@/Core";
 import { SuggestionsPopover } from "./SuggestionsPopover";
+import { resolveLabel, resolveValue } from "./suggestionResolvers";
 
 interface Props {
   attributeName: string;
@@ -24,24 +26,13 @@ interface Props {
   shouldBeDisabled?: boolean;
   isTextarea?: boolean;
   handleInputChange: (value, event) => void;
-  suggestions?: string[] | null;
+  suggestions?: SuggestionValue[] | null;
 }
 
 /**
- * A form input component for text-based input fields.
- *
- * @component
- * @param {Props} props - The props for the TextListFormInput component.
- *  @prop {string} attributeName - The name of the attribute.
- *  @prop {string} attributeValue - The value of the attribute.
- *  @prop {string | null} description - The description of the attribute.
- *  @prop {boolean} isOptional - Whether the attribute is optional.
- *  @prop {boolean} shouldBeDisabled - Whether the attribute should be disabled. Default is false.
- *  @prop {string} typeHint - The type hint for the attribute.
- *  @prop {string} typeHint - The type hint for the attribute.
- *  @prop {string} placeholder - The placeholder for the input field.
- *  @prop {function} handleInputChange - The callback for handling input changes.
- *  @prop {string[]} suggestions - The suggestions for the input field.
+ * A text/textarea form input. With suggestions it behaves as a typeahead: the
+ * field shows a suggestion's `label` but submits its `value`, free typing still
+ * works, and a stored value is mapped back to its label on load.
  */
 export const TextFormInput: React.FC<Props> = ({
   attributeName,
@@ -57,27 +48,53 @@ export const TextFormInput: React.FC<Props> = ({
   suggestions = [],
   ...props
 }) => {
-  const inputRef = React.useRef<HTMLInputElement>(null);
-  const [isOpen, setIsOpen] = React.useState(false);
-  const [inputValue, setInputValue] = React.useState(attributeValue);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [isOpen, setIsOpen] = useState(false);
+  const hasSuggestions = !!(suggestions && suggestions.length > 0);
+  const editedRef = useRef(false);
+  const [displayValue, setDisplayValue] = useState<string>(() =>
+    resolveLabel(suggestions, attributeValue)
+  );
 
-  /**
-   * Handles the input change.
-   *
-   * @param {string} value - The new value of the input field.
-   *
-   * @returns {void}
-   */
-  const handleChange = (value) => {
-    setInputValue(value);
+  const handleType = (text: string) => {
+    editedRef.current = true;
+    setDisplayValue(text);
+
+    if (!hasSuggestions && type === "number") {
+      // Plain number field: convert the input to a number (empty -> null) right here.
+      handleInputChange(text === "" ? null : Number(text), null);
+    } else {
+      // Suggestion fields submit a string; sanitizeAttributes applies the
+      // attribute's real (e.g. numeric) type at submit.
+      handleInputChange(resolveValue(suggestions, text), null);
+    }
+  };
+
+  // Selecting a suggestion shows its label and submits its value.
+  const handleSelect = (value: string) => {
+    editedRef.current = true;
+    setDisplayValue(resolveLabel(suggestions, value));
+    handleInputChange(value, null);
+  };
+
+  // Leaving the field is its "commit" point: resolve the value to its label,
+  // Plain (non-suggestion) fields are left alone so their typed text isn't normalized.
+  const handleBlur = () => {
+    if (!hasSuggestions) {
+      return;
+    }
+    editedRef.current = false;
+    setDisplayValue(resolveLabel(suggestions, attributeValue));
   };
 
   useEffect(() => {
-    if (attributeValue !== inputValue) {
-      handleInputChange(inputValue, null);
+    // Show the label for the controlled value: on mount, on an edit round-trip,
+    // and once async suggestions arrive. Skipped while the user is editing
+    // (editedRef) so what they type is never overwritten by a resolved label.
+    if (!editedRef.current) {
+      setDisplayValue(resolveLabel(suggestions, attributeValue));
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [attributeValue, inputValue]);
+  }, [attributeValue, suggestions]);
 
   return (
     <FormGroup
@@ -108,8 +125,8 @@ export const TextFormInput: React.FC<Props> = ({
       </FormHelperText>
       {isTextarea ? (
         <TextArea
-          value={inputValue || ""}
-          onChange={(_event, value) => handleChange(value)}
+          value={displayValue || ""}
+          onChange={(_event, value) => handleType(value)}
           id={attributeName}
           name={attributeName}
           placeholder={placeholder}
@@ -123,35 +140,28 @@ export const TextFormInput: React.FC<Props> = ({
           <TextInput
             ref={inputRef}
             isRequired={!isOptional}
-            type={type}
+            // Rendered as text so a non-numeric label coupled to a numeric
+            // value can show (e.g. "10 Gbps" + 10000).
+            type={hasSuggestions ? TextInputTypes.text : type}
             id={attributeName}
             name={attributeName}
             placeholder={placeholder}
             aria-describedby={`${attributeName}-helper`}
             aria-label={`TextInput-${attributeName}`}
-            value={inputValue}
-            onChange={(_event, value) => {
-              if (type === "number") {
-                handleChange(value === "" ? null : Number(value));
-              } else {
-                handleChange(value);
-              }
-            }}
+            value={displayValue}
+            onChange={(_event, value) => handleType(value)}
             isDisabled={shouldBeDisabled}
-            onFocus={() => setIsOpen(true)}
+            onFocus={() => hasSuggestions && setIsOpen(true)}
+            onBlur={handleBlur}
           />
-          {suggestions && suggestions.length > 0 && (
+          {hasSuggestions && (
             <SuggestionsPopover
               suggestions={suggestions}
-              filter={inputRef.current?.value || ""}
-              handleSuggestionClick={(suggestion) => {
-                if (inputRef.current) {
-                  handleChange(suggestion);
-                }
-              }}
+              filter={displayValue}
+              handleSuggestionClick={handleSelect}
               ref={inputRef}
               isOpen={isOpen}
-              setIsOpen={setIsOpen}
+              close={() => setIsOpen(false)}
             />
           )}
         </>

--- a/src/UI/Components/ServiceInstanceForm/Components/TextFormInput.tsx
+++ b/src/UI/Components/ServiceInstanceForm/Components/TextFormInput.tsx
@@ -80,10 +80,10 @@ export const TextFormInput: React.FC<Props> = ({
   // Leaving the field is its "commit" point: resolve the value to its label,
   // Plain (non-suggestion) fields are left alone so their typed text isn't normalized.
   const handleBlur = () => {
+    editedRef.current = false;
     if (!hasSuggestions) {
       return;
     }
-    editedRef.current = false;
     setDisplayValue(resolveLabel(suggestions, attributeValue));
   };
 

--- a/src/UI/Components/ServiceInstanceForm/Components/TextListFormInput.test.tsx
+++ b/src/UI/Components/ServiceInstanceForm/Components/TextListFormInput.test.tsx
@@ -2,6 +2,7 @@ import { act } from "react";
 import { TextInputTypes } from "@patternfly/react-core";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
+import { SuggestionValue } from "@/Core";
 import { TextListFormInput } from "./TextListFormInput";
 
 describe("TextListInputField", () => {
@@ -95,37 +96,98 @@ describe("TextListInputField", () => {
     expect(handleClick).toHaveBeenCalledWith([], null);
   });
 
-  it("Should render an inputField with suggestions when suggestions are provided.", async () => {
+  it("Should show the selected suggestion's label in the input and store its value as a chip.", async () => {
+    const handleInputChange = vi.fn();
+    const suggestions: SuggestionValue[] = [{ label: "Production network", value: "9f3c1b2a" }];
+
     render(
       <TextListFormInput
         attributeName="text_list"
         type={TextInputTypes.text}
-        attributeValue={["value1", "value2", "value3"]}
+        attributeValue={[]}
         description="a text list input field"
-        handleInputChange={handleClick}
-        suggestions={["apple", "banana", "cherry"]}
+        handleInputChange={handleInputChange}
+        suggestions={suggestions}
       />
     );
 
-    // Open the suggestions popover
     const input = screen.getByRole("textbox");
 
-    //this action require act due to updates within the patternfly component triggering "act warning"
     await act(async () => {
       fireEvent.focus(input);
     });
 
-    // Check if the values are present
-    const firstSuggestion = screen.getByText("apple");
+    // The dropdown shows the label, not the raw value.
+    expect(screen.getByText(suggestions[0].label)).toBeInTheDocument();
+    expect(screen.queryByText(suggestions[0].value)).not.toBeInTheDocument();
 
-    expect(firstSuggestion).toBeInTheDocument();
+    // Selecting puts the label into the input...
+    await act(async () => {
+      fireEvent.click(screen.getByText(suggestions[0].label));
+    });
+    expect(input).toHaveValue(suggestions[0].label);
 
-    const secondSuggestion = screen.getByText("banana");
+    // ...and adding it stores the value, while the chip still shows the label.
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Add" }));
+    });
 
-    expect(secondSuggestion).toBeInTheDocument();
+    expect(handleInputChange).toHaveBeenCalledWith([suggestions[0].value], null);
 
-    const thirdSuggestion = screen.getByText("cherry");
+    const chips = screen.getAllByRole("listitem");
 
-    expect(thirdSuggestion).toBeInTheDocument();
+    expect(chips).toHaveLength(1);
+    expect(chips[0]).toHaveTextContent(suggestions[0].label);
+    expect(chips[0]).not.toHaveTextContent(suggestions[0].value);
+  });
+
+  it("Should store the value when a typed label exactly matches a suggestion (no list pick).", async () => {
+    const handleInputChange = vi.fn();
+    const suggestions: SuggestionValue[] = [{ label: "10 Gbps", value: "10000" }];
+
+    render(
+      <TextListFormInput
+        attributeName="text_list"
+        type={TextInputTypes.text}
+        attributeValue={[]}
+        description="a text list input field"
+        handleInputChange={handleInputChange}
+        suggestions={suggestions}
+      />
+    );
+
+    const input = screen.getByRole("textbox");
+
+    await userEvent.type(input, "10 Gbps");
+    await userEvent.click(screen.getByRole("button", { name: "Add" }));
+
+    // Typed label links to the value behind it, just like picking it from the list.
+    expect(handleInputChange).toHaveBeenCalledWith(["10000"], null);
+
+    const chips = screen.getAllByRole("listitem");
+
+    expect(chips).toHaveLength(1);
+    expect(chips[0]).toHaveTextContent("10 Gbps");
+  });
+
+  it("Should map stored values back to their labels on load (edit round-trip).", () => {
+    const suggestions: SuggestionValue[] = [{ label: "10 Gbps", value: "10000" }];
+
+    render(
+      <TextListFormInput
+        attributeName="text_list"
+        type={TextInputTypes.text}
+        attributeValue={["10000"]}
+        description="a text list input field"
+        handleInputChange={vi.fn()}
+        suggestions={suggestions}
+      />
+    );
+
+    const chips = screen.getAllByRole("listitem");
+
+    expect(chips).toHaveLength(1);
+    expect(chips[0]).toHaveTextContent("10 Gbps");
+    expect(chips[0]).not.toHaveTextContent("10000");
   });
 });

--- a/src/UI/Components/ServiceInstanceForm/Components/TextListFormInput.tsx
+++ b/src/UI/Components/ServiceInstanceForm/Components/TextListFormInput.tsx
@@ -1,7 +1,4 @@
-/**
- * A form input component for managing a list of text values.
- */
-import React, { useEffect } from "react";
+import React, { useEffect, useRef } from "react";
 import {
   Label,
   LabelGroup,
@@ -19,8 +16,10 @@ import {
 } from "@patternfly/react-core";
 
 import { HelpIcon, TimesIcon } from "@patternfly/react-icons";
+import { SuggestionValue } from "@/Core";
 import { words } from "@/UI/words";
 import { SuggestionsPopover } from "./SuggestionsPopover";
+import { resolveLabel, resolveValue } from "./suggestionResolvers";
 
 /**
  * Props for the TextListFormInput component.
@@ -34,22 +33,25 @@ interface Props {
   typeHint?: string;
   placeholder?: string;
   handleInputChange: (value: string[], event: React.FormEvent<HTMLInputElement> | null) => void;
-  suggestions?: string[] | null;
+  suggestions?: SuggestionValue[] | null;
 }
 
 /**
  * A form input component for managing a list of text values.
  *
+ * When suggestions are provided, the field behaves as a typeahead: each chip
+ * displays the suggestion's `label` while the stored/submitted value is its
+ * `value`. Free typing still works (the typed text is both shown and stored).
+ *
  * @props {Props} props - The props for the TextListFormInput component.
  *  @prop {string} attributeName - The name of the attribute.
- *  @prop {string[]} attributeValue - The value of the attribute.
+ *  @prop {string[]} attributeValue - The submitted values of the attribute.
  *  @prop {string | null} description - The description of the attribute.
  *  @prop {boolean} shouldBeDisabled - Whether the attribute should be disabled. Default is false.
  *  @prop {string} typeHint - The type hint for the attribute.
- *  @prop {string} typeHint - The type hint for the attribute.
  *  @prop {string} placeholder - The placeholder for the input field.
  *  @prop {function} handleInputChange - The callback for handling input changes.
- *  @prop {string[]} suggestions - The suggestions for the input field.
+ *  @prop {SuggestionValue[]} suggestions - The suggestions for the input field; selecting one stores its `value` and displays its `label`.
  *
  *  @returns {React.FC<Props>} The TextListFormInput component.
  */
@@ -67,11 +69,12 @@ export const TextListFormInput: React.FC<Props> = ({
   const [inputValue, setInputValue] = React.useState("");
   const [currentChips, setCurrentChips] = React.useState<string[]>([]);
   const [isOpen, setIsOpen] = React.useState(false);
-  const inputRef = React.useRef<HTMLInputElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const hasSuggestions = !!(suggestions && suggestions.length > 0);
 
   /**
    * Callback for removing a chip from the chip selections.
-   * @param chipToDelete - The chip to be removed.
+   * @param chipToDelete - The chip value to be removed.
    */
   const deleteChip = (chipToDelete: string) => {
     const newChips = currentChips.filter((chip) => !Object.is(chip, chipToDelete));
@@ -92,17 +95,24 @@ export const TextListFormInput: React.FC<Props> = ({
   };
 
   /**
-   * Adds a new chip to the chip selections.
+   * Adds a new chip. When the input text matches a suggestion label (whether
+   * picked from the list or typed), that suggestion's value is stored; otherwise
+   * the typed text is stored as-is.
    *
    * @returns {void}
    */
   const addChip = () => {
-    if (inputValue.trim()) {
-      const newChips = [...currentChips, inputValue.trim()];
-      setCurrentChips(newChips);
-      handleInputChange(newChips, null);
-      setInputValue("");
+    const trimmed = inputValue.trim();
+
+    if (!trimmed) {
+      return;
     }
+
+    const newChips = [...currentChips, resolveValue(suggestions, trimmed)];
+
+    setCurrentChips(newChips);
+    handleInputChange(newChips, null);
+    setInputValue("");
   };
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
@@ -152,16 +162,16 @@ export const TextListFormInput: React.FC<Props> = ({
         </HelperText>
       </FormHelperText>
       <TextInputGroup isDisabled={shouldBeDisabled}>
-        {suggestions && suggestions.length > 0 && (
+        {hasSuggestions && (
           <SuggestionsPopover
             suggestions={suggestions}
             filter={inputValue}
-            handleSuggestionClick={(suggestion) => {
-              setInputValue(suggestion);
+            handleSuggestionClick={(value) => {
+              setInputValue(resolveLabel(suggestions, value));
             }}
             ref={inputRef}
             isOpen={isOpen}
-            setIsOpen={setIsOpen}
+            close={() => setIsOpen(false)}
           />
         )}
         <TextInputGroupMain
@@ -169,7 +179,7 @@ export const TextListFormInput: React.FC<Props> = ({
           value={inputValue}
           placeholder={placeholder}
           onChange={handleChangeInput}
-          onFocus={() => setIsOpen(true)}
+          onFocus={() => hasSuggestions && setIsOpen(true)}
           onKeyDown={handleKeyDown}
         >
           <LabelGroup>
@@ -179,9 +189,9 @@ export const TextListFormInput: React.FC<Props> = ({
                 key={currentChip}
                 onClose={() => deleteChip(currentChip)}
                 disabled={shouldBeDisabled}
-                closeBtnAriaLabel={`Close ${currentChip}`}
+                closeBtnAriaLabel={`Close ${resolveLabel(suggestions, currentChip)}`}
               >
-                <Truncate content={currentChip} />
+                <Truncate content={resolveLabel(suggestions, currentChip)} />
               </Label>
             ))}
           </LabelGroup>

--- a/src/UI/Components/ServiceInstanceForm/Components/suggestionResolvers.ts
+++ b/src/UI/Components/ServiceInstanceForm/Components/suggestionResolvers.ts
@@ -14,6 +14,10 @@ export const resolveLabel = (
 /**
  * Resolves the value to submit for typed text: if it exactly matches a
  * suggestion's label, returns that suggestion's value; otherwise the text itself.
+ *
+ * Note: typing a string that exactly equals a label is deliberately treated as
+ * selecting that suggestion, so the underlying value is submitted rather than
+ * the literal text.
  */
 export const resolveValue = (
   suggestions: SuggestionValue[] | null | undefined,

--- a/src/UI/Components/ServiceInstanceForm/Components/suggestionResolvers.ts
+++ b/src/UI/Components/ServiceInstanceForm/Components/suggestionResolvers.ts
@@ -1,0 +1,21 @@
+import { SuggestionValue } from "@/Core";
+
+/**
+ * Resolves the label to display for a submitted value (reverse lookup),
+ * falling back to the value itself when no suggestion matches.
+ */
+export const resolveLabel = (
+  suggestions: SuggestionValue[] | null | undefined,
+  value: unknown
+): string =>
+  suggestions?.find((suggestion) => suggestion.value === String(value ?? ""))?.label ??
+  String(value ?? "");
+
+/**
+ * Resolves the value to submit for typed text: if it exactly matches a
+ * suggestion's label, returns that suggestion's value; otherwise the text itself.
+ */
+export const resolveValue = (
+  suggestions: SuggestionValue[] | null | undefined,
+  text: string
+): string => suggestions?.find((suggestion) => suggestion.label === text)?.value ?? text;


### PR DESCRIPTION
# Description

- Add a `SuggestionValue` `{ label, value }` type; `FormSuggestion.values` now accepts plain strings or `{ label, value }` pairs
- Normalize every suggestion flavor (literal, parameters) to one `{ label, value }[]` shape in `useSuggestions`, coercing numeric fields to strings

So essentially it's now possible to use label/value pairs for the form suggestions and everything will get normalized into that shape.
Wrote tests to try and minimize/catch regressions.
I think more improvements are possible but I split possible future form improvements (mostly keyboard related) into a different ticket to try and stick to the scope/essence of the ticket.

Below the example (10Gbps as label  => 10000 as value):
<img width="363" height="139" alt="Screenshot 2026-06-26 at 15 38 29" src="https://github.com/user-attachments/assets/303db02b-517d-41a8-9c33-95c521534982" />
<img width="551" height="272" alt="Screenshot 2026-06-26 at 15 38 34" src="https://github.com/user-attachments/assets/4a306ddb-27a2-4a03-a695-dccbf9f1d996" />


closes https://github.com/inmanta/web-console/issues/7008

