### PR TITLE
Renew the database login session before it expires

### DIFF
--- a/changelogs/unreleased/database-session-renewal.yml
+++ b/changelogs/unreleased/database-session-renewal.yml
@@ -1,0 +1,5 @@
+description: Automatically renew the database login session before it expires, so active users are no longer logged out mid-session when the session token reaches its (default one hour) lifetime.
+change-type: minor
+destination-branches: [master, iso9]
+sections:
+  minor-improvement: "{{description}}"

--- a/src/Data/Auth/AuthContext.ts
+++ b/src/Data/Auth/AuthContext.ts
@@ -24,8 +24,10 @@ export interface AuthContextInterface {
    * Function to update the current user and their token.
    * @param user - The new user.
    * @param token - The new token.
+   * @param expiresIn - Lifetime of the token in seconds, or null when it does not expire. Used to renew
+   *                    the session before it expires.
    */
-  updateUser: (user: string, token: string) => void;
+  updateUser: (user: string, token: string, expiresIn?: number | null) => void;
 
   /**
    * Function to get the current user's token.
@@ -56,7 +58,7 @@ export const defaultAuthContext: AuthContextInterface = {
   getUser: () => null,
   login: () => {},
   logout: () => {},
-  updateUser: (_user: string, _token: string) => {},
+  updateUser: (_user: string, _token: string, _expiresIn?: number | null) => {},
   getToken: () => null,
   isDisabled: () => true,
   isDatabaseSession: () => false,

--- a/src/Data/Auth/Providers/DatabaseAuthProvider.test.tsx
+++ b/src/Data/Auth/Providers/DatabaseAuthProvider.test.tsx
@@ -1,0 +1,129 @@
+import React, { useContext } from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { HttpResponse, http } from "msw";
+import { setupServer } from "msw/node";
+import { AuthContext } from "@/Data/Auth/AuthContext";
+import { AuthProvider } from "@/Data/Auth/AuthProvider";
+import * as CookieHelper from "@/Data/Common/CookieHelper";
+
+const mockedUsedNavigate = vi.hoisted(() => vi.fn());
+
+vi.mock("react-router", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-router")>();
+
+  return {
+    ...actual,
+    useNavigate: () => mockedUsedNavigate,
+  };
+});
+
+/**
+ * A minimal consumer that logs a user in through the DatabaseAuthProvider. The expiry is short (below the
+ * renewal buffer) so the provider's renewal timer fires immediately, letting the tests observe renewal
+ * without fake timers.
+ */
+const Consumer: React.FC<{ expiresIn?: number | null }> = ({ expiresIn = 30 }) => {
+  const { updateUser, getUser } = useContext(AuthContext);
+
+  return (
+    <>
+      <span data-testid="user">{getUser() ?? "none"}</span>
+      <button onClick={() => updateUser("admin", "initial-token", expiresIn)}>login</button>
+    </>
+  );
+};
+
+const setup = (expiresIn?: number | null) => (
+  <AuthProvider config={{ method: "database" }}>
+    <Consumer expiresIn={expiresIn} />
+  </AuthProvider>
+);
+
+describe("DatabaseAuthProvider session renewal", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    // A restored username so the mount effect does not log out while a (mocked) token cookie is present.
+    localStorage.setItem("inmanta_user", "admin");
+    mockedUsedNavigate.mockClear();
+    // The provider reads the current token from the cookie to authenticate the renewal request.
+    vi.spyOn(CookieHelper, "getCookie").mockReturnValue("initial-token");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renews the token shortly before the session expires", async () => {
+    const spiedCreateCookie = vi.spyOn(CookieHelper, "createCookie");
+    const server = setupServer(
+      http.post("/api/v2/login/renew", () =>
+        HttpResponse.json({
+          data: {
+            token: "renewed-token",
+            user: { username: "admin", auth_method: "database" },
+            expires_in: 3600,
+          },
+        })
+      )
+    );
+    server.listen();
+
+    render(setup(30));
+    await userEvent.click(screen.getByRole("button", { name: "login" }));
+
+    // The 30s expiry is within the 60s renewal buffer, so the renewal fires right away and stores the
+    // fresh token in the cookie.
+    await waitFor(() =>
+      expect(spiedCreateCookie).toHaveBeenCalledWith("inmanta_user", "renewed-token", 12)
+    );
+
+    server.close();
+  });
+
+  it("logs the user out when renewal fails", async () => {
+    const spiedRemoveCookie = vi.spyOn(CookieHelper, "removeCookie");
+    const server = setupServer(
+      http.post("/api/v2/login/renew", () => new HttpResponse(null, { status: 401 }))
+    );
+    server.listen();
+
+    render(setup(30));
+    await userEvent.click(screen.getByRole("button", { name: "login" }));
+
+    await waitFor(() =>
+      expect(mockedUsedNavigate).toHaveBeenCalledWith(expect.stringContaining("login"))
+    );
+    expect(spiedRemoveCookie).toHaveBeenCalledWith("inmanta_user");
+
+    server.close();
+  });
+
+  it("does not schedule renewal for a session without an expiry", async () => {
+    let renewCalls = 0;
+    const server = setupServer(
+      http.post("/api/v2/login/renew", () => {
+        renewCalls += 1;
+
+        return HttpResponse.json({
+          data: {
+            token: "renewed-token",
+            user: { username: "admin", auth_method: "database" },
+            expires_in: 3600,
+          },
+        });
+      })
+    );
+    server.listen();
+
+    render(setup(null));
+    await userEvent.click(screen.getByRole("button", { name: "login" }));
+
+    // Give any (unexpected) scheduled renewal a chance to fire before asserting none did.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(renewCalls).toBe(0);
+    expect(localStorage.getItem("inmanta_session_expiry")).toBeNull();
+
+    server.close();
+  });
+});

--- a/src/Data/Auth/Providers/DatabaseAuthProvider.tsx
+++ b/src/Data/Auth/Providers/DatabaseAuthProvider.tsx
@@ -1,12 +1,26 @@
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router";
 import { PrimaryBaseUrlManager } from "@/UI/Routing";
 import { AuthContext } from "../AuthContext";
 import { clearLocalToken, getLocalToken, getLocalUsername, setLocalToken } from "./localToken";
 
+/** Persisted expiry (absolute epoch ms) of the current session token, used to schedule renewal. */
+const SESSION_EXPIRY_KEY = "inmanta_session_expiry";
+
+/** Renew this long before the session expires, so an in-flight request never races the expiry. */
+const RENEWAL_BUFFER_MS = 60 * 1000;
+
 /**
  * DatabaseAuthProvider component provides authentication functionality using a database.
  * It manages user authentication state, token management, and navigation.
+ *
+ * Login sessions expire server-side (see server.login_session_expire). To keep an active user from being
+ * logged out mid-session, the provider renews the token shortly before it expires by calling the
+ * /api/v2/login/renew endpoint, mirroring the silent renewal the OIDC and Keycloak providers already do.
+ *
+ * The renewal timer is managed imperatively (a ref, not React state) on purpose: renewing a token does not
+ * change any state a consumer renders, and bumping state on every token change would re-fire effects that
+ * depend on the auth context (e.g. the login form's redirect effect) in a loop.
  */
 export const DatabaseAuthProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
   const [user, setUser] = useState<string | null>(null);
@@ -17,44 +31,148 @@ export const DatabaseAuthProvider: React.FC<React.PropsWithChildren> = ({ childr
   );
   const basePathname = baseUrlManager.getBasePathname();
 
+  // The pending renewal timer, and a ref to the latest renew() so the timer always runs the current one.
+  const renewalTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const renewRef = useRef<() => void>(() => {});
+
+  const clearRenewalTimer = useCallback((): void => {
+    if (renewalTimer.current !== null) {
+      clearTimeout(renewalTimer.current);
+      renewalTimer.current = null;
+    }
+  }, []);
+
+  const clearSession = useCallback((): void => {
+    clearRenewalTimer();
+    clearLocalToken();
+    localStorage.removeItem(SESSION_EXPIRY_KEY);
+  }, [clearRenewalTimer]);
+
   const getUser = (): string | null => user;
 
   const logout = useCallback((): void => {
-    clearLocalToken();
+    clearSession();
     navigate(`${basePathname}/login`);
-  }, [navigate, basePathname]);
+  }, [navigate, basePathname, clearSession]);
 
   const login = (): void => {
     // The login function is called when we also get a 401 error.
     // This means that the user is not authenticated and
     // we need to clear the cookies to avoid lingering cookies that are invalid.
-    clearLocalToken();
+    clearSession();
     navigate(`${basePathname}/login`);
   };
 
   const getToken = (): string | null => getLocalToken();
 
-  const updateUser = (username: string, token: string) => {
+  /**
+   * (Re)arm the one-shot renewal timer for a token that expires at expiryMs (absolute epoch ms), or clear it
+   * when there is no expiry.
+   */
+  const armRenewal = useCallback(
+    (expiryMs: number | null): void => {
+      clearRenewalTimer();
+      if (expiryMs === null) {
+        return;
+      }
+      const delay = Math.max(expiryMs - Date.now() - RENEWAL_BUFFER_MS, 0);
+      renewalTimer.current = setTimeout(() => renewRef.current(), delay);
+    },
+    [clearRenewalTimer]
+  );
+
+  /**
+   * Store a freshly issued session (token + username), persist its expiry (so renewal survives a reload),
+   * and arm the renewal timer.
+   */
+  const persistSession = useCallback(
+    (username: string, token: string, expiresIn: number | null): void => {
+      setLocalToken(username, token);
+      if (typeof expiresIn === "number" && expiresIn > 0) {
+        const expiryMs = Date.now() + expiresIn * 1000;
+
+        localStorage.setItem(SESSION_EXPIRY_KEY, String(expiryMs));
+        armRenewal(expiryMs);
+      } else {
+        // A session without an expiry does not need renewal.
+        localStorage.removeItem(SESSION_EXPIRY_KEY);
+        armRenewal(null);
+      }
+    },
+    [armRenewal]
+  );
+
+  const updateUser = (username: string, token: string, expiresIn: number | null = null): void => {
     setUser(username);
-    setLocalToken(username, token);
+    persistSession(username, token, expiresIn);
   };
 
-  const isDisabled = () => !getToken();
+  /**
+   * Exchange the current, still-valid session token for a fresh one. On success the new token and expiry are
+   * stored and the timer re-arms; on any failure the session ends, sending the user to the login page.
+   */
+  const renew = useCallback(async (): Promise<void> => {
+    const token = getLocalToken();
+    const username = getLocalUsername();
+
+    if (!token || !username) {
+      return;
+    }
+
+    try {
+      const baseUrl = new PrimaryBaseUrlManager(
+        globalThis.location.origin,
+        globalThis.location.pathname
+      ).getBaseUrl();
+      const response = await fetch(`${baseUrl}/api/v2/login/renew`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error(`Session renewal failed with status ${response.status}`);
+      }
+
+      const body = await response.json();
+
+      persistSession(username, body.data.token, body.data.expires_in ?? null);
+    } catch {
+      logout();
+    }
+  }, [persistSession, logout]);
 
   const isDatabaseSession = () => true;
 
   useEffect(() => {
-    // If user is not set and token is present, set the user from the local storage or logs out. case where there is an user but not token is handled automatically as lacks of token prompt use to login again
-    if (!user && getToken()) {
+    renewRef.current = () => {
+      void renew();
+    };
+  }, [renew]);
+
+  useEffect(() => {
+    // Restore the session on load: if a token is present, set the user and arm renewal from the persisted
+    // expiry. A missing username means the session is unusable, so log out.
+    if (!user && getLocalToken()) {
       const username = getLocalUsername();
 
       if (username) {
         setUser(username);
+        const expiry = localStorage.getItem(SESSION_EXPIRY_KEY);
+
+        armRenewal(expiry ? Number(expiry) : null);
       } else {
         logout();
       }
     }
-  }, [user, logout]);
+  }, [user, logout, armRenewal]);
+
+  // Clear any pending renewal when the provider unmounts.
+  useEffect(() => clearRenewalTimer, [clearRenewalTimer]);
+
+  const isDisabled = () => !getToken();
 
   return (
     <AuthContext.Provider

--- a/src/Data/Queries/Slices/Auth/Login/useLogin.ts
+++ b/src/Data/Queries/Slices/Auth/Login/useLogin.ts
@@ -8,6 +8,8 @@ interface LoginResponse {
       username: string;
       auth_method: string;
     };
+    // Lifetime of the token in seconds, or null when it does not expire. Used to renew before it lapses.
+    expires_in: number | null;
   };
 }
 

--- a/src/Slices/Login/UI/LoginForm.tsx
+++ b/src/Slices/Login/UI/LoginForm.tsx
@@ -71,7 +71,7 @@ export const LoginPageComponent: React.FC<Props> = ({ submitButtonText }) => {
 
   useEffect(() => {
     if (isSuccess) {
-      authHelper.updateUser(data.data.user.username, data.data.token);
+      authHelper.updateUser(data.data.user.username, data.data.token, data.data.expires_in);
       navigate(basePathname);
     }
   }, [isSuccess, navigate, data, authHelper, basePathname]);


### PR DESCRIPTION
Automatically renew the database login session before it expires, so an active user is no longer logged out mid-session.

> Depends on the backend endpoint in inmanta-core PR #10540 (`POST /api/v2/login/renew`). Merge that first.

## Why

inmanta-core now gives database/break-glass login sessions a finite lifetime (default one hour). That is good for security, but it means an actively-used console session is silently dropped after an hour, forcing a re-login mid-work. The OIDC and Keycloak providers already renew their tokens silently through their client libraries; the built-in database provider had no equivalent. This closes that gap.

## Change

- `DatabaseAuthProvider` renews the token ~60s before it expires by calling `POST /api/v2/login/renew`, and stores the fresh token. On renewal failure it logs the user out (same path as a 401).
- The expiry is persisted to `localStorage`, so renewal is rescheduled correctly after a page reload.
- `LoginReturn` / `useLogin` now carry `expires_in`; `updateUser` gained an optional `expiresIn` used to schedule the first renewal.
- The renewal timer is managed imperatively via a ref rather than React state, on purpose: renewing a token changes no rendered state, and bumping state on every token change would re-fire auth-context effects (the login form's redirect effect) in a render loop.

## Tests

New `DatabaseAuthProvider.test.tsx`: renews shortly before expiry (asserts the fresh token is stored), logs out when renewal fails, and does not schedule renewal for a session without an expiry. The existing Login flow test still passes. eslint / prettier / tsc clean.

## Changelog

`changelogs/unreleased/database-session-renewal.yml` (minor, master + iso9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
