### PR TITLE
Database login fallback for OIDC/JWT authentication

### DIFF
--- a/changelogs/unreleased/oidc-database-login-fallback.yml
+++ b/changelogs/unreleased/oidc-database-login-fallback.yml
@@ -1,0 +1,5 @@
+description: Added a database login fallback for OIDC and JWT authentication. When enabled and the identity provider is unavailable, an admin can sign in with a local database account and manage users and roles as with database authentication.
+change-type: minor
+destination-branches: [master, iso9]
+sections:
+  minor-improvement: "{{description}}"

--- a/src/Data/Auth/AuthContext.ts
+++ b/src/Data/Auth/AuthContext.ts
@@ -38,6 +38,15 @@ export interface AuthContextInterface {
    * @returns the boolean.
    */
   isDisabled: () => boolean;
+
+  /**
+   * Whether the active session authenticates against the built-in database, either
+   * because database auth is configured or because the user logged in via the local
+   * login fallback while an external provider (OIDC/JWT) is configured. When true,
+   * database user and role management is available.
+   * @returns the boolean.
+   */
+  isDatabaseSession: () => boolean;
 }
 
 /**
@@ -50,6 +59,7 @@ export const defaultAuthContext: AuthContextInterface = {
   updateUser: (_user: string, _token: string) => {},
   getToken: () => null,
   isDisabled: () => true,
+  isDatabaseSession: () => false,
 };
 
 /**

--- a/src/Data/Auth/Providers/DatabaseAuthProvider.tsx
+++ b/src/Data/Auth/Providers/DatabaseAuthProvider.tsx
@@ -1,8 +1,8 @@
 import React, { useCallback, useEffect, useState } from "react";
 import { useNavigate } from "react-router";
 import { PrimaryBaseUrlManager } from "@/UI/Routing";
-import { createCookie, getCookie, removeCookie } from "../../Common/CookieHelper";
 import { AuthContext } from "../AuthContext";
+import { clearLocalToken, getLocalToken, getLocalUsername, setLocalToken } from "./localToken";
 
 /**
  * DatabaseAuthProvider component provides authentication functionality using a database.
@@ -17,15 +17,10 @@ export const DatabaseAuthProvider: React.FC<React.PropsWithChildren> = ({ childr
   );
   const basePathname = baseUrlManager.getBasePathname();
 
-  const clearCookies = (): void => {
-    removeCookie("inmanta_user");
-    localStorage.removeItem("inmanta_user");
-  };
-
   const getUser = (): string | null => user;
 
   const logout = useCallback((): void => {
-    clearCookies();
+    clearLocalToken();
     navigate(`${basePathname}/login`);
   }, [navigate, basePathname]);
 
@@ -33,26 +28,25 @@ export const DatabaseAuthProvider: React.FC<React.PropsWithChildren> = ({ childr
     // The login function is called when we also get a 401 error.
     // This means that the user is not authenticated and
     // we need to clear the cookies to avoid lingering cookies that are invalid.
-    clearCookies();
+    clearLocalToken();
     navigate(`${basePathname}/login`);
   };
 
-  const getToken = (): string | null => getCookie("inmanta_user");
+  const getToken = (): string | null => getLocalToken();
 
   const updateUser = (username: string, token: string) => {
     setUser(username);
-    localStorage.setItem("inmanta_user", username);
-
-    const hoursToExpire = 12;
-    createCookie("inmanta_user", token, hoursToExpire);
+    setLocalToken(username, token);
   };
 
   const isDisabled = () => !getToken();
 
+  const isDatabaseSession = () => true;
+
   useEffect(() => {
     // If user is not set and token is present, set the user from the local storage or logs out. case where there is an user but not token is handled automatically as lacks of token prompt use to login again
     if (!user && getToken()) {
-      const username = localStorage.getItem("inmanta_user");
+      const username = getLocalUsername();
 
       if (username) {
         setUser(username);
@@ -63,7 +57,9 @@ export const DatabaseAuthProvider: React.FC<React.PropsWithChildren> = ({ childr
   }, [user, logout]);
 
   return (
-    <AuthContext.Provider value={{ getUser, login, logout, updateUser, getToken, isDisabled }}>
+    <AuthContext.Provider
+      value={{ getUser, login, logout, updateUser, getToken, isDisabled, isDatabaseSession }}
+    >
       {children}
     </AuthContext.Provider>
   );

--- a/src/Data/Auth/Providers/JwtAuthProvider.tsx
+++ b/src/Data/Auth/Providers/JwtAuthProvider.tsx
@@ -1,19 +1,30 @@
 import React, { useContext, useEffect, useState } from "react";
 import { useGetCurrentUser } from "@/Data/Queries";
 import { AuthContext } from "../AuthContext";
+import { getLocalToken, getLocalUsername, setLocalToken } from "./localToken";
 
 /**
  * Component that implements a authentication provider when jwt authentication is enabled.
  * In practice it fetches username from the backend because whole authentication flow is managed by 3rd party outside of the scope of our application.
  * User will open application already authorized and from our perspective the flow is almost identical as in case of no authorization.
+ *
+ * When a database local login fallback session is present (created via the /login form
+ * when the proxy could not authenticate the user), its token and username take over,
+ * and database user management becomes available.
  */
 export const JwtAuthProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
-  const [user, setUser] = useState<string | null>(null);
+  const [user, setUser] = useState<string | null>(getLocalUsername());
   const { data, isSuccess } = useGetCurrentUser().useOneTime();
   const authContext = useContext(AuthContext);
 
   const getUser = (): string | null => user;
+  const getToken = (): string | null => getLocalToken();
+  const updateUser = (username: string, token: string): void => {
+    setLocalToken(username, token);
+    setUser(username);
+  };
   const isDisabled = () => !getUser();
+  const isDatabaseSession = () => !!getLocalToken();
 
   useEffect(() => {
     if (isSuccess) {
@@ -22,7 +33,9 @@ export const JwtAuthProvider: React.FC<React.PropsWithChildren> = ({ children })
   }, [data, isSuccess]);
 
   return (
-    <AuthContext.Provider value={{ ...authContext, getUser, isDisabled }}>
+    <AuthContext.Provider
+      value={{ ...authContext, getUser, getToken, updateUser, isDisabled, isDatabaseSession }}
+    >
       {children}
     </AuthContext.Provider>
   );

--- a/src/Data/Auth/Providers/KeycloakAuthProvider.tsx
+++ b/src/Data/Auth/Providers/KeycloakAuthProvider.tsx
@@ -46,6 +46,11 @@ const KeycloakProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
   };
   const isDisabled = () => !getUser();
 
+  // The legacy Keycloak provider (implicit flow, login-required) does not support the
+  // database local login fallback. Deployments that need it should migrate to the
+  // generic OIDC provider (method "oidc-generic").
+  const isDatabaseSession = () => false;
+
   useEffect(() => {
     if (keycloak && !keycloak.profile) {
       keycloak.loadUserProfile();
@@ -61,6 +66,7 @@ const KeycloakProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
         login,
         logout,
         isDisabled,
+        isDatabaseSession,
         updateUser: (_user: string, _token: string) => {},
       }}
     >

--- a/src/Data/Auth/Providers/OidcAuthProvider.test.tsx
+++ b/src/Data/Auth/Providers/OidcAuthProvider.test.tsx
@@ -1,0 +1,107 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { TestMemoryRouter } from "@/UI/Routing/TestMemoryRouter";
+import { OidcAuthProvider } from "./OidcAuthProvider";
+
+const mocks = vi.hoisted(() => ({
+  auth: {
+    isLoading: false,
+    isAuthenticated: false,
+    error: undefined as undefined | { message: string },
+    user: undefined as undefined | { profile?: Record<string, unknown>; access_token?: string },
+    signinRedirect: vi.fn(),
+    signoutRedirect: vi.fn(),
+  },
+  localToken: null as string | null,
+}));
+
+vi.mock("react-oidc-context", () => ({
+  AuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useAuth: () => mocks.auth,
+}));
+
+vi.mock("./localToken", () => ({
+  getLocalToken: () => mocks.localToken,
+  getLocalUsername: () => null,
+  setLocalToken: vi.fn(),
+  clearLocalToken: vi.fn(),
+}));
+
+const config = {
+  method: "oidc-generic" as const,
+  authority: "https://idp.example.com",
+  clientId: "test-client",
+};
+
+const renderProvider = (localFallback: boolean) =>
+  render(
+    <TestMemoryRouter>
+      <OidcAuthProvider config={{ ...config, localFallback }}>
+        <div>APP CONTENT</div>
+      </OidcAuthProvider>
+    </TestMemoryRouter>
+  );
+
+beforeEach(() => {
+  mocks.auth.isLoading = false;
+  mocks.auth.isAuthenticated = false;
+  mocks.auth.error = undefined;
+  mocks.auth.user = undefined;
+  mocks.auth.signinRedirect.mockClear();
+  mocks.localToken = null;
+});
+
+describe("OidcAuthProvider local login fallback", () => {
+  it("redirects to the IdP first (no chooser) when the fallback is enabled and there is no error", () => {
+    renderProvider(true);
+
+    expect(mocks.auth.signinRedirect).toHaveBeenCalled();
+    expect(screen.queryByLabelText("local-login-fallback")).not.toBeInTheDocument();
+    expect(screen.queryByText("APP CONTENT")).not.toBeInTheDocument();
+  });
+
+  it("offers the local login fallback only after the IdP has errored", () => {
+    mocks.auth.error = { message: "idp unreachable" };
+
+    renderProvider(true);
+
+    expect(screen.getByLabelText("local-login-fallback")).toBeInTheDocument();
+    expect(mocks.auth.signinRedirect).not.toHaveBeenCalled();
+  });
+
+  it("redirects to the IdP and shows no fallback when the fallback is disabled", () => {
+    renderProvider(false);
+
+    expect(screen.queryByLabelText("local-login-fallback")).not.toBeInTheDocument();
+    expect(screen.queryByText("APP CONTENT")).not.toBeInTheDocument();
+    expect(mocks.auth.signinRedirect).toHaveBeenCalled();
+  });
+
+  it("shows the plain error and no fallback when the IdP errors and the fallback is disabled", () => {
+    mocks.auth.error = { message: "idp unreachable" };
+
+    renderProvider(false);
+
+    expect(screen.queryByLabelText("local-login-fallback")).not.toBeInTheDocument();
+    expect(mocks.auth.signinRedirect).not.toHaveBeenCalled();
+  });
+
+  it("renders the app when authenticated through the IdP", () => {
+    mocks.auth.isAuthenticated = true;
+    mocks.auth.user = { profile: { preferred_username: "alice" } };
+
+    renderProvider(true);
+
+    expect(screen.getByText("APP CONTENT")).toBeInTheDocument();
+    expect(screen.queryByLabelText("local-login-fallback")).not.toBeInTheDocument();
+  });
+
+  it("renders the app on a local fallback session even without IdP authentication", () => {
+    mocks.localToken = "a-local-token";
+
+    renderProvider(true);
+
+    expect(screen.getByText("APP CONTENT")).toBeInTheDocument();
+  });
+});

--- a/src/Data/Auth/Providers/OidcAuthProvider.tsx
+++ b/src/Data/Auth/Providers/OidcAuthProvider.tsx
@@ -1,7 +1,15 @@
 import React, { useState } from "react";
 import { AuthProvider as OidcContextProvider, useAuth } from "react-oidc-context";
 import { useLocation, useNavigate } from "react-router";
-import { Bullseye, Button, Content, Spinner, Stack, StackItem, Title } from "@patternfly/react-core";
+import {
+  Bullseye,
+  Button,
+  Content,
+  Spinner,
+  Stack,
+  StackItem,
+  Title,
+} from "@patternfly/react-core";
 import { words } from "@/UI";
 import { PrimaryBaseUrlManager } from "@/UI/Routing";
 import { AuthContext } from "../AuthContext";
@@ -44,7 +52,12 @@ const OidcFallbackChooser: React.FC<OidcFallbackChooserProps> = ({
         </Button>
       </StackItem>
       <StackItem>
-        <Button variant="secondary" isBlock onClick={onLocalLogin} aria-label="local-login-fallback">
+        <Button
+          variant="secondary"
+          isBlock
+          onClick={onLocalLogin}
+          aria-label="local-login-fallback"
+        >
           {words("login.fallback.local")}
         </Button>
       </StackItem>

--- a/src/Data/Auth/Providers/OidcAuthProvider.tsx
+++ b/src/Data/Auth/Providers/OidcAuthProvider.tsx
@@ -1,15 +1,144 @@
-import React from "react";
+import React, { useState } from "react";
 import { AuthProvider as OidcContextProvider, useAuth } from "react-oidc-context";
-import { Bullseye, Spinner } from "@patternfly/react-core";
+import { useLocation, useNavigate } from "react-router";
+import { Bullseye, Button, Content, Spinner, Stack, StackItem, Title } from "@patternfly/react-core";
 import { words } from "@/UI";
+import { PrimaryBaseUrlManager } from "@/UI/Routing";
 import { AuthContext } from "../AuthContext";
 import { OidcAuthConfig } from "../types";
+import { clearLocalToken, getLocalToken, getLocalUsername, setLocalToken } from "./localToken";
+
+interface OidcFallbackChooserProps {
+  errorMessage?: string;
+  onIdpLogin: () => void;
+  onLocalLogin: () => void;
+}
+
+/**
+ * Break-glass screen shown when the identity provider cannot authenticate the user
+ * and the database local login fallback is enabled. It offers a retry against the
+ * IdP and a route to the local database login form.
+ */
+const OidcFallbackChooser: React.FC<OidcFallbackChooserProps> = ({
+  errorMessage,
+  onIdpLogin,
+  onLocalLogin,
+}) => (
+  <Bullseye>
+    <Stack hasGutter style={{ maxWidth: "30rem", textAlign: "center" }}>
+      <StackItem>
+        <Title headingLevel="h1" size="lg">
+          {words("login.title")}
+        </Title>
+      </StackItem>
+      <StackItem>
+        <Content component="p">
+          {errorMessage
+            ? words("error.authentication")(errorMessage)
+            : words("login.fallback.description")}
+        </Content>
+      </StackItem>
+      <StackItem>
+        <Button variant="primary" isBlock onClick={onIdpLogin}>
+          {words("login.fallback.idp")}
+        </Button>
+      </StackItem>
+      <StackItem>
+        <Button variant="secondary" isBlock onClick={onLocalLogin} aria-label="local-login-fallback">
+          {words("login.fallback.local")}
+        </Button>
+      </StackItem>
+    </Stack>
+  </Bullseye>
+);
+
+interface InnerProps {
+  localFallback: boolean;
+}
 
 /**
  * Inner provider that bridges react-oidc-context to our AuthContext.
+ *
+ * When localFallback is enabled and the IdP cannot authenticate the user, the
+ * provider does not dead-end on a redirect: it keeps the /login route reachable
+ * and offers a database login so an admin can get in when the IdP is unavailable.
  */
-const OidcInnerProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
+const OidcInnerProvider: React.FC<React.PropsWithChildren<InnerProps>> = ({
+  children,
+  localFallback,
+}) => {
   const auth = useAuth();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [localUser, setLocalUser] = useState<string | null>(getLocalUsername());
+
+  const baseUrlManager = new PrimaryBaseUrlManager(
+    globalThis.location.origin,
+    globalThis.location.pathname
+  );
+  const basePathname = baseUrlManager.getBasePathname();
+  const loginPath = `${basePathname}/login`;
+
+  const hasLocalSession = (): boolean => !!getLocalToken();
+
+  const getUser = (): string | null => {
+    if (auth.user?.profile) {
+      return (
+        (auth.user.profile.preferred_username as string) ||
+        auth.user.profile.email ||
+        auth.user.profile.sub ||
+        null
+      );
+    }
+
+    return localUser;
+  };
+
+  const getToken = (): string | null => auth.user?.access_token || getLocalToken();
+
+  const updateUser = (username: string, token: string): void => {
+    setLocalToken(username, token);
+    setLocalUser(username);
+  };
+
+  const logout = (): void => {
+    if (hasLocalSession()) {
+      clearLocalToken();
+      setLocalUser(null);
+      navigate(loginPath);
+
+      return;
+    }
+    auth.signoutRedirect();
+  };
+
+  const login = (): void => {
+    // A 401 also triggers this. If we hold a local fallback session (its token is no
+    // longer valid), or the user is on the local login page (e.g. a failed login
+    // attempt returns 401), return to the login form instead of bouncing to the IdP.
+    if (hasLocalSession() || location.pathname.endsWith("/login")) {
+      clearLocalToken();
+      setLocalUser(null);
+      navigate(loginPath);
+
+      return;
+    }
+    auth.signinRedirect();
+  };
+
+  const isDisabled = (): boolean => !getUser();
+
+  const isDatabaseSession = (): boolean => !auth.isAuthenticated && hasLocalSession();
+
+  const contextValue = {
+    getUser,
+    getToken,
+    login,
+    logout,
+    isDisabled,
+    updateUser,
+    isDatabaseSession,
+  };
 
   if (auth.isLoading) {
     return (
@@ -19,11 +148,20 @@ const OidcInnerProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
     );
   }
 
-  if (auth.error) {
-    return <Bullseye>{words("error.authentication")(auth.error.message || "")}</Bullseye>;
+  // Authenticated through the IdP, or holding a local fallback session: render the app.
+  if (auth.isAuthenticated || hasLocalSession()) {
+    return <AuthContext.Provider value={contextValue}>{children}</AuthContext.Provider>;
   }
 
-  if (!auth.isAuthenticated) {
+  // Manual break-glass: when the fallback is enabled the /login route stays reachable by
+  // URL, so an admin can deliberately choose local login even while the IdP is healthy.
+  if (localFallback && location.pathname.endsWith("/login")) {
+    return <AuthContext.Provider value={contextValue}>{children}</AuthContext.Provider>;
+  }
+
+  // Identity provider first: as long as the IdP has not errored, redirect to it just like
+  // a normal OIDC login.
+  if (!auth.error) {
     auth.signinRedirect();
 
     return (
@@ -33,47 +171,19 @@ const OidcInnerProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
     );
   }
 
-  const getUser = (): string | null => {
-    if (!auth.user?.profile) {
-      return null;
-    }
-
+  // The IdP failed to authenticate the user. Offer the database login as a backup when it
+  // is enabled; otherwise show the error as before.
+  if (localFallback) {
     return (
-      (auth.user.profile.preferred_username as string) ||
-      auth.user.profile.email ||
-      auth.user.profile.sub ||
-      null
+      <OidcFallbackChooser
+        errorMessage={auth.error.message}
+        onIdpLogin={() => auth.signinRedirect()}
+        onLocalLogin={() => navigate(loginPath)}
+      />
     );
-  };
+  }
 
-  const getToken = (): string | null => {
-    return auth.user?.access_token || null;
-  };
-
-  const logout = (): void => {
-    auth.signoutRedirect();
-  };
-
-  const login = (): void => {
-    auth.signinRedirect();
-  };
-
-  const isDisabled = () => !getUser();
-
-  return (
-    <AuthContext.Provider
-      value={{
-        getUser,
-        getToken,
-        login,
-        logout,
-        isDisabled,
-        updateUser: (_user: string, _token: string) => {},
-      }}
-    >
-      {children}
-    </AuthContext.Provider>
-  );
+  return <Bullseye>{words("error.authentication")(auth.error.message || "")}</Bullseye>;
 };
 
 interface Props {
@@ -109,7 +219,7 @@ export const OidcAuthProvider: React.FC<React.PropsWithChildren<Props>> = ({
 
   return (
     <OidcContextProvider {...oidcConfig}>
-      <OidcInnerProvider>{children}</OidcInnerProvider>
+      <OidcInnerProvider localFallback={!!config.localFallback}>{children}</OidcInnerProvider>
     </OidcContextProvider>
   );
 };

--- a/src/Data/Auth/Providers/localToken.ts
+++ b/src/Data/Auth/Providers/localToken.ts
@@ -1,0 +1,38 @@
+import { createCookie, getCookie, removeCookie } from "../../Common/CookieHelper";
+
+/**
+ * Shared storage for a database (local) login session.
+ *
+ * The bearer token is kept in the `inmanta_user` cookie and the username in
+ * localStorage under the same key. This is used both by the DatabaseAuthProvider
+ * and, as a break-glass fallback, by the OIDC and JWT providers when the local
+ * login fallback is enabled and the identity provider is unavailable.
+ */
+const LOCAL_SESSION_KEY = "inmanta_user";
+const HOURS_TO_EXPIRE = 12;
+
+/**
+ * Return the bearer token of the active local session, or null if there is none.
+ */
+export const getLocalToken = (): string | null => getCookie(LOCAL_SESSION_KEY);
+
+/**
+ * Return the username of the active local session, or null if there is none.
+ */
+export const getLocalUsername = (): string | null => localStorage.getItem(LOCAL_SESSION_KEY);
+
+/**
+ * Persist a local session (bearer token + username).
+ */
+export const setLocalToken = (username: string, token: string): void => {
+  localStorage.setItem(LOCAL_SESSION_KEY, username);
+  createCookie(LOCAL_SESSION_KEY, token, HOURS_TO_EXPIRE);
+};
+
+/**
+ * Clear the active local session.
+ */
+export const clearLocalToken = (): void => {
+  removeCookie(LOCAL_SESSION_KEY);
+  localStorage.removeItem(LOCAL_SESSION_KEY);
+};

--- a/src/Data/Auth/types.ts
+++ b/src/Data/Auth/types.ts
@@ -27,8 +27,18 @@ export interface OidcAuthConfig {
   postLogoutRedirectUri?: string;
   scope?: string;
   extraConfig?: Record<string, unknown>;
+
+  /**
+   * When true, the web-console offers a database (break-glass) login as a fallback
+   * if the identity provider is unavailable. inmanta-ui only sets this when a
+   * signing config and at least one database user exist.
+   */
+  localFallback?: boolean;
 }
 
 export interface LocalConfig {
   method: "database" | "jwt";
+
+  /** Whether the database local login fallback is available (relevant for method "jwt"). */
+  localFallback?: boolean;
 }

--- a/src/Slices/UserManagement/UI/Components/UserInfoRow.tsx
+++ b/src/Slices/UserManagement/UI/Components/UserInfoRow.tsx
@@ -3,7 +3,7 @@ import { Button, Flex, FlexItem } from "@patternfly/react-core";
 import { UserShieldIcon } from "@patternfly/react-icons";
 import { Td, Tr } from "@patternfly/react-table";
 import { useRemoveUser, UserInfo } from "@/Data/Queries";
-import { words } from "@/UI";
+import { DependencyContext, words } from "@/UI";
 import { ConfirmUserActionForm } from "@/UI/Components";
 import { useAppAlert } from "@/UI/Root/Components/AppAlertProvider";
 import { ModalContext } from "@/UI/Root/Components/ModalProvider";
@@ -23,8 +23,9 @@ interface Props {
  */
 export const UserInfoRow: React.FC<Props> = ({ user }) => {
   const { triggerModal, closeModal } = useContext(ModalContext);
+  const { authHelper } = useContext(DependencyContext);
   const authConfig = globalThis && globalThis.auth;
-  const showRoles = authConfig?.provider === "policy-engine" && authConfig?.method === "database";
+  const showRoles = authConfig?.provider === "policy-engine" && authHelper.isDatabaseSession();
   const [isExpanded, setIsExpanded] = useState(false);
   const { notifyError } = useAppAlert();
   const { mutate } = useRemoveUser({

--- a/src/Slices/UserManagement/UI/Page.tsx
+++ b/src/Slices/UserManagement/UI/Page.tsx
@@ -3,7 +3,7 @@ import { Button, Flex, FlexItem } from "@patternfly/react-core";
 import { Table, Tbody, Th, Thead, Tr } from "@patternfly/react-table";
 import { useGetUsers } from "@/Data/Queries";
 import { UserCredentialsForm } from "@/Slices/UserManagement/UI/Components/AddUserForm";
-import { words } from "@/UI";
+import { DependencyContext, words } from "@/UI";
 import { EmptyView, ErrorView, LoadingView, PageContainer } from "@/UI/Components";
 import { ModalContext } from "@/UI/Root/Components/ModalProvider";
 import { UserInfoRow } from "./Components/UserInfoRow";
@@ -18,10 +18,11 @@ import { UserInfoRow } from "./Components/UserInfoRow";
  */
 export const UserManagementPage: React.FC = () => {
   const { triggerModal } = useContext(ModalContext);
+  const { authHelper } = useContext(DependencyContext);
   const { data, isSuccess, isError, error, refetch } = useGetUsers().useOneTime();
 
   const authConfig = globalThis && globalThis.auth;
-  const showRoles = authConfig?.provider === "policy-engine" && authConfig?.method === "database";
+  const showRoles = authConfig?.provider === "policy-engine" && authHelper.isDatabaseSession();
 
   /**
    * Opens a modal with a form for user credentials.

--- a/src/UI/Root/Components/Header/EnvSelector/EnvSelector.tsx
+++ b/src/UI/Root/Components/Header/EnvSelector/EnvSelector.tsx
@@ -70,9 +70,9 @@ export const EnvSelector: React.FC<Props> = ({
     setIsOpen(!isOpen);
   };
 
-  // Only show the user management link if the auth method is database. Other auth methods have external user and role management.
-  const authConfig = globalThis && globalThis.auth;
-  const showUserManagement = !authHelper.isDisabled() && authConfig?.method === "database";
+  // Only show the user management link for a database session (database auth, or the
+  // OIDC/JWT local login fallback). Other auth methods have external user and role management.
+  const showUserManagement = !authHelper.isDisabled() && authHelper.isDatabaseSession();
   const showLogout = !authHelper.isDisabled();
 
   const filteredItems = searchText

--- a/src/UI/words.tsx
+++ b/src/UI/words.tsx
@@ -971,6 +971,10 @@ const dict = {
   "login.title": "Log in to your account",
   "login.subtitle": "Enter your credentials",
   "login.login": "Log in",
+  "login.fallback.description":
+    "The identity provider could not sign you in. You can retry, or use a local account.",
+  "login.fallback.idp": "Sign in with your identity provider",
+  "login.fallback.local": "Sign in with a local account",
 
   /**
    * User Management


### PR DESCRIPTION
_Claude, opening this on behalf of @bartv._

## What
When the identity provider is unavailable (or misconfigured), the web-console now lets an admin sign in with a database **break-glass** account, and manage users/roles as with database-only auth.

## Behaviour (identity provider first)
- On a normal load the OIDC provider auto-redirects to the IdP exactly as before.
- The local-login option is a **backup**: the chooser is shown only when the IdP errors (`auth.error` set), plus a manual break-glass via the `/console/login` URL.
- The local login page no longer bounces to the IdP: a failed local login (wrong password -> 401) triggers `authHelper.login()`, so `login()` now returns to `/login` (instead of `signinRedirect()`) when a local session exists or the user is on the login page.

## How
- Shared local-token store (`localToken.ts`, extracted from `DatabaseAuthProvider`) used by the OIDC and JWT providers in `getToken`/`updateUser`.
- `isDatabaseSession()` added to `AuthContextInterface`; the three checks that were hard-coded to `method === "database"` (`EnvSelector`, `UserManagement/Page`, `UserInfoRow`) now key off it, so user management works on a fallback session.
- `localFallback` field on the config types; three new translation strings.

Depends on inmanta-ui emitting `localFallback` in `config.js` and on inmanta-core allowing a break-glass DB user under `auth_method=oidc`.

## Tests
- New `OidcAuthProvider.test.tsx` (6 cases): IdP-first redirect, chooser only on error, plain error when fallback disabled, authenticated/local-session render the app.
- Affected suites (UserManagement, EnvSelector, Login) pass; eslint + tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Related PRs / MRs
- inmanta-core: https://github.com/inmanta/inmanta-core/pull/10531 (stacked on #10529 `db-singleton-lock`)
- inmanta-ui: https://github.com/inmanta/inmanta-ui/pull/822
- web-console: https://github.com/inmanta/web-console/pull/7069
- local-setup (test harness): https://code.inmanta.com/inmanta/local-setup/-/merge_requests/48