### PR TITLE
Align and soften version dropdown timestamps in attribute comparison (#7054)

### DIFF
--- a/changelogs/unreleased/7044-version-dropdown-timestamp.yml
+++ b/changelogs/unreleased/7044-version-dropdown-timestamp.yml
@@ -1,0 +1,6 @@
+description: In the attribute comparison view, the version dropdown now aligns each version's timestamp in a column and renders it as smaller, subtler text.
+issue-nr: 7044
+change-type: patch
+destination-branches: [master, iso9]
+sections:
+  minor-improvement: "{{description}}"

--- a/src/Slices/ServiceInstanceDetails/UI/Components/AttributesComponents/AttributesCompare.tsx
+++ b/src/Slices/ServiceInstanceDetails/UI/Components/AttributesComponents/AttributesCompare.tsx
@@ -7,7 +7,7 @@ import {
   FormSelect,
   FormSelectOption,
   SelectOptionProps,
-  Label,
+  Content,
 } from "@patternfly/react-core";
 import { InstanceAttributeModel } from "@/Core";
 import { InstanceLog } from "@/Core/Domain/HistoryLog";
@@ -53,21 +53,26 @@ export const AttributesCompare: React.FC<Props> = ({ instanceLogs, selectedVersi
 
   const { theme: preferredTheme } = useTheme();
 
-  const availableVersions: SelectOptionProps[] = useMemo(
-    () =>
-      instanceLogs.map(({ version, timestamp }) => ({
-        value: version,
-        children: (
-          <Flex gap={{ default: "gapSm" }} alignItems={{ default: "alignItemsCenter" }}>
-            {version}
-            <Label color="blue" variant="outline">
-              {datePresenter.getFull(timestamp)}
-            </Label>
-          </Flex>
-        ),
-      })),
-    [instanceLogs]
-  );
+  const availableVersions: SelectOptionProps[] = useMemo(() => {
+    // Width of the longest version, so every timestamp starts at the same place.
+    const versionColWidth = instanceLogs.length
+      ? Math.max(...instanceLogs.map(({ version }) => String(version).length))
+      : 0;
+
+    return instanceLogs.map(({ version, timestamp }) => ({
+      value: version,
+      children: (
+        <Flex
+          gap={{ default: "gapSm" }}
+          alignItems={{ default: "alignItemsCenter" }}
+          flexWrap={{ default: "nowrap" }}
+        >
+          <Content style={{ minWidth: `${versionColWidth}ch` }}>{version}</Content>
+          <Content component="small">{datePresenter.getFull(timestamp)}</Content>
+        </Flex>
+      ),
+    }));
+  }, [instanceLogs]);
 
   useEffect(() => {
     if (rightVersion) {


### PR DESCRIPTION
Pull request opened by the merge tool on behalf of #7054