### PR TITLE
Fix blank dashboard flash when deleting an environment

### DIFF
--- a/changelogs/unreleased/7058-delete-env-redirect.yml
+++ b/changelogs/unreleased/7058-delete-env-redirect.yml
@@ -1,0 +1,6 @@
+description: Deleting an environment no longer briefly shows a blank or errored dashboard; the console now navigates directly to a remaining environment (or the Create Environment page when none are left).
+issue-nr: 7058
+change-type: patch
+destination-branches: [master, iso9]
+sections:
+  bugfix: "{{description}}"

--- a/src/Slices/Settings/UI/Tabs/Environment/Components/Actions.test.tsx
+++ b/src/Slices/Settings/UI/Tabs/Environment/Components/Actions.test.tsx
@@ -1,18 +1,39 @@
+import { useLocation } from "react-router";
 import { QueryClientProvider } from "@tanstack/react-query";
-import { render, screen, within } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
 import { setupServer } from "msw/node";
-import { EnvironmentDetails, MockedDependencyProvider } from "@/Test";
+import { EnvironmentPreview } from "@/Data/Queries";
+import { Environment, EnvironmentDetails, MockedDependencyProvider } from "@/Test";
 import { testClient } from "@/Test/Utils/react-query-setup";
 import { ModalProvider } from "@/UI/Root/Components/ModalProvider";
 import { TestMemoryRouter } from "@/UI/Routing/TestMemoryRouter";
 import { Actions } from "./Actions";
 
-function setup(protectedEnvironment: boolean = false) {
+/**
+ * Renders the current router location so navigation triggered by the component under test can be
+ * asserted (pathname and search are exposed separately to keep assertions precise).
+ */
+const LocationView = () => {
+  const location = useLocation();
+
+  return (
+    <>
+      <div data-testid="location-pathname">{location.pathname}</div>
+      <div data-testid="location-search">{location.search}</div>
+    </>
+  );
+};
+
+function setup(
+  protectedEnvironment: boolean = false,
+  allEnvironments: EnvironmentPreview[] = [],
+  environment: { id: string; name: string } = { id: "env", name: "connect" }
+) {
   const component = (
     <QueryClientProvider client={testClient}>
-      <TestMemoryRouter>
+      <TestMemoryRouter initialEntries={[`/?env=${environment.id}`]}>
         <MockedDependencyProvider
           env={{
             ...EnvironmentDetails.env,
@@ -21,10 +42,12 @@ function setup(protectedEnvironment: boolean = false) {
               protected_environment: protectedEnvironment,
             },
           }}
+          allEnvironments={allEnvironments}
         >
           <ModalProvider>
-            <Actions environment={{ id: "env", name: "connect" }} />
+            <Actions environment={environment} />
           </ModalProvider>
+          <LocationView />
         </MockedDependencyProvider>
       </TestMemoryRouter>
     </QueryClientProvider>
@@ -117,6 +140,51 @@ describe("Environment Actions", () => {
     await userEvent.click(deleteButton);
 
     expect(counter).toBe(1);
+  });
+
+  test("GIVEN delete executed WHEN other environments remain THEN navigates directly to a surviving env", async () => {
+    const { previewA, previewB } = Environment;
+
+    server.use(http.delete(`/api/v2/environment/${previewA.id}`, () => HttpResponse.json()));
+    // Delete previewA while previewB survives; previewA must be filtered out of the navigation target.
+    const { component } = setup(false, [previewA, previewB], previewA);
+
+    render(component);
+
+    await userEvent.click(await screen.findByRole("button", { name: "Delete environment" }));
+    await userEvent.type(
+      screen.getByRole<HTMLInputElement>("textbox", { name: "delete environment check" }),
+      previewA.name
+    );
+    await userEvent.click(screen.getByRole("button", { name: "delete" }));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("location-search")).toHaveTextContent(`?env=${previewB.id}`)
+    );
+    expect(screen.getByTestId("location-pathname")).toHaveTextContent("/dashboard");
+  });
+
+  test("GIVEN delete executed WHEN no environments remain THEN falls back to the home redirect", async () => {
+    const { previewA } = Environment;
+
+    server.use(http.delete(`/api/v2/environment/${previewA.id}`, () => HttpResponse.json()));
+    // previewA is the only environment, so `remaining` is empty and we defer to the Provider (redirectToHome)
+    const { component } = setup(false, [previewA], previewA);
+
+    render(component);
+
+    await userEvent.click(await screen.findByRole("button", { name: "Delete environment" }));
+    await userEvent.type(
+      screen.getByRole<HTMLInputElement>("textbox", { name: "delete environment check" }),
+      previewA.name
+    );
+    await userEvent.click(screen.getByRole("button", { name: "delete" }));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("location-pathname")).toHaveTextContent("/dashboard")
+    );
+    // No surviving env to select, so the current search is preserved rather than pointing at one.
+    expect(screen.getByTestId("location-search")).toHaveTextContent(`?env=${previewA.id}`);
   });
 
   test("GIVEN Environment Actions and delete modal WHEN delete executed and error THEN error is shown", async () => {

--- a/src/Slices/Settings/UI/Tabs/Environment/Components/ConfirmationForm.tsx
+++ b/src/Slices/Settings/UI/Tabs/Environment/Components/ConfirmationForm.tsx
@@ -12,8 +12,14 @@ import {
 import { useQueryClient } from "@tanstack/react-query";
 import styled from "styled-components";
 import { FlatEnvironment } from "@/Core";
-import { useClearEnvironment, useDeleteEnvironment, getEnvironmentsKey } from "@/Data/Queries";
+import {
+  useClearEnvironment,
+  useDeleteEnvironment,
+  getEnvironmentsKey,
+  GetEnvironmentPreviewKey,
+} from "@/Data/Queries";
 import { AppAlert } from "@/UI/Components";
+import { DependencyContext } from "@/UI/Dependency";
 import { ModalContext } from "@/UI/Root/Components/ModalProvider";
 import { useNavigateTo } from "@/UI/Routing";
 import { words } from "@/UI/words";
@@ -35,8 +41,10 @@ interface Props {
  */
 export const ConfirmationForm: React.FC<Props> = ({ environment, type }) => {
   const { closeModal } = useContext(ModalContext);
+  const { environmentHandler } = useContext(DependencyContext);
   const navigateTo = useNavigateTo();
   const client = useQueryClient();
+  const allEnvironments = environmentHandler.useAll();
 
   const [candidateEnv, setCandidateEnv] = useState("");
   const [errorMessage, setErrorMessage] = useState<null | string>(null);
@@ -46,13 +54,27 @@ export const ConfirmationForm: React.FC<Props> = ({ environment, type }) => {
   const redirectToHome = () => navigateTo("Dashboard", undefined);
 
   const deleteEnv = useDeleteEnvironment(environment.id, {
-    onSuccess: () => {
-      //reset the queries removes the cache which improves the ux when navigating back to the environments page,
-      // without it the user won't see loading state and will see the old data for a split second and then removed env will be removed from the view
+    onSuccess: async () => {
+      // reset removes the cache so the header env selector / user management list show a loading
+      // state instead of briefly rendering the deleted env. Fire-and-forget: neither drives the redirect.
       client.resetQueries({ queryKey: getEnvironmentsKey.root() });
 
+      // Refresh the preview list (feeds the header env preview and PageFrame/Provider) so the deleted
+      // env is gone app-wide. Awaited so the empty-list case below sees an up-to-date allEnvironments.
+      await client.refetchQueries({ queryKey: GetEnvironmentPreviewKey.root() });
+
       closeModal();
-      redirectToHome();
+
+      // Navigate straight to a surviving env instead of the neutral Dashboard URL, so we skip the
+      // Provider's missing-env bounce that would otherwise flash a blank Dashboard. When no envs are
+      // left, fall back to the Provider (redirectToHome) so its "no environments" toast still fires.
+      const remaining = allEnvironments.filter((env) => env.id !== environment.id);
+
+      if (remaining.length > 0) {
+        navigateTo("Dashboard", undefined, `?env=${remaining[0].id}`);
+      } else {
+        redirectToHome();
+      }
     },
     onError: (error) => {
       setErrorMessage(error.message);

--- a/src/Slices/Settings/UI/Tabs/Environment/Components/ConfirmationForm.tsx
+++ b/src/Slices/Settings/UI/Tabs/Environment/Components/ConfirmationForm.tsx
@@ -51,7 +51,7 @@ export const ConfirmationForm: React.FC<Props> = ({ environment, type }) => {
   const [isBusy, setIsBusy] = useState(false);
   const validated = environment.name === candidateEnv ? "success" : "default";
 
-  const redirectToHome = () => navigateTo("Dashboard", undefined);
+  const redirectToHome = () => navigateTo("Dashboard", undefined, undefined, { replace: true });
 
   const deleteEnv = useDeleteEnvironment(environment.id, {
     onSuccess: async () => {
@@ -60,7 +60,9 @@ export const ConfirmationForm: React.FC<Props> = ({ environment, type }) => {
       client.resetQueries({ queryKey: getEnvironmentsKey.root() });
 
       // Refresh the preview list (feeds the header env preview and PageFrame/Provider) so the deleted
-      // env is gone app-wide. Awaited so the empty-list case below sees an up-to-date allEnvironments.
+      // env is gone app-wide. Awaited so the empty-list fallback below reaches the Provider only after
+      // the list has emptied. Note: allEnvironments here is the render snapshot and is NOT refreshed by
+      // this await — the filter below drops the deleted env, which is what makes `remaining` correct.
       await client.refetchQueries({ queryKey: GetEnvironmentPreviewKey.root() });
 
       closeModal();
@@ -68,10 +70,11 @@ export const ConfirmationForm: React.FC<Props> = ({ environment, type }) => {
       // Navigate straight to a surviving env instead of the neutral Dashboard URL, so we skip the
       // Provider's missing-env bounce that would otherwise flash a blank Dashboard. When no envs are
       // left, fall back to the Provider (redirectToHome) so its "no environments" toast still fires.
+      // Both replace the history entry so Back doesn't return to the deleted env's URL.
       const remaining = allEnvironments.filter((env) => env.id !== environment.id);
 
       if (remaining.length > 0) {
-        navigateTo("Dashboard", undefined, `?env=${remaining[0].id}`);
+        navigateTo("Dashboard", undefined, `?env=${remaining[0].id}`, { replace: true });
       } else {
         redirectToHome();
       }

--- a/src/Slices/Settings/UI/Tabs/Environment/Components/ConfirmationForm.tsx
+++ b/src/Slices/Settings/UI/Tabs/Environment/Components/ConfirmationForm.tsx
@@ -62,7 +62,7 @@ export const ConfirmationForm: React.FC<Props> = ({ environment, type }) => {
       // Refresh the preview list (feeds the header env preview and PageFrame/Provider) so the deleted
       // env is gone app-wide. Awaited so the empty-list fallback below reaches the Provider only after
       // the list has emptied. Note: allEnvironments here is the render snapshot and is NOT refreshed by
-      // this await — the filter below drops the deleted env, which is what makes `remaining` correct.
+      // this await; the filter below drops the deleted env, which is what makes `remaining` correct.
       await client.refetchQueries({ queryKey: GetEnvironmentPreviewKey.root() });
 
       closeModal();

--- a/src/Test/Inject/dependencies.tsx
+++ b/src/Test/Inject/dependencies.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { FlatEnvironment } from "@/Core";
 import { AuthContextInterface, PrimaryArchiveHelper, defaultAuthContext } from "@/Data";
+import { EnvironmentPreview } from "@/Data/Queries";
 import { EnvironmentDetails } from "@/Test";
 import { MockEnvironmentHandler, MockOrchestratorProvider, MockFileManager } from "@/Test/Mock";
 import { DependencyProvider } from "@/UI/Dependency";
@@ -12,6 +13,7 @@ interface Props {
   env?: FlatEnvironment;
   authHelper?: AuthContextInterface;
   isCompiling?: boolean;
+  allEnvironments?: EnvironmentPreview[];
 }
 
 /**
@@ -23,11 +25,12 @@ export const MockedDependencyProvider: React.FC<React.PropsWithChildren<Props>> 
   env = EnvironmentDetails.env,
   authHelper = defaultAuthContext,
   isCompiling = false,
+  allEnvironments = [],
   children,
 }) => {
   const baseUrl = "";
   const routeManager = PrimaryRouteManager(baseUrl);
-  const environmentHandler = MockEnvironmentHandler(env, isCompiling);
+  const environmentHandler = MockEnvironmentHandler(env, isCompiling, allEnvironments);
   const orchestratorProvider = new MockOrchestratorProvider();
   const urlManager = new UrlManagerImpl(orchestratorProvider, baseUrl);
   const fileManager = new MockFileManager();

--- a/src/Test/Mock/MockEnvironmentHandler.ts
+++ b/src/Test/Mock/MockEnvironmentHandler.ts
@@ -5,11 +5,15 @@ import { EnvironmentPreview } from "@/Data/Queries";
  * MockEnvironmentHandler is a function that returns a mocked EnvironmentHandler object.
  *
  * @param {FlatEnvironment} environment - The environment to be used in the mock.
+ * @param {boolean} isCompiling - Whether the mocked environment reports as compiling.
+ * @param {EnvironmentPreview[]} allEnvironments - The list returned by `useAll()`, for tests that
+ *   exercise logic depending on the full environment list (defaults to empty).
  * @returns {EnvironmentHandler}An EnvironmentHandler object.
  */
 export function MockEnvironmentHandler(
   environment: FlatEnvironment,
-  isCompiling: boolean = false
+  isCompiling: boolean = false,
+  allEnvironments: EnvironmentPreview[] = []
 ): EnvironmentHandler {
   function useName(): string {
     return environment.name;
@@ -62,7 +66,7 @@ export function MockEnvironmentHandler(
   }
 
   function useAll(): EnvironmentPreview[] {
-    return [];
+    return allEnvironments;
   }
 
   return {

--- a/src/UI/Routing/Utils.ts
+++ b/src/UI/Routing/Utils.ts
@@ -1,13 +1,23 @@
 import { useContext, useEffect } from "react";
-import { useNavigate, useLocation, useParams, Params } from "react-router";
+import { useNavigate, useLocation, useParams, Params, NavigateOptions } from "react-router";
 import { RouteKind, RouteParams } from "@/Core";
 import { DependencyContext } from "@/UI/Dependency";
 
-type NavigateTo = (kind: RouteKind, params: RouteParams<typeof kind>, search?: string) => void;
+type NavigateTo = (
+  kind: RouteKind,
+  params: RouteParams<typeof kind>,
+  newSearch?: string,
+  options?: NavigateOptions
+) => void;
 
 /**
  * The useNavigateTo hook returns a navigateTo function which navigates to a route.
- * @param newSearch This string should start with a question mark "?".
+ * @param kind The route to navigate to.
+ * @param params The route parameters for that route.
+ * @param newSearch The query string to use; must start with a question mark "?". When omitted, the
+ *   current location's search is preserved.
+ * @param options React Router's `NavigateOptions` (e.g. `{ replace: true }` to replace the current
+ *   history entry instead of pushing a new one — useful for redirects).
  * @throws Will throw an error when newSearch is invalid
  */
 export const useNavigateTo = (): NavigateTo => {
@@ -15,14 +25,14 @@ export const useNavigateTo = (): NavigateTo => {
   const { search } = useLocation();
   const navigate = useNavigate();
 
-  return (routeKind, params, newSearch) => {
+  return (routeKind, params, newSearch, options) => {
     if (newSearch !== undefined) {
       validateSearch(newSearch);
     }
 
     const pathname = routeManager.getUrl(routeKind, params);
 
-    navigate(`${pathname}${newSearch || search}`);
+    navigate(`${pathname}${newSearch || search}`, options);
   };
 };
 

--- a/src/UI/Routing/Utils.ts
+++ b/src/UI/Routing/Utils.ts
@@ -17,7 +17,7 @@ type NavigateTo = (
  * @param newSearch The query string to use; must start with a question mark "?". When omitted, the
  *   current location's search is preserved.
  * @param options React Router's `NavigateOptions` (e.g. `{ replace: true }` to replace the current
- *   history entry instead of pushing a new one — useful for redirects).
+ *   history entry instead of pushing a new one, useful for redirects).
  * @throws Will throw an error when newSearch is invalid
  */
 export const useNavigateTo = (): NavigateTo => {


### PR DESCRIPTION
# Description

- On delete, refetch the environment preview list (feeds redirect logic) and reset the REST environment list (header selector, user management) so the deleted env is gone app-wide
- Navigate directly to a surviving environment instead of the neutral Dashboard URL, avoiding the missing-env bounce that flashed a blank/errored dashboard
- Fall back to the Create Environment page (via PageFrame Provider, so its "no environments" toast still fires) when the last environment is deleted

closes https://github.com/inmanta/web-console/issues/7058

https://github.com/user-attachments/assets/775be92a-64d7-403f-aafe-233243386cdc