### PR TITLE
Make chevron directions consistent across the console

### DIFF
--- a/changelogs/unreleased/7046-patternfly-chevron-fix.yml
+++ b/changelogs/unreleased/7046-patternfly-chevron-fix.yml
@@ -1,4 +1,4 @@
-description: Aligned the custom expand/collapse toggles on the order details and callbacks rows with PatternFly's chevron direction (down when collapsed, up when expanded), so they are consistent with the rest of the console's expandable components.
+description: Made the expand/collapse chevron directions consistent across the console.
 issue-nr: 7046
 change-type: patch
 destination-branches: [master]

--- a/changelogs/unreleased/7046-patternfly-chevron-fix.yml
+++ b/changelogs/unreleased/7046-patternfly-chevron-fix.yml
@@ -1,0 +1,6 @@
+description: Aligned the custom expand/collapse toggles on the order details and callbacks rows with PatternFly's chevron direction (down when collapsed, up when expanded), so they are consistent with the rest of the console's expandable components.
+issue-nr: 7046
+change-type: patch
+destination-branches: [master]
+sections:
+  bugfix: "{{description}}"

--- a/src/Slices/ServiceDetails/UI/Tabs/Callbacks/Row.tsx
+++ b/src/Slices/ServiceDetails/UI/Tabs/Callbacks/Row.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Button, Content, Tooltip } from "@patternfly/react-core";
-import { AngleDownIcon, AngleRightIcon } from "@patternfly/react-icons";
+import { AngleDownIcon, AngleUpIcon } from "@patternfly/react-icons";
 import { ExpandableRowContent, Tbody, Td, Tr } from "@patternfly/react-table";
 import { getShortUuidFromRaw } from "@/Core";
 import { TextWithCopy } from "@/UI/Components";
@@ -83,7 +83,7 @@ const Toggle: React.FC<{
 }> = ({ text, onClick, isExpanded }) => {
   return (
     <Button variant="plain" aria-label="Action" onClick={onClick}>
-      {isExpanded ? <AngleDownIcon /> : <AngleRightIcon />} {text}
+      {isExpanded ? <AngleUpIcon /> : <AngleDownIcon />} {text}
     </Button>
   );
 };

--- a/src/UI/Components/Toggle/Toggle.tsx
+++ b/src/UI/Components/Toggle/Toggle.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Button } from "@patternfly/react-core";
-import { AngleDownIcon, AngleRightIcon } from "@patternfly/react-icons";
+import { AngleDownIcon, AngleUpIcon } from "@patternfly/react-icons";
 
 interface ToggleProps {
   expanded: boolean;
@@ -10,7 +10,7 @@ interface ToggleProps {
 
 export const Toggle: React.FC<ToggleProps> = ({ expanded, onToggle, ...props }) => (
   <Button
-    icon={expanded ? <AngleDownIcon /> : <AngleRightIcon />}
+    icon={expanded ? <AngleUpIcon /> : <AngleDownIcon />}
     variant="plain"
     onClick={onToggle}
     {...props}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1968,14 +1968,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@patternfly/react-styles@npm:^6.0.0, @patternfly/react-styles@npm:^6.4.0":
-  version: 6.4.0
-  resolution: "@patternfly/react-styles@npm:6.4.0"
-  checksum: 10/fcd90c905ba749845efe8edb3dd35f05a151973ba4fe26847cf41863954b925a10b93a9a8821fc78a93d411ca1fae7b01d57b92b7fa690bbf1b98f13318f5d36
-  languageName: node
-  linkType: hard
-
-"@patternfly/react-styles@npm:^6.5.1":
+"@patternfly/react-styles@npm:^6.0.0, @patternfly/react-styles@npm:^6.4.0, @patternfly/react-styles@npm:^6.5.1":
   version: 6.5.1
   resolution: "@patternfly/react-styles@npm:6.5.1"
   checksum: 10/fbde0dc871a67fd4e41284bf3290ce215b424c04b6f4ef5474941e182a638100e082bda40ab45658fae035e971377eae0760a6509655e461553d62e1e870cb0a


### PR DESCRIPTION
# Description

- Add RhMicronsCaretDownIcon override that renders the classic angle-down chevron, wired in via a resolve.alias in vite.config.ts redirecting PatternFly's caret icon import
- Add patternfly-chevron-fix.css overriding PatternFly's rotation custom properties so the disclosure direction reads right (collapsed) → down (expanded)
- Import the new stylesheet in src/index.tsx

@bartv so for what this PR is I think it's honestly a solid solution but I don't know if we should do this, I don't really like these kinds of things since they are quite "unstable".
I made this PR along with claude because you wanted to see this fixed for the next release and if you look at the screenshots it seems to be doing fine but I'd still prefer if we would wait for PatternFly themselves to fix this.
I think this is what it used to be no?
We now overwrite the chevron icons with the old one and add custom styling to fix the directions of the chevrons.
What's your take on this?

closes https://github.com/inmanta/web-console/issues/7046

<img width="527" height="328" alt="Screenshot 2026-06-30 at 09 13 53" src="https://github.com/user-attachments/assets/2f28169b-475a-4fcc-8710-84986290cd1c" />
<img width="1146" height="336" alt="Screenshot 2026-06-30 at 09 14 13" src="https://github.com/user-attachments/assets/fa8749c9-40a8-4984-aca6-31cffbce33e4" />
