### PR TITLE
Require the current password when changing your own password

### DIFF
--- a/changelogs/unreleased/self-service-password-current.yml
+++ b/changelogs/unreleased/self-service-password-current.yml
@@ -1,0 +1,3 @@
+description: When a user changes their own password in User Management, the current password is now required (a new Current Password field). An administrator changing another user's password is unaffected.
+change-type: minor
+destination-branches: [master, iso9]

--- a/src/Data/Queries/Slices/Auth/ChangeUserPassword/useChangeUserPassword.ts
+++ b/src/Data/Queries/Slices/Auth/ChangeUserPassword/useChangeUserPassword.ts
@@ -3,6 +3,12 @@ import { usePatchWithoutEnv } from "@/Data/Queries";
 
 interface ChangeUserPasswordBody {
   password: string;
+
+  /**
+   * The current password. Required by the server when a user changes their own password; omitted when
+   * an administrator changes another user's password.
+   */
+  current_password?: string;
 }
 
 /**

--- a/src/Slices/UserManagement/UI/Components/ChangePasswordForm/ChangePasswordForm.test.tsx
+++ b/src/Slices/UserManagement/UI/Components/ChangePasswordForm/ChangePasswordForm.test.tsx
@@ -1,0 +1,83 @@
+import React from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import { AuthContextInterface, defaultAuthContext } from "@/Data";
+import { MockedDependencyProvider } from "@/Test";
+import { ChangePasswordForm } from "./ChangePasswordForm";
+
+function setup(user: string, authHelper: AuthContextInterface = defaultAuthContext) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <MockedDependencyProvider authHelper={authHelper}>
+        <ChangePasswordForm user={user} />
+      </MockedDependencyProvider>
+    </QueryClientProvider>
+  );
+}
+
+describe("ChangePasswordForm", () => {
+  const server = setupServer();
+
+  beforeAll(() => server.listen());
+  afterEach(() => server.resetHandlers());
+  afterAll(() => server.close());
+
+  test("GIVEN an admin changing another user's password THEN no current-password field is shown and none is sent", async () => {
+    let sentBody: Record<string, unknown> | null = null;
+    server.use(
+      http.patch("/api/v2/user/other_user/password", async ({ request }) => {
+        sentBody = (await request.json()) as Record<string, unknown>;
+
+        return HttpResponse.json();
+      })
+    );
+
+    // Default auth helper: getUser() returns null, so this is not a self-service change.
+    render(setup("other_user"));
+
+    expect(screen.queryByLabelText("current-password-input")).toBeNull();
+
+    await userEvent.type(screen.getByLabelText("new-password-input"), "new_password_123");
+    await userEvent.click(screen.getByTestId("change-password-button"));
+
+    await waitFor(() => expect(sentBody).toEqual({ password: "new_password_123" }));
+  });
+
+  test("GIVEN a user changing their own password THEN the current password is required and sent", async () => {
+    let sentBody: Record<string, unknown> | null = null;
+    server.use(
+      http.patch("/api/v2/user/self_user/password", async ({ request }) => {
+        sentBody = (await request.json()) as Record<string, unknown>;
+
+        return HttpResponse.json();
+      })
+    );
+
+    const selfAuth: AuthContextInterface = { ...defaultAuthContext, getUser: () => "self_user" };
+    render(setup("self_user", selfAuth));
+
+    const currentPasswordInput = screen.getByLabelText("current-password-input");
+    const newPasswordInput = screen.getByLabelText("new-password-input");
+    const submit = screen.getByTestId("change-password-button");
+
+    // The submit stays disabled until both the current and the new password are filled in.
+    await userEvent.type(newPasswordInput, "new_password_123");
+    expect(submit).toBeDisabled();
+    await userEvent.type(currentPasswordInput, "old_password_123");
+    expect(submit).toBeEnabled();
+
+    await userEvent.click(submit);
+
+    await waitFor(() =>
+      expect(sentBody).toEqual({
+        password: "new_password_123",
+        current_password: "old_password_123",
+      })
+    );
+  });
+});

--- a/src/Slices/UserManagement/UI/Components/ChangePasswordForm/ChangePasswordForm.tsx
+++ b/src/Slices/UserManagement/UI/Components/ChangePasswordForm/ChangePasswordForm.tsx
@@ -12,7 +12,7 @@ import {
 } from "@patternfly/react-core";
 import { ExclamationTriangleIcon } from "@patternfly/react-icons";
 import { useChangeUserPassword } from "@/Data/Queries";
-import { words } from "@/UI";
+import { DependencyContext, words } from "@/UI";
 import { useAppAlert } from "@/UI/Root/Components/AppAlertProvider";
 import { ModalContext } from "@/UI/Root/Components/ModalProvider";
 
@@ -29,7 +29,11 @@ interface Props {
  */
 export const ChangePasswordForm: React.FC<Props> = ({ user }) => {
   const { closeModal } = useContext(ModalContext);
+  const { authHelper } = useContext(DependencyContext);
+  // Changing your own password requires the current one; an administrator changing another user's does not.
+  const isSelf = authHelper.getUser() === user;
   const [password, setPassword] = useState("");
+  const [currentPassword, setCurrentPassword] = useState("");
   const { notifySuccess } = useAppAlert();
   const { mutate, isPending, isError, error } = useChangeUserPassword(user, {
     onSuccess: () => {
@@ -53,7 +57,7 @@ export const ChangePasswordForm: React.FC<Props> = ({ user }) => {
     event: React.FormEvent<HTMLFormElement> | React.MouseEvent<HTMLButtonElement, MouseEvent>
   ): void => {
     event.preventDefault();
-    mutate({ password });
+    mutate(isSelf ? { password, current_password: currentPassword } : { password });
   };
 
   return (
@@ -71,6 +75,17 @@ export const ChangePasswordForm: React.FC<Props> = ({ user }) => {
           </HelperText>
         </FormHelperText>
       )}
+      {isSelf && (
+        <FormGroup label={words("userManagement.changePassword.currentPassword")} isRequired>
+          <TextInput
+            aria-label="current-password-input"
+            type="password"
+            placeholder={words("userManagement.changePassword.currentPassword.placeholder")}
+            value={currentPassword}
+            onChange={(_event, value) => setCurrentPassword(value)}
+          />
+        </FormGroup>
+      )}
       <FormGroup label="New Password" isRequired>
         <TextInput
           aria-label="new-password-input"
@@ -87,7 +102,7 @@ export const ChangePasswordForm: React.FC<Props> = ({ user }) => {
             variant="primary"
             type="submit"
             isLoading={isPending}
-            isDisabled={isPending || password.length < 1}
+            isDisabled={isPending || password.length < 1 || (isSelf && currentPassword.length < 1)}
           >
             {words("userManagement.changePassword")}
           </Button>

--- a/src/UI/words.tsx
+++ b/src/UI/words.tsx
@@ -978,6 +978,8 @@ const dict = {
   "userManagement.name": "Name",
   "userManagement.changePassword": "Change Password",
   "userManagement.changePassword.placeholder": "New Password...",
+  "userManagement.changePassword.currentPassword": "Current Password",
+  "userManagement.changePassword.currentPassword.placeholder": "Current Password...",
   "userManagement.changePassword.success": "Password changed successfully",
   "userManagement.changePassword.message": (username: string) =>
     `Please provide a new password for user ${username}`,


### PR DESCRIPTION
The server now requires the current password when a user changes their **own** password (so a hijacked session cannot silently take over the account). This adapts the User Management change-password form accordingly.

Backend counterpart: inmanta/inmanta-core#10537 (the `set_password` API gains an optional `current_password`; a self-service change without it is rejected). This PR should merge together with that one.

## Change

- `useChangeUserPassword` can now send an optional `current_password`.
- The change-password form detects when the target user is the logged-in user (`authHelper.getUser() === user`). In that self-service case it shows a required **Current Password** field and sends it as `current_password`; the submit button stays disabled until both fields are filled.
- Changing **another** user's password (an administrator reset) is unchanged - no current password is shown or sent.

## Tests

`ChangePasswordForm.test.tsx`: the admin path shows no current-password field and sends only `password`; the self-service path shows the field, keeps submit disabled until it is filled, and sends `current_password`. The existing UserManagement change-password test (admin path) still passes. tsc / eslint / prettier clean.

## Changelog

`changelogs/unreleased/self-service-password-current.yml` (minor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
