### PR TITLE
List and revoke API tokens in the Settings Tokens tab

### DIFF
--- a/changelogs/unreleased/token-registry.yml
+++ b/changelogs/unreleased/token-registry.yml
@@ -1,0 +1,3 @@
+description: Add a token registry view to the Settings Tokens tab. Tokens can now be generated as revocable (registered) tokens, and registered tokens are listed with their creator, client types, issue and last-used times, and can be individually revoked.
+change-type: minor
+destination-branches: [master, iso9]

--- a/src/Core/Domain/Token.ts
+++ b/src/Core/Domain/Token.ts
@@ -2,4 +2,24 @@ export type ClientType = "api" | "agent" | "compiler";
 
 export interface TokenInfo {
   client_types: ClientType[];
+
+  /**
+   * When false, the generated token is registered in the token registry and can be individually
+   * revoked. When true (the default), the token is reproducible and stateless (not revocable).
+   */
+  idempotent?: boolean;
+}
+
+/**
+ * A registered (revocable) token as returned by the token registry.
+ */
+export interface Token {
+  jti: string;
+  created_by: string | null;
+  client_types: string[];
+  environment: string | null;
+  issued_at: string;
+  expires_at: string | null;
+  revoked: boolean;
+  last_used: string | null;
 }

--- a/src/Data/Queries/Slices/Environment/GetTokens/index.ts
+++ b/src/Data/Queries/Slices/Environment/GetTokens/index.ts
@@ -1,0 +1,1 @@
+export * from "./useGetTokens";

--- a/src/Data/Queries/Slices/Environment/GetTokens/useGetTokens.ts
+++ b/src/Data/Queries/Slices/Environment/GetTokens/useGetTokens.ts
@@ -1,0 +1,28 @@
+import { useContext } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Token } from "@/Core/Domain";
+import { useGet } from "@/Data/Queries";
+import { KeyFactory, SliceKeys } from "@/Data/Queries/Helpers/KeyFactory";
+import { DependencyContext } from "@/UI";
+
+export const getTokensKey = new KeyFactory(SliceKeys.environment, "get_tokens");
+
+/**
+ * React Query hook to fetch the registered (revocable) tokens of the current environment.
+ *
+ * @returns An object with a `useOneTime` hook returning the list of tokens.
+ */
+export const useGetTokens = () => {
+  const { environmentHandler } = useContext(DependencyContext);
+  const env = environmentHandler.useId();
+  const get = useGet(env)<{ data: Token[] }>;
+
+  return {
+    useOneTime: () =>
+      useQuery({
+        queryKey: getTokensKey.list([env]),
+        queryFn: () => get("/api/v2/environment_auth"),
+        select: (data) => data.data,
+      }),
+  };
+};

--- a/src/Data/Queries/Slices/Environment/RevokeToken/index.ts
+++ b/src/Data/Queries/Slices/Environment/RevokeToken/index.ts
@@ -1,0 +1,1 @@
+export * from "./useRevokeToken";

--- a/src/Data/Queries/Slices/Environment/RevokeToken/useRevokeToken.ts
+++ b/src/Data/Queries/Slices/Environment/RevokeToken/useRevokeToken.ts
@@ -1,0 +1,33 @@
+import { useContext } from "react";
+import {
+  UseMutationOptions,
+  UseMutationResult,
+  useMutation,
+  useQueryClient,
+} from "@tanstack/react-query";
+import { useDelete } from "@/Data/Queries";
+import { DependencyContext } from "@/UI";
+import { getTokensKey } from "../GetTokens/useGetTokens";
+
+/**
+ * React Query hook to revoke a registered token by its jti.
+ *
+ * @returns The mutation object; call `mutate(jti)` to revoke a token.
+ */
+export const useRevokeToken = (
+  options?: UseMutationOptions<void, Error, string, unknown>
+): UseMutationResult<void, Error, string, unknown> => {
+  const client = useQueryClient();
+  const { environmentHandler } = useContext(DependencyContext);
+  const env = environmentHandler.useId();
+  const deleteFn = useDelete(env);
+
+  return useMutation({
+    mutationFn: (jti) => deleteFn(`/api/v2/environment_auth/${encodeURIComponent(jti)}`),
+    mutationKey: ["revokeToken", env],
+    onSuccess: () => {
+      client.invalidateQueries({ queryKey: getTokensKey.root() });
+    },
+    ...options,
+  });
+};

--- a/src/Data/Queries/Slices/Environment/index.ts
+++ b/src/Data/Queries/Slices/Environment/index.ts
@@ -10,4 +10,6 @@ export * from "./ClearEnvironment";
 export * from "./ResetEnvironmentSetting";
 export * from "./UpdateEnvironmentSetting";
 export * from "./GenerateToken";
+export * from "./GetTokens";
+export * from "./RevokeToken";
 export * from "./GetEnvironmentPreview";

--- a/src/Slices/Settings/UI/Tabs/Token/Tab.test.tsx
+++ b/src/Slices/Settings/UI/Tabs/Token/Tab.test.tsx
@@ -25,6 +25,10 @@ describe("Token Tab", () => {
   const server = setupServer();
 
   beforeAll(() => server.listen());
+  // The tab also renders the registered-token list; give it a default (empty) response.
+  beforeEach(() =>
+    server.use(http.get("/api/v2/environment_auth", () => HttpResponse.json({ data: [] })))
+  );
   afterEach(() => server.resetHandlers());
   afterAll(() => server.close());
 
@@ -84,6 +88,49 @@ describe("Token Tab", () => {
     await waitFor(() => {
       expect(screen.queryByLabelText("ToastError")).toBeNull();
     });
+  });
+
+  test("GIVEN the revocable checkbox is checked WHEN generate is clicked THEN idempotent is false", async () => {
+    let requestBody: Record<string, unknown> | null = null;
+    server.use(
+      http.post("/api/v2/environment_auth", async ({ request }) => {
+        requestBody = (await request.json()) as Record<string, unknown>;
+
+        return HttpResponse.json({ data: "tokenstring123" });
+      })
+    );
+
+    const { component } = setup();
+
+    render(component);
+
+    await userEvent.click(screen.getByRole("checkbox", { name: "RevocableOption" }));
+    await userEvent.click(
+      screen.getByRole("button", { name: words("settings.tabs.token.generate") })
+    );
+
+    await waitFor(() => expect(requestBody).toEqual({ client_types: [], idempotent: false }));
+  });
+
+  test("GIVEN the revocable checkbox is unchecked WHEN generate is clicked THEN idempotent is true", async () => {
+    let requestBody: Record<string, unknown> | null = null;
+    server.use(
+      http.post("/api/v2/environment_auth", async ({ request }) => {
+        requestBody = (await request.json()) as Record<string, unknown>;
+
+        return HttpResponse.json({ data: "tokenstring123" });
+      })
+    );
+
+    const { component } = setup();
+
+    render(component);
+
+    await userEvent.click(
+      screen.getByRole("button", { name: words("settings.tabs.token.generate") })
+    );
+
+    await waitFor(() => expect(requestBody).toEqual({ client_types: [], idempotent: true }));
   });
 
   test("GIVEN TokenTab WHEN generate fails THEN the error is shown", async () => {

--- a/src/Slices/Settings/UI/Tabs/Token/Tab.tsx
+++ b/src/Slices/Settings/UI/Tabs/Token/Tab.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from "react";
 import { Title } from "@patternfly/react-core";
 import { useQueryClient } from "@tanstack/react-query";
-import styled from "styled-components";
 import { ClientType, toggleValueInList } from "@/Core";
 import { getTokensKey, useGenerateToken } from "@/Data/Queries";
 import { words } from "@/UI/words";
@@ -69,15 +68,10 @@ export const Tab: React.FC = () => {
         error={error}
         isBusy={isBusy}
       />
-      <RegisteredTitle headingLevel="h2">
+      <Title className="lined_section" headingLevel="h2" size="md">
         {words("settings.tabs.token.registered.title")}
-      </RegisteredTitle>
+      </Title>
       <TokenTable />
     </>
   );
 };
-
-const RegisteredTitle = styled(Title)`
-  padding-top: 1rem;
-  padding-bottom: 1rem;
-`;

--- a/src/Slices/Settings/UI/Tabs/Token/Tab.tsx
+++ b/src/Slices/Settings/UI/Tabs/Token/Tab.tsx
@@ -1,23 +1,35 @@
 import React, { useState } from "react";
+import { Title } from "@patternfly/react-core";
+import { useQueryClient } from "@tanstack/react-query";
+import styled from "styled-components";
 import { ClientType, toggleValueInList } from "@/Core";
-import { useGenerateToken } from "@/Data/Queries";
+import { getTokensKey, useGenerateToken } from "@/Data/Queries";
+import { words } from "@/UI/words";
 import { TokenForm } from "./TokenForm";
+import { TokenTable } from "./TokenTable";
 
 /**
  * Token tab for the Settings page
  *
- * It handles the generation of tokens for the current user
+ * It handles the generation of tokens for the current environment and lists the
+ * registered (revocable) tokens so they can be revoked.
  *
  * @returns {React.FC} The Token tab
  */
 export const Tab: React.FC = () => {
+  const client = useQueryClient();
   const [clientTypes, setClientTypes] = useState<ClientType[]>([]);
+  const [isRevocable, setIsRevocable] = useState(false);
   const [isBusy, setIsBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [token, setToken] = useState<string | null>(null);
   const { mutate } = useGenerateToken({
     onError: (error) => setError(error.message),
-    onSuccess: (data) => setToken(data.data),
+    onSuccess: (data) => {
+      setToken(data.data);
+      // A revocable token was added to the registry: refresh the list.
+      client.invalidateQueries({ queryKey: getTokensKey.root() });
+    },
   });
 
   const isClientTypeSelected = (clientType: ClientType): boolean =>
@@ -39,20 +51,33 @@ export const Tab: React.FC = () => {
     setError(null);
     setToken(null);
     setIsBusy(true);
-    mutate({ client_types: clientTypes });
+    mutate({ client_types: clientTypes, idempotent: !isRevocable });
 
     setIsBusy(false);
   };
 
   return (
-    <TokenForm
-      onGenerate={onGenerate}
-      onErrorClose={() => setError(null)}
-      getClientTypeSelector={getClientTypeSelector}
-      isClientTypeSelected={isClientTypeSelected}
-      token={token}
-      error={error}
-      isBusy={isBusy}
-    />
+    <>
+      <TokenForm
+        onGenerate={onGenerate}
+        onErrorClose={() => setError(null)}
+        getClientTypeSelector={getClientTypeSelector}
+        isClientTypeSelected={isClientTypeSelected}
+        isRevocable={isRevocable}
+        onRevocableChange={setIsRevocable}
+        token={token}
+        error={error}
+        isBusy={isBusy}
+      />
+      <RegisteredTitle headingLevel="h2">
+        {words("settings.tabs.token.registered.title")}
+      </RegisteredTitle>
+      <TokenTable />
+    </>
   );
 };
+
+const RegisteredTitle = styled(Title)`
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+`;

--- a/src/Slices/Settings/UI/Tabs/Token/TokenForm.tsx
+++ b/src/Slices/Settings/UI/Tabs/Token/TokenForm.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import {
   Button,
+  Checkbox,
   Flex,
   FlexItem,
   InputGroup,
@@ -19,6 +20,8 @@ interface Props {
   onErrorClose(): void;
   getClientTypeSelector(clientType: ClientType): (selected: boolean) => void;
   isClientTypeSelected(clientType: ClientType): boolean;
+  isRevocable: boolean;
+  onRevocableChange(value: boolean): void;
   token: string | null;
   error: string | null;
   isBusy: boolean;
@@ -28,6 +31,8 @@ export const TokenForm: React.FC<Props> = ({
   onGenerate,
   getClientTypeSelector,
   isClientTypeSelected,
+  isRevocable,
+  onRevocableChange,
   token,
   error,
   onErrorClose,
@@ -63,6 +68,16 @@ export const TokenForm: React.FC<Props> = ({
             isDisabled={isBusy}
           />
         </ToggleGroup>
+      </FlexItem>
+      <FlexItem>
+        <Checkbox
+          id="token-revocable"
+          label={words("settings.tabs.token.revocable")}
+          aria-label="RevocableOption"
+          isChecked={isRevocable}
+          isDisabled={isBusy}
+          onChange={(_event, checked) => onRevocableChange(checked)}
+        />
       </FlexItem>
       <FlexItem>
         <Button variant="primary" onClick={onGenerate} isDisabled={isBusy}>

--- a/src/Slices/Settings/UI/Tabs/Token/TokenTable.test.tsx
+++ b/src/Slices/Settings/UI/Tabs/Token/TokenTable.test.tsx
@@ -1,0 +1,138 @@
+import React from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import { Token } from "@/Core/Domain";
+import { MockedDependencyProvider } from "@/Test";
+import { words } from "@/UI";
+import { ModalProvider } from "@/UI/Root/Components/ModalProvider";
+import { TokenTable } from "./TokenTable";
+
+const makeToken = (overrides: Partial<Token> = {}): Token => ({
+  jti: "11111111-1111-1111-1111-111111111111",
+  created_by: "admin",
+  client_types: ["api"],
+  environment: null,
+  issued_at: "2026-07-04T10:00:00+00:00",
+  expires_at: null,
+  revoked: false,
+  last_used: null,
+  ...overrides,
+});
+
+function setup() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <MockedDependencyProvider>
+        <ModalProvider>
+          <TokenTable />
+        </ModalProvider>
+      </MockedDependencyProvider>
+    </QueryClientProvider>
+  );
+}
+
+describe("TokenTable", () => {
+  const server = setupServer();
+
+  beforeAll(() => server.listen());
+  afterEach(() => server.resetHandlers());
+  afterAll(() => server.close());
+
+  test("GIVEN no registered tokens THEN the empty view is shown", async () => {
+    server.use(http.get("/api/v2/environment_auth", () => HttpResponse.json({ data: [] })));
+
+    render(setup());
+
+    expect(await screen.findByLabelText("TokenTable-Empty")).toBeVisible();
+  });
+
+  test("GIVEN registered tokens THEN they are listed with creator, client types and status", async () => {
+    server.use(
+      http.get("/api/v2/environment_auth", () =>
+        HttpResponse.json({
+          data: [
+            makeToken({ jti: "aaa", created_by: "alice", client_types: ["api", "compiler"] }),
+            makeToken({ jti: "bbb", created_by: "bob", revoked: true }),
+          ],
+        })
+      )
+    );
+
+    render(setup());
+
+    const activeRow = await screen.findByLabelText("token-row-aaa");
+    expect(within(activeRow).getByText("alice")).toBeVisible();
+    expect(within(activeRow).getByText("api, compiler")).toBeVisible();
+    expect(within(activeRow).getByText(words("settings.tabs.token.status.active"))).toBeVisible();
+
+    const revokedRow = screen.getByLabelText("token-row-bbb");
+    expect(within(revokedRow).getByText(words("settings.tabs.token.status.revoked"))).toBeVisible();
+    // An already-revoked token cannot be revoked again.
+    expect(within(revokedRow).getByRole("button", { name: "revoke-bbb" })).toBeDisabled();
+  });
+
+  test("GIVEN a token WHEN revoke is confirmed THEN the revoke call is made and the list refreshes", async () => {
+    let revokedJti: string | null = null;
+    let tokens: Token[] = [makeToken({ jti: "ccc", created_by: "carol" })];
+
+    server.use(
+      http.get("/api/v2/environment_auth", () => HttpResponse.json({ data: tokens })),
+      http.delete("/api/v2/environment_auth/:jti", ({ params }) => {
+        revokedJti = params.jti as string;
+        tokens = [];
+
+        return new HttpResponse(null, { status: 200 });
+      })
+    );
+
+    render(setup());
+
+    await userEvent.click(await screen.findByRole("button", { name: "revoke-ccc" }));
+    // Confirm in the modal.
+    await userEvent.click(await screen.findByRole("button", { name: "confirm-revoke" }));
+
+    await waitFor(() => expect(revokedJti).toBe("ccc"));
+    expect(await screen.findByLabelText("TokenTable-Empty")).toBeVisible();
+  });
+
+  test("GIVEN a token WHEN revoke is cancelled THEN no revoke call is made", async () => {
+    let deleteCalled = false;
+
+    server.use(
+      http.get("/api/v2/environment_auth", () =>
+        HttpResponse.json({ data: [makeToken({ jti: "ddd" })] })
+      ),
+      http.delete("/api/v2/environment_auth/:jti", () => {
+        deleteCalled = true;
+
+        return new HttpResponse(null, { status: 200 });
+      })
+    );
+
+    render(setup());
+
+    await userEvent.click(await screen.findByRole("button", { name: "revoke-ddd" }));
+    await userEvent.click(await screen.findByRole("button", { name: words("cancel") }));
+
+    // The row is still there and no delete was issued.
+    expect(screen.getByLabelText("token-row-ddd")).toBeVisible();
+    expect(deleteCalled).toBe(false);
+  });
+
+  test("GIVEN the list request fails THEN the error view is shown", async () => {
+    server.use(
+      http.get("/api/v2/environment_auth", () =>
+        HttpResponse.json({ message: "boom" }, { status: 500 })
+      )
+    );
+
+    render(setup());
+
+    expect(await screen.findByLabelText("TokenTable-Failed")).toBeVisible();
+  });
+});

--- a/src/Slices/Settings/UI/Tabs/Token/TokenTable.tsx
+++ b/src/Slices/Settings/UI/Tabs/Token/TokenTable.tsx
@@ -1,0 +1,106 @@
+import React, { useContext } from "react";
+import { Button, Label } from "@patternfly/react-core";
+import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
+import { useGetTokens, useRevokeToken } from "@/Data/Queries";
+import { EmptyView, ErrorView, LoadingView } from "@/UI/Components";
+import { ModalContext } from "@/UI/Root/Components/ModalProvider";
+import { words } from "@/UI/words";
+
+const formatDate = (value: string | null): string =>
+  value ? new Date(value).toLocaleString() : "-";
+
+/**
+ * Lists the registered (revocable) tokens of the current environment and allows revoking them.
+ *
+ * @returns {React.FC} The token registry table.
+ */
+export const TokenTable: React.FC = () => {
+  const { triggerModal, closeModal } = useContext(ModalContext);
+  const { data, isSuccess, isError, error, refetch } = useGetTokens().useOneTime();
+  const revoke = useRevokeToken();
+
+  const confirmRevoke = (jti: string) => {
+    triggerModal({
+      title: words("settings.tabs.token.revoke.title"),
+      iconVariant: "danger",
+      content: words("settings.tabs.token.revoke.confirm")(jti),
+      actions: [
+        <Button
+          key="confirm"
+          variant="danger"
+          aria-label="confirm-revoke"
+          onClick={() => {
+            revoke.mutate(jti);
+            closeModal();
+          }}
+        >
+          {words("settings.tabs.token.revoke")}
+        </Button>,
+        <Button key="cancel" variant="link" onClick={closeModal}>
+          {words("cancel")}
+        </Button>,
+      ],
+    });
+  };
+
+  if (isError) {
+    return (
+      <ErrorView
+        title={words("error")}
+        message={words("error.general")(error.message)}
+        ariaLabel="TokenTable-Failed"
+        retry={refetch}
+      />
+    );
+  }
+
+  if (!isSuccess) {
+    return <LoadingView ariaLabel="TokenTable-Loading" />;
+  }
+
+  if (data.length === 0) {
+    return <EmptyView message={words("settings.tabs.token.empty")} aria-label="TokenTable-Empty" />;
+  }
+
+  return (
+    <Table aria-label="tokens-table" variant="compact">
+      <Thead>
+        <Tr>
+          <Th>{words("settings.tabs.token.column.createdBy")}</Th>
+          <Th>{words("settings.tabs.token.column.clientTypes")}</Th>
+          <Th>{words("settings.tabs.token.column.issuedAt")}</Th>
+          <Th>{words("settings.tabs.token.column.lastUsed")}</Th>
+          <Th>{words("settings.tabs.token.column.status")}</Th>
+          <Th screenReaderText={words("common.emptyColumnHeader")} />
+        </Tr>
+      </Thead>
+      <Tbody>
+        {data.map((token) => (
+          <Tr key={token.jti} aria-label={`token-row-${token.jti}`}>
+            <Td>{token.created_by ?? "-"}</Td>
+            <Td>{token.client_types.join(", ")}</Td>
+            <Td>{formatDate(token.issued_at)}</Td>
+            <Td>{formatDate(token.last_used)}</Td>
+            <Td>
+              {token.revoked ? (
+                <Label color="red">{words("settings.tabs.token.status.revoked")}</Label>
+              ) : (
+                <Label color="green">{words("settings.tabs.token.status.active")}</Label>
+              )}
+            </Td>
+            <Td isActionCell>
+              <Button
+                variant="danger"
+                isDisabled={token.revoked}
+                aria-label={`revoke-${token.jti}`}
+                onClick={() => confirmRevoke(token.jti)}
+              >
+                {words("settings.tabs.token.revoke")}
+              </Button>
+            </Td>
+          </Tr>
+        ))}
+      </Tbody>
+    </Table>
+  );
+};

--- a/src/UI/words.tsx
+++ b/src/UI/words.tsx
@@ -801,6 +801,20 @@ const dict = {
   "settings.tabs.token.description":
     "Generate authentication tokens for authorizing agents, api or compiler for this specific environment.",
   "settings.tabs.token.generate": "Generate",
+  "settings.tabs.token.revocable": "Create a revocable token",
+  "settings.tabs.token.registered.title": "Registered tokens",
+  "settings.tabs.token.empty": "No revocable tokens have been created for this environment.",
+  "settings.tabs.token.column.createdBy": "Created by",
+  "settings.tabs.token.column.clientTypes": "Client types",
+  "settings.tabs.token.column.issuedAt": "Issued at",
+  "settings.tabs.token.column.lastUsed": "Last used",
+  "settings.tabs.token.column.status": "Status",
+  "settings.tabs.token.status.active": "Active",
+  "settings.tabs.token.status.revoked": "Revoked",
+  "settings.tabs.token.revoke": "Revoke",
+  "settings.tabs.token.revoke.title": "Revoke token",
+  "settings.tabs.token.revoke.confirm": (jti: string) =>
+    `Are you sure you want to revoke token ${jti}? This action cannot be undone.`,
   "settings.update": "Setting Changed",
   "settings.warning.update": "Changed value has not been saved",
   "settings.protected.message": (protected_by: string) =>


### PR DESCRIPTION
Extend the Settings -> Tokens tab so registered API tokens can be viewed and revoked.

Backend counterpart: inmanta/inmanta-core#10535.

## Change

- **Generate a revocable token:** a "Create a revocable token" checkbox on the generate form. When checked, the token is minted with `idempotent: false`, so the server registers it and it can later be revoked. Unchecked keeps the previous behavior (a stable, non-revocable token).
- **Registry table:** below the form, a table lists the environment's registered tokens (creator, client types, issued time, last used, active/revoked status) with a per-row **Revoke** action behind a confirm modal. Already-revoked tokens show as such and cannot be revoked again.
- New query hooks `useGetTokens` / `useRevokeToken` against `environment_token_list` / `environment_token_revoke`; generating a revocable token refreshes the list.

## Tests

`TokenTable.test.tsx` (list rendering, empty and error views, revoke via the confirm modal, cancel) and extended `Tab.test.tsx` (the revocable checkbox controls the `idempotent` flag). All green; tsc / eslint (zero-warnings) / prettier clean.

## Changelog

`changelogs/unreleased/token-registry.yml` (minor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)