### PR TITLE
The expert and destroy action toggles no longer stay highlighted behind the confirmation modal once it opens (iso9)

### DIFF
--- a/changelogs/unreleased/7047-modal-dropdown-fixes.yml
+++ b/changelogs/unreleased/7047-modal-dropdown-fixes.yml
@@ -1,0 +1,8 @@
+description: |
+  The expert and destroy action toggles no longer stay highlighted behind the confirmation modal once it opens.
+  The confirmation modal no longer closes when a click starts inside it and is released on the backdrop.
+issue-nr: 7047
+change-type: patch
+destination-branches: [iso9]
+sections:
+  bugfix: "{{description}}"

--- a/changelogs/unreleased/7047-modal-dropdown-fixes.yml
+++ b/changelogs/unreleased/7047-modal-dropdown-fixes.yml
@@ -1,6 +1,6 @@
 description: |
   The expert and destroy action toggles no longer stay highlighted behind the confirmation modal once it opens.
-  The confirmation modal no longer closes when a click starts inside it and is released on the backdrop.
+  Modals now close whenever clicking outside of the modal.
 issue-nr: 7047
 change-type: patch
 destination-branches: [iso9]

--- a/src/Slices/ServiceInstanceDetails/Test/InstanceActions.test.tsx
+++ b/src/Slices/ServiceInstanceDetails/Test/InstanceActions.test.tsx
@@ -122,6 +122,37 @@ describe("Page Actions - Success", () => {
     );
   });
 
+  it("Expert actions - collapses the toggle when an action opens its modal", async () => {
+    render(setupServiceInstanceDetails(true));
+
+    expect(
+      await screen.findByRole("region", { name: "Instance-Details-Success" })
+    ).toBeInTheDocument();
+
+    const expertDropdown = screen.getByRole("button", {
+      name: "Expert-Actions-Toggle",
+    });
+
+    // opening the dropdown expands the toggle
+    await userEvent.click(expertDropdown);
+    expect(expertDropdown).toHaveAttribute("aria-expanded", "true");
+
+    // selecting a state target opens the modal and must collapse the toggle,
+    // so it does not stay highlighted behind the modal
+    await userEvent.click(screen.getByRole("menuitem", { name: "up" }));
+    expect(screen.getByRole("dialog")).toBeVisible();
+    expect(expertDropdown).toHaveAttribute("aria-expanded", "false");
+
+    // the same must hold for the destroy action
+    await userEvent.click(screen.getByRole("button", { name: /no/i }));
+    await userEvent.click(expertDropdown);
+    expect(expertDropdown).toHaveAttribute("aria-expanded", "true");
+
+    await userEvent.click(screen.getByRole("menuitem", { name: /destroy/i }));
+    expect(screen.getByRole("dialog")).toBeVisible();
+    expect(expertDropdown).toHaveAttribute("aria-expanded", "false");
+  });
+
   it("Normal Instance Actions Enabled - delete action", async () => {
     const component = setupServiceInstanceDetails();
 

--- a/src/Slices/ServiceInstanceDetails/UI/Components/InstanceActions/Actions/DeleteAction.tsx
+++ b/src/Slices/ServiceInstanceDetails/UI/Components/InstanceActions/Actions/DeleteAction.tsx
@@ -13,7 +13,7 @@ interface Props {
   instance_id: string;
   service_entity: string;
   version: ParsedNumber;
-  onClose: () => void;
+  collapseToggle: () => void;
   setInterfaceBlocked: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
@@ -26,7 +26,7 @@ interface Props {
  *  @prop {string} instance_id - the hashed id of the instance
  *  @prop {string} service_entity - the service entity type of the instance
  *  @prop {ParsedNumber} version - the current version of the instance
- *  @prop {function} onClose - callback method when the modal gets closed
+ *  @prop {function} collapseToggle - collapses the dropdown toggle when the modal opens
  *  @prop {React.Dispatch<React.SetStateAction<boolean>>} setInterfaceBlocked - setState variable to block the interface when the modal is opened.
  *  This is meant to avoid clickEvents triggering the onOpenChange from the dropdown to shut down the modal.
  * @returns {React.FC<Props>} A React Component displaying the Delete Dropdown Item
@@ -37,7 +37,7 @@ export const DeleteAction: React.FC<Props> = ({
   instance_display_identity,
   instance_id,
   version,
-  onClose,
+  collapseToggle,
   setInterfaceBlocked,
 }) => {
   const { triggerModal, closeModal } = useContext(ModalContext);
@@ -63,6 +63,9 @@ export const DeleteAction: React.FC<Props> = ({
         />
       ),
     });
+    // Collapse the toggle now: setInterfaceBlocked(true) suppresses the dropdown's
+    // onOpenChange, so it can't collapse the toggle itself while the modal is open.
+    collapseToggle();
   };
 
   /**
@@ -71,8 +74,7 @@ export const DeleteAction: React.FC<Props> = ({
   const closeCallback = useCallback(() => {
     closeModal();
     setInterfaceBlocked(false);
-    onClose();
-  }, [closeModal, setInterfaceBlocked, onClose]);
+  }, [closeModal, setInterfaceBlocked]);
 
   return (
     <>

--- a/src/Slices/ServiceInstanceDetails/UI/Components/InstanceActions/Actions/DestroyAction.tsx
+++ b/src/Slices/ServiceInstanceDetails/UI/Components/InstanceActions/Actions/DestroyAction.tsx
@@ -13,7 +13,7 @@ interface Props {
   instance_id: string;
   service_entity: string;
   version: ParsedNumber;
-  onClose: () => void;
+  collapseToggle: () => void;
   setInterfaceBlocked: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
@@ -25,7 +25,7 @@ interface Props {
  *  @prop {string} instance_id - the hashed id of the instance
  *  @prop {string} service_entity - the service entity type of the instance
  *  @prop {ParsedNumber} version - the current version of the instance
- *  @prop {function} onClose - callback method when the modal gets closed
+ *  @prop {function} collapseToggle - collapses the dropdown toggle when the modal opens
  *  @prop {React.Dispatch<React.SetStateAction<boolean>>} setInterfaceBlocked - setState variable to block the interface when the modal is opened.
  *  This is meant to avoid clickEvents triggering the onOpenChange from the dropdown to shut down the modal.
  * @returns {React.FC<Props>} A React Component displaying the Destroy Dropdown Item
@@ -35,7 +35,7 @@ export const DestroyAction: React.FC<Props> = ({
   instance_display_identity,
   instance_id,
   version,
-  onClose,
+  collapseToggle,
   setInterfaceBlocked,
 }) => {
   const { triggerModal, closeModal } = useContext(ModalContext);
@@ -57,7 +57,11 @@ export const DestroyAction: React.FC<Props> = ({
         />
       ),
       iconVariant: "danger",
+      cancelCb: closeModalCallback,
     });
+    // Collapse the toggle now: setInterfaceBlocked(true) suppresses the dropdown's
+    // onOpenChange, so it can't collapse the toggle itself while the modal is open.
+    collapseToggle();
   };
 
   /**
@@ -66,8 +70,7 @@ export const DestroyAction: React.FC<Props> = ({
   const closeModalCallback = useCallback(() => {
     closeModal();
     setInterfaceBlocked(false);
-    onClose();
-  }, [closeModal, setInterfaceBlocked, onClose]);
+  }, [closeModal, setInterfaceBlocked]);
 
   return (
     <>

--- a/src/Slices/ServiceInstanceDetails/UI/Components/InstanceActions/Actions/ExpertStateTransfer.tsx
+++ b/src/Slices/ServiceInstanceDetails/UI/Components/InstanceActions/Actions/ExpertStateTransfer.tsx
@@ -26,7 +26,7 @@ interface Props {
   instance_id: string;
   service_entity: string;
   version: ParsedNumber;
-  onClose: () => void;
+  collapseToggle: () => void;
   setInterfaceBlocked: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
@@ -39,7 +39,7 @@ interface Props {
  *  @prop {string} instance_id - the UUID of the instance
  *  @prop {string} service_entity - the service entity type of the instance
  *  @prop {ParsedNumber} version - the current version of the instance
- *  @prop {function} onClose - callback method when the modal gets closed
+ *  @prop {function} collapseToggle - collapses the dropdown toggle when the modal opens
  *  @prop {React.Dispatch<React.SetStateAction<boolean>>} setInterfaceBlocked - setState variable to block the interface when the modal is opened.
  *  This is meant to avoid clickEvents triggering the onOpenChange from the dropdown to shut down the modal.
  * @returns {React.FC<Props>} A React Component displaying the Expert State transfer Dropdown Item
@@ -50,7 +50,7 @@ export const ExpertStateTransfer: React.FC<Props> = ({
   instance_id,
   targets = [],
   version,
-  onClose,
+  collapseToggle,
   setInterfaceBlocked,
 }) => {
   const { triggerModal, closeModal } = useContext(ModalContext);
@@ -79,6 +79,9 @@ export const ExpertStateTransfer: React.FC<Props> = ({
       iconVariant: "danger",
       cancelCb: closeModalCallback,
     });
+    // Collapse the toggle now: setInterfaceBlocked(true) suppresses the dropdown's
+    // onOpenChange, so it can't collapse the toggle itself while the modal is open.
+    collapseToggle();
   };
 
   /**
@@ -87,8 +90,7 @@ export const ExpertStateTransfer: React.FC<Props> = ({
   const closeModalCallback = useCallback(() => {
     closeModal();
     setInterfaceBlocked(false);
-    onClose();
-  }, [closeModal, setInterfaceBlocked, onClose]);
+  }, [closeModal, setInterfaceBlocked]);
 
   return (
     <>

--- a/src/Slices/ServiceInstanceDetails/UI/Components/InstanceActions/Actions/StateAction.tsx
+++ b/src/Slices/ServiceInstanceDetails/UI/Components/InstanceActions/Actions/StateAction.tsx
@@ -11,7 +11,7 @@ interface Props {
   instance_id: string;
   service_entity: string;
   version: ParsedNumber;
-  onClose: () => void;
+  collapseToggle: () => void;
   setInterfaceBlocked: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
@@ -24,7 +24,7 @@ interface Props {
  *  @prop {string} instance_id - the hashed id of the instance
  *  @prop {string} service_entity - the service entity type of the instance
  *  @prop {ParsedNumber} version - the current version of the instance
- *  @prop {function} onClose - callback method when the modal gets closed
+ *  @prop {function} collapseToggle - collapses the dropdown toggle when the modal opens
  *  @prop {React.Dispatch<React.SetStateAction<boolean>>} setInterfaceBlocked - setState variable to block the interface when the modal is opened.
  *  This is meant to avoid clickEvents triggering the onOpenChange from the dropdown to shut down the modal.
  * @returns {React.FC<Props>} A React Component displaying the State transfer Dropdown Item
@@ -35,7 +35,7 @@ export const StateAction: React.FC<Props> = ({
   instance_id,
   targets = [],
   version,
-  onClose,
+  collapseToggle,
   setInterfaceBlocked,
 }) => {
   const { triggerModal } = useContext(ModalContext);
@@ -62,10 +62,12 @@ export const StateAction: React.FC<Props> = ({
       iconVariant: "danger",
       cancelCb: () => {
         setInterfaceBlocked(false);
-        onClose();
       },
     });
     setInterfaceBlocked(true);
+    // Collapse the toggle now: setInterfaceBlocked(true) suppresses the dropdown's
+    // onOpenChange, so it can't collapse the toggle itself while the modal is open.
+    collapseToggle();
   };
 
   return (

--- a/src/Slices/ServiceInstanceDetails/UI/Components/InstanceActions/InstanceActions.tsx
+++ b/src/Slices/ServiceInstanceDetails/UI/Components/InstanceActions/InstanceActions.tsx
@@ -87,7 +87,7 @@ export const InstanceActions: React.FC = () => {
               instance_id={instance.id}
               service_entity={instance.service_entity}
               version={instance.version}
-              onClose={() => setIsDropdownOpen(false)}
+              collapseToggle={() => setIsExpertDropdownOpen(false)}
               setInterfaceBlocked={setBlockedInterface}
             />
             {!instance.deleted && expertStateTargets.length > 0 && (
@@ -101,7 +101,7 @@ export const InstanceActions: React.FC = () => {
                   instance_id={instance.id}
                   service_entity={instance.service_entity}
                   version={instance.version}
-                  onClose={() => setIsDropdownOpen(false)}
+                  collapseToggle={() => setIsExpertDropdownOpen(false)}
                   setInterfaceBlocked={setBlockedInterface}
                 />
               </>
@@ -180,7 +180,7 @@ export const InstanceActions: React.FC = () => {
             instance_display_identity={instance.service_identity_attribute_value ?? instance.id}
             instance_id={instance.id}
             version={instance.version}
-            onClose={() => setIsDropdownOpen(false)}
+            collapseToggle={() => setIsDropdownOpen(false)}
             setInterfaceBlocked={setBlockedInterface}
           />
           {stateTargets.length > 0 && (
@@ -195,7 +195,7 @@ export const InstanceActions: React.FC = () => {
                   instance_id={instance.id}
                   service_entity={instance.service_entity}
                   version={instance.version}
-                  onClose={() => setIsDropdownOpen(false)}
+                  collapseToggle={() => setIsDropdownOpen(false)}
                   setInterfaceBlocked={setBlockedInterface}
                 />
               </DropdownGroup>

--- a/src/UI/Root/Components/ModalProvider/ModalProvider.test.tsx
+++ b/src/UI/Root/Components/ModalProvider/ModalProvider.test.tsx
@@ -1,7 +1,7 @@
 import { useContext } from "react";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { ModalContext, ModalProvider, Params } from "./ModalProvider";
+import { BACKDROP_CLASS, ModalContext, ModalProvider, Params } from "./ModalProvider";
 
 const MockedModalUser = ({ overrides = {} }: { overrides?: Partial<Params> }) => {
   const { triggerModal, closeModal } = useContext(ModalContext);
@@ -137,6 +137,51 @@ describe("ModalProvider", () => {
       await userEvent.click(screen.getByText("Click me"));
 
       await expect(userEvent.click(screen.getByLabelText("Close"))).resolves.not.toThrow();
+    });
+  });
+
+  describe("backdrop press", () => {
+    const getBackdrop = () => {
+      const backdrop = document.querySelector(`.${BACKDROP_CLASS}`);
+      if (!backdrop) {
+        throw new Error(`Backdrop .${BACKDROP_CLASS} not found`);
+      }
+
+      return backdrop;
+    };
+
+    it("closes when the press starts on the backdrop", async () => {
+      setup();
+
+      await userEvent.click(screen.getByText("Click me"));
+
+      fireEvent.mouseDown(getBackdrop());
+
+      expect(screen.queryByTestId("GlobalModal")).toBeNull();
+    });
+
+    it("stays open when the press starts inside the dialog and ends on the backdrop", async () => {
+      setup();
+
+      await userEvent.click(screen.getByText("Click me"));
+
+      // Press begins on the modal content (e.g. selecting text) and is released
+      // on the backdrop - must not close the modal. The decision is made on
+      // mousedown, so a backdrop release after an inside press is a no-op.
+      fireEvent.mouseDown(screen.getByTestId("content"));
+      fireEvent.mouseUp(getBackdrop());
+
+      expect(screen.getByTestId("GlobalModal")).toBeVisible();
+    });
+
+    it("does not close when showClose is false", async () => {
+      setup({ showClose: false });
+
+      await userEvent.click(screen.getByText("Click me"));
+
+      fireEvent.mouseDown(getBackdrop());
+
+      expect(screen.getByTestId("GlobalModal")).toBeVisible();
     });
   });
 

--- a/src/UI/Root/Components/ModalProvider/ModalProvider.tsx
+++ b/src/UI/Root/Components/ModalProvider/ModalProvider.tsx
@@ -1,7 +1,13 @@
-import React, { PropsWithChildren, createContext, useState } from "react";
+import React, { PropsWithChildren, createContext, useEffect, useState } from "react";
 import { Modal, ModalVariant, ModalBody, ModalFooter, ModalHeader } from "@patternfly/react-core";
 
 type IconVariant = "success" | "danger" | "warning" | "info" | "custom";
+
+/**
+ * Our own class on the modal backdrop so the outside-press handler can detect
+ * the backdrop without relying on PatternFly's version-specific internal class.
+ */
+export const BACKDROP_CLASS = "global-modal-backdrop";
 
 /**
  * `Params` is an interface for the parameters accepted by the `triggerModal` function.
@@ -143,6 +149,33 @@ export const ModalProvider: React.FC<PropsWithChildren> = ({ children }) => {
     }
   };
 
+  useEffect(() => {
+    if (!isOpen || !showClose) {
+      return;
+    }
+
+    // Close only when the press starts on the backdrop, not inside the dialog,
+    // so a press that begins in the dialog and ends on the backdrop is ignored.
+    const handleMouseDown = (e: MouseEvent) => {
+      if (e.button !== 0) {
+        return;
+      }
+
+      const target = e.target as HTMLElement;
+      if (
+        target.closest(`.${BACKDROP_CLASS}`) !== null &&
+        target.closest('[role="dialog"]') === null
+      ) {
+        closeModal();
+      }
+    };
+
+    document.addEventListener("mousedown", handleMouseDown);
+
+    return () => document.removeEventListener("mousedown", handleMouseDown);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen, showClose]);
+
   return (
     <ModalContext.Provider
       value={{
@@ -153,6 +186,7 @@ export const ModalProvider: React.FC<PropsWithChildren> = ({ children }) => {
       <Modal
         data-testid={dataTestId}
         aria-label={ariaLabel}
+        backdropClassName={BACKDROP_CLASS}
         isOpen={isOpen}
         onClose={showClose ? closeModal : undefined}
         variant={variant}


### PR DESCRIPTION
# Description

Iso 9 pr => merge conflicts
This code was already reviewed

closes https://github.com/inmanta/web-console/issues/7047