### PR TITLE
Align and soften version dropdown timestamps in attribute comparison

### DIFF
--- a/changelogs/unreleased/7044-version-dropdown-timestamp.yml
+++ b/changelogs/unreleased/7044-version-dropdown-timestamp.yml
@@ -1,0 +1,6 @@
+description: In the attribute comparison view, the version dropdown now aligns each version's timestamp in a column and renders it as smaller, subtler text.
+issue-nr: 7044
+change-type: patch
+destination-branches: [master, iso9]
+sections:
+  minor-improvement: "{{description}}"

--- a/src/Slices/ServiceInstanceDetails/UI/Components/AttributesComponents/AttributesCompare.tsx
+++ b/src/Slices/ServiceInstanceDetails/UI/Components/AttributesComponents/AttributesCompare.tsx
@@ -7,7 +7,7 @@ import {
   FormSelect,
   FormSelectOption,
   SelectOptionProps,
-  Label,
+  Content,
 } from "@patternfly/react-core";
 import { InstanceAttributeModel } from "@/Core";
 import { InstanceLog } from "@/Core/Domain/HistoryLog";
@@ -53,21 +53,33 @@ export const AttributesCompare: React.FC<Props> = ({ instanceLogs, selectedVersi
 
   const { theme: preferredTheme } = useTheme();
 
-  const availableVersions: SelectOptionProps[] = useMemo(
-    () =>
-      instanceLogs.map(({ version, timestamp }) => ({
-        value: version,
-        children: (
-          <Flex gap={{ default: "gapSm" }} alignItems={{ default: "alignItemsCenter" }}>
-            {version}
-            <Label color="blue" variant="outline">
-              {datePresenter.getFull(timestamp)}
-            </Label>
-          </Flex>
-        ),
-      })),
-    [instanceLogs]
-  );
+  const availableVersions: SelectOptionProps[] = useMemo(() => {
+    // Width of the longest version, so every timestamp starts at the same place.
+    const versionColWidth = instanceLogs.length
+      ? Math.max(...instanceLogs.map(({ version }) => String(version).length))
+      : 0;
+
+    return instanceLogs.map(({ version, timestamp }) => ({
+      value: version,
+      children: (
+        <Flex
+          gap={{ default: "gapSm" }}
+          alignItems={{ default: "alignItemsCenter" }}
+          flexWrap={{ default: "nowrap" }}
+        >
+          <Content style={{ minWidth: `${versionColWidth}ch` }}>{version}</Content>
+          <Content
+            style={{
+              fontSize: "var(--pf-t--global--font--size--body--sm)",
+              color: "var(--pf-t--global--text--color--subtle)",
+            }}
+          >
+            {datePresenter.getFull(timestamp)}
+          </Content>
+        </Flex>
+      ),
+    }));
+  }, [instanceLogs]);
 
   useEffect(() => {
     if (rightVersion) {

--- a/src/Slices/ServiceInstanceDetails/UI/Components/AttributesComponents/AttributesCompare.tsx
+++ b/src/Slices/ServiceInstanceDetails/UI/Components/AttributesComponents/AttributesCompare.tsx
@@ -68,14 +68,7 @@ export const AttributesCompare: React.FC<Props> = ({ instanceLogs, selectedVersi
           flexWrap={{ default: "nowrap" }}
         >
           <Content style={{ minWidth: `${versionColWidth}ch` }}>{version}</Content>
-          <Content
-            style={{
-              fontSize: "var(--pf-t--global--font--size--body--sm)",
-              color: "var(--pf-t--global--text--color--subtle)",
-            }}
-          >
-            {datePresenter.getFull(timestamp)}
-          </Content>
+          <Content component="small">{datePresenter.getFull(timestamp)}</Content>
         </Flex>
       ),
     }));


### PR DESCRIPTION
# Description

- Version dropdown timestamps now align in a column, sized to the widest version via a derived ch min-width
- Timestamps render smaller (body--sm token) and subtler (text--color--subtle token), with the label outline removed

=> This should be way more subtle without doing crazy adjustments

closes https://github.com/inmanta/web-console/issues/7044

<img width="322" height="404" alt="Screenshot 2026-06-29 at 14 58 26" src="https://github.com/user-attachments/assets/c9dd9763-006f-4a72-989f-3645b4d9fda4" />