### PR TITLE
Extend value rendering to parameters and resource facts tables

### DIFF
--- a/changelogs/unreleased/7048-parameters-resource-facts-value-expand.yml
+++ b/changelogs/unreleased/7048-parameters-resource-facts-value-expand.yml
@@ -1,0 +1,6 @@
+description: The parameters table and the resource details facts table now present each value according to its content - JSON, XML, and other long or multi-line values can be expanded inline into a read-only, formatted code editor with copy and download controls, while short text values can be copied directly from the row, matching the facts table.
+issue-nr: 7048
+change-type: patch
+destination-branches: [master, iso9]
+sections:
+  minor-improvement: "{{description}}"

--- a/src/Slices/Facts/UI/FactsRow.tsx
+++ b/src/Slices/Facts/UI/FactsRow.tsx
@@ -1,8 +1,15 @@
-import React, { memo, useState, useContext } from "react";
-import { Button, Truncate } from "@patternfly/react-core";
-import { ExpandableRowContent, Tbody, Tr, Td } from "@patternfly/react-table";
+import React, { memo, useContext } from "react";
+import { Button } from "@patternfly/react-core";
+import { Tbody, Tr, Td } from "@patternfly/react-table";
 import { ClassifiedAttribute } from "@/Data";
-import { AttributeValue, DateWithTooltip, Link, isEditorKind } from "@/UI/Components";
+import {
+  AttributeExpandTd,
+  AttributeExpansionRow,
+  AttributeValueCell,
+  DateWithTooltip,
+  Link,
+  useAttributeExpansion,
+} from "@/UI/Components";
 import { DependencyContext } from "@/UI/Dependency";
 import { words } from "@/UI/words";
 import { Fact } from "@S/Facts/Core/Domain";
@@ -18,23 +25,17 @@ interface Props {
 export const FactsRow: React.FC<Props> = memo(
   ({ row, attribute, rowIndex, numberOfColumns, showExpandColumn }) => {
     const { routeManager } = useContext(DependencyContext);
-    const [isExpanded, setIsExpanded] = useState(false);
-    const isExpandable = isEditorKind(attribute.kind);
+    const { isExpandable, isExpanded, toggleExpanded } = useAttributeExpansion(attribute);
 
     return (
       <Tbody isExpanded={isExpandable ? isExpanded : undefined}>
         <Tr aria-label="FactsRow">
           {showExpandColumn && (
-            <Td
-              expand={
-                isExpandable
-                  ? {
-                      rowIndex,
-                      isExpanded,
-                      onToggle: () => setIsExpanded((prev) => !prev),
-                    }
-                  : undefined
-              }
+            <AttributeExpandTd
+              isExpandable={isExpandable}
+              rowIndex={rowIndex}
+              isExpanded={isExpanded}
+              onToggle={toggleExpanded}
             />
           )}
           <Td dataLabel={words("facts.column.name")}>{row.name}</Td>
@@ -42,22 +43,12 @@ export const FactsRow: React.FC<Props> = memo(
             {row.updated && <DateWithTooltip timestamp={row.updated} />}
           </Td>
           <Td modifier="breakWord" dataLabel={words("facts.column.value")}>
-            {isExpandable ? (
-              <Button
-                variant="link"
-                isInline
-                onClick={() => setIsExpanded((prev) => !prev)}
-                aria-expanded={isExpanded}
-              >
-                <Truncate
-                  content={row.value}
-                  maxCharsDisplayed={30}
-                  tooltipProps={{ isVisible: false, trigger: "manual" }}
-                />
-              </Button>
-            ) : (
-              <AttributeValue attribute={attribute} />
-            )}
+            <AttributeValueCell
+              value={row.value}
+              attribute={attribute}
+              isExpanded={isExpanded}
+              onToggle={toggleExpanded}
+            />
           </Td>
           <Td modifier="breakWord" dataLabel={words("facts.column.resourceId")}>
             <Link
@@ -72,13 +63,11 @@ export const FactsRow: React.FC<Props> = memo(
           </Td>
         </Tr>
         {isExpandable && (
-          <Tr isExpanded={isExpanded}>
-            <Td colSpan={numberOfColumns}>
-              <ExpandableRowContent>
-                <AttributeValue attribute={attribute} />
-              </ExpandableRowContent>
-            </Td>
-          </Tr>
+          <AttributeExpansionRow
+            isExpanded={isExpanded}
+            colSpan={numberOfColumns}
+            attribute={attribute}
+          />
         )}
       </Tbody>
     );

--- a/src/Slices/Facts/UI/FactsTable.tsx
+++ b/src/Slices/Facts/UI/FactsTable.tsx
@@ -1,14 +1,11 @@
-import React, { useMemo } from "react";
+import React from "react";
 import { OnSort, Table, TableVariant, Th, Thead, Tr } from "@patternfly/react-table";
 import { Sort } from "@/Core";
-import { AttributeClassifier } from "@/Data";
 import { SortKey } from "@/Slices/Facts/Core/Types";
-import { isEditorKind } from "@/UI/Components";
+import { useClassifiedRows } from "@/UI/Components";
 import { Fact } from "@S/Facts/Core/Domain";
 import { FactsRow } from "./FactsRow";
 import { FactsTablePresenter } from "./FactsTablePresenter";
-
-const classifier = new AttributeClassifier();
 
 interface Props {
   rows: Fact[];
@@ -25,15 +22,7 @@ export const FactsTable: React.FC<Props> = ({ rows, tablePresenter, sort, setSor
     });
   };
   const activeSortIndex = tablePresenter.getIndexForColumnName(sort.name);
-  const classifiedRows = useMemo(
-    () =>
-      rows.map((row) => ({
-        row,
-        attribute: classifier.classify({ value: row.value })[0],
-      })),
-    [rows]
-  );
-  const hasExpandableRows = classifiedRows.some(({ attribute }) => isEditorKind(attribute.kind));
+  const { classifiedRows, hasExpandableRows } = useClassifiedRows(rows);
   const numberOfColumns = tablePresenter.getNumberOfColumns() + (hasExpandableRows ? 1 : 0);
   const heads = tablePresenter.getColumnHeads().map(({ apiName, displayName }, columnIndex) => {
     const hasSort = tablePresenter.getSortableColumnNames().includes(apiName);

--- a/src/Slices/Parameters/UI/Page.test.tsx
+++ b/src/Slices/Parameters/UI/Page.test.tsx
@@ -262,4 +262,32 @@ describe("ParametersPage", () => {
 
     expect(initialRows2).toHaveLength(10);
   });
+
+  test("When a parameter has a long value Then it renders an expandable preview that reveals the code editor", async () => {
+    server.use(http.get("/api/v2/parameters", () => HttpResponse.json(Parameters.response)));
+
+    const { component } = setup();
+
+    render(component);
+
+    const longValue =
+      Parameters.response.data.find((parameter) => parameter.name === "different_param")?.value ??
+      "";
+
+    // A long value is now classified as expandable: the cell renders a preview
+    // button (rather than the previous plain truncated cell) that reveals the
+    // value in the mocked code editor (test-setup.ts). The button label is a
+    // middle-truncated form of the value, so match on its distinctive tail.
+    const [preview] = await screen.findAllByRole("button", { name: /long value$/ });
+
+    await userEvent.click(preview);
+
+    // The editor renders the value verbatim (whitespace preserved), so the full
+    // fixture value appears in its content.
+    const editor = screen
+      .getAllByTestId("code-editor-content")
+      .find((element) => element.textContent?.includes(longValue));
+
+    expect(editor).toBeVisible();
+  });
 });

--- a/src/Slices/Parameters/UI/ParametersTable.tsx
+++ b/src/Slices/Parameters/UI/ParametersTable.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { OnSort, Table, TableVariant, Th, Thead, Tr } from "@patternfly/react-table";
 import { Sort, Parameter } from "@/Core";
 import { SortKey } from "@/Slices/Parameters/Core/Types";
+import { useClassifiedRows } from "@/UI/Components";
 import { ParametersTablePresenter } from "./ParametersTablePresenter";
 import { ParametersTableRow } from "./ParametersTableRow";
 
@@ -25,6 +26,9 @@ export const ParametersTable: React.FC<Props> = ({
       order,
     });
   };
+
+  const { classifiedRows, hasExpandableRows } = useClassifiedRows(rows);
+  const numberOfColumns = tablePresenter.getColumnHeads().length + (hasExpandableRows ? 1 : 0);
 
   const heads = tablePresenter.getColumnHeads().map(({ apiName, displayName }, columnIndex) => {
     const sortParams = tablePresenter.getSortableColumnNames().includes(apiName)
@@ -50,10 +54,20 @@ export const ParametersTable: React.FC<Props> = ({
   return (
     <Table {...props} variant={TableVariant.compact}>
       <Thead>
-        <Tr>{heads}</Tr>
+        <Tr>
+          {hasExpandableRows && <Th screenReaderText="Row expansion" />}
+          {heads}
+        </Tr>
       </Thead>
-      {rows.map((row) => (
-        <ParametersTableRow row={row} key={row.id} />
+      {classifiedRows.map(({ row, attribute }, rowIndex) => (
+        <ParametersTableRow
+          row={row}
+          attribute={attribute}
+          key={row.id}
+          rowIndex={rowIndex}
+          numberOfColumns={numberOfColumns}
+          showExpandColumn={hasExpandableRows}
+        />
       ))}
     </Table>
   );

--- a/src/Slices/ResourceDetails/UI/Tabs/FactsTab/FactsRow.tsx
+++ b/src/Slices/ResourceDetails/UI/Tabs/FactsTab/FactsRow.tsx
@@ -1,25 +1,26 @@
 import React from "react";
 import { Tbody, Td, Tr } from "@patternfly/react-table";
-import { Parameter } from "@/Core";
 import { ClassifiedAttribute } from "@/Data";
 import {
   AttributeExpandTd,
   AttributeExpansionRow,
   AttributeValueCell,
-  DateWithTooltip,
   useAttributeExpansion,
 } from "@/UI/Components";
-import { words } from "@/UI/words";
+import { CustomDatePresenter } from "@/UI/Utils";
+import { Fact } from "@S/Facts/Core/Domain";
+
+const datePresenter = new CustomDatePresenter();
 
 interface Props {
-  row: Parameter;
+  row: Pick<Fact, "id" | "name" | "updated" | "value">;
   attribute: ClassifiedAttribute;
   rowIndex: number;
   numberOfColumns: number;
   showExpandColumn: boolean;
 }
 
-export const ParametersTableRow: React.FC<Props> = ({
+export const FactsRow: React.FC<Props> = ({
   row,
   attribute,
   rowIndex,
@@ -30,7 +31,7 @@ export const ParametersTableRow: React.FC<Props> = ({
 
   return (
     <Tbody isExpanded={isExpandable ? isExpanded : undefined}>
-      <Tr aria-label="Parameters Table Row">
+      <Tr aria-label="Facts table row">
         {showExpandColumn && (
           <AttributeExpandTd
             isExpandable={isExpandable}
@@ -39,16 +40,9 @@ export const ParametersTableRow: React.FC<Props> = ({
             onToggle={toggleExpanded}
           />
         )}
-        <Td dataLabel={words("parameters.columns.name")} width={20}>
-          {row.name}
-        </Td>
-        <Td dataLabel={words("parameters.columns.updated")} width={10}>
-          {row.updated ? <DateWithTooltip timestamp={row.updated} /> : ""}
-        </Td>
-        <Td dataLabel={words("parameters.columns.source")} width={10}>
-          {row.source}
-        </Td>
-        <Td modifier="breakWord" dataLabel={words("parameters.columns.value")}>
+        <Td>{row.name}</Td>
+        <Td>{row.updated && datePresenter.getFull(row.updated)}</Td>
+        <Td modifier="breakWord">
           <AttributeValueCell
             value={row.value}
             attribute={attribute}

--- a/src/Slices/ResourceDetails/UI/Tabs/FactsTab/FactsTab.test.tsx
+++ b/src/Slices/ResourceDetails/UI/Tabs/FactsTab/FactsTab.test.tsx
@@ -1,6 +1,6 @@
-import React from "react";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { render, screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
 import { delay, http, HttpResponse } from "msw";
 import { setupServer } from "msw/node";
 import { MockedDependencyProvider } from "@/Test";
@@ -9,6 +9,14 @@ import { TestMemoryRouter } from "@/UI/Routing/TestMemoryRouter";
 import { Mock } from "@S/Facts/Test";
 import { FactsTab } from "./FactsTab";
 import { sortFactRows } from "./FactsTable";
+
+const valueOf = (name: string) => Mock.list.find((f) => f.name === name)?.value ?? "";
+
+// The code editor is mocked globally in test-setup.ts; it renders its content
+// into a <pre data-testid="code-editor-content">. Scope to it so we match the
+// formatted value in the editor rather than the raw value in the preview button.
+const editorShowing = (snippet: string) =>
+  screen.getAllByTestId("code-editor-content").find((el) => el.textContent?.includes(snippet));
 
 function setup() {
   const component = (
@@ -63,6 +71,30 @@ describe("FactsTab", () => {
     expect(await screen.findByRole("region", { name: "Facts-Loading" })).toBeInTheDocument();
 
     expect(await screen.findByRole("grid", { name: "Facts-Success" })).toBeInTheDocument();
+  });
+
+  test("Given the FactsTab When a fact has a JSON value Then it expands into the formatted editor", async () => {
+    server.use(http.get("/api/v2/resource/abc/facts", () => HttpResponse.json(Mock.response)));
+    const { component } = setup();
+
+    render(component);
+
+    await userEvent.click(await screen.findByRole("button", { name: valueOf("jsonValueFact") }));
+
+    // The editor shows the pretty-printed JSON (a space after the colon that the
+    // raw value does not have) - distinctive of the formatted output.
+    expect(editorShowing('"status": "deployed"')).toBeVisible();
+  });
+
+  test("Given the FactsTab When a fact has an XML value Then it expands into the formatted editor", async () => {
+    server.use(http.get("/api/v2/resource/abc/facts", () => HttpResponse.json(Mock.response)));
+    const { component } = setup();
+
+    render(component);
+
+    await userEvent.click(await screen.findByRole("button", { name: valueOf("xmlValueFact") }));
+
+    expect(editorShowing("<host>localhost</host>")).toBeVisible();
   });
 
   test("Given sortFactRows When sorting by different columns Then the result is correct", async () => {

--- a/src/Slices/ResourceDetails/UI/Tabs/FactsTab/FactsTable.tsx
+++ b/src/Slices/ResourceDetails/UI/Tabs/FactsTab/FactsTable.tsx
@@ -1,13 +1,12 @@
 import React, { useEffect, useState } from "react";
-import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
+import { Table, Th, Thead, Tr } from "@patternfly/react-table";
 import { Sort } from "@/Core";
 import { Order } from "@/Core/Domain/Sort";
+import { useClassifiedRows } from "@/UI/Components";
 import { ColumnHead } from "@/UI/Presenters";
-import { CustomDatePresenter } from "@/UI/Utils";
 import { words } from "@/UI/words";
-
-const datePresenter = new CustomDatePresenter();
 import { Fact } from "@S/Facts/Core/Domain";
+import { FactsRow } from "./FactsRow";
 
 type FactRow = Pick<Fact, "id" | "name" | "updated" | "value">;
 
@@ -24,7 +23,9 @@ const factsColumnHeads: ColumnHead[] = [
 export const FactsTable: React.FC<Props> = ({ facts }) => {
   const [sort, setSort] = useState<Sort.Type>({ name: "name", order: "asc" });
   const [rows, setRows] = useState(sortFactRows(facts, sort.name, sort.order));
-  const onSort = (event, index, direction) => {
+  const { classifiedRows, hasExpandableRows } = useClassifiedRows(rows);
+  const numberOfColumns = factsColumnHeads.length + (hasExpandableRows ? 1 : 0);
+  const onSort = (_event, index, direction) => {
     const updatedSortColumn = indexToColumnName(index);
 
     setSort({ name: updatedSortColumn, order: direction });
@@ -42,6 +43,7 @@ export const FactsTable: React.FC<Props> = ({ facts }) => {
     <Table variant="compact" aria-label="Facts-Success">
       <Thead>
         <Tr>
+          {hasExpandableRows && <Th screenReaderText="Row expansion" />}
           {factsColumnHeads.map(({ displayName }, idx) => (
             <Th
               key={displayName}
@@ -60,15 +62,16 @@ export const FactsTable: React.FC<Props> = ({ facts }) => {
           ))}
         </Tr>
       </Thead>
-      <Tbody>
-        {rows.map((fact) => (
-          <Tr key={fact.id} aria-label="Facts table row">
-            <Td>{fact.name}</Td>
-            <Td>{fact.updated && datePresenter.getFull(fact.updated)}</Td>
-            <Td>{fact.value}</Td>
-          </Tr>
-        ))}
-      </Tbody>
+      {classifiedRows.map(({ row, attribute }, rowIndex) => (
+        <FactsRow
+          row={row}
+          attribute={attribute}
+          key={row.id}
+          rowIndex={rowIndex}
+          numberOfColumns={numberOfColumns}
+          showExpandColumn={hasExpandableRows}
+        />
+      ))}
     </Table>
   );
 };
@@ -86,7 +89,7 @@ function columnNameToIndex(columnName: string): number {
 }
 
 export function sortFactRows(rows: FactRow[], columnName: string, direction: Order): FactRow[] {
-  return rows.sort((a: FactRow, b: FactRow) => {
+  return [...rows].sort((a: FactRow, b: FactRow) => {
     // sort by date
     if (columnName === "updated") {
       const aDate = coalesceDateToMin(a[columnName]);

--- a/src/UI/Components/AttributeList/ExpandableAttributeValue.tsx
+++ b/src/UI/Components/AttributeList/ExpandableAttributeValue.tsx
@@ -1,0 +1,134 @@
+import React, { useMemo, useState } from "react";
+import { Button, Truncate } from "@patternfly/react-core";
+import { ExpandableRowContent, Td, Tr } from "@patternfly/react-table";
+import { ClassifiedAttribute } from "@/Data";
+import { AttributeClassifier } from "@/Data/Common/AttributeClassifier/AttributeClassifier";
+import { AttributeValue } from "./AttributeList";
+import { isEditorKind } from "./helpers";
+
+const classifier = new AttributeClassifier();
+
+/**
+ * A table row paired with the classification of its value, as produced by
+ * {@link useClassifiedRows}.
+ *
+ * @template Row - The original row type.
+ */
+export interface ClassifiedRow<Row> {
+  row: Row;
+  attribute: ClassifiedAttribute;
+}
+
+/**
+ * Classifies every row's `value` so a table can render each one according to
+ * its content (JSON, XML, multiline code, or plain text) and decide whether the
+ * extra expand column is needed at all.
+ *
+ * @param rows - The rows to classify; each must carry a string `value`.
+ * @returns The classified rows and whether any of them render in the expandable
+ *   code editor (`hasExpandableRows`).
+ */
+export function useClassifiedRows<Row extends { value: string }>(
+  rows: Row[]
+): { classifiedRows: ClassifiedRow<Row>[]; hasExpandableRows: boolean } {
+  return useMemo(() => {
+    const classifiedRows = rows.map((row) => ({
+      row,
+      attribute: classifier.classify({ value: row.value })[0],
+    }));
+
+    return {
+      classifiedRows,
+      hasExpandableRows: classifiedRows.some(({ attribute }) => isEditorKind(attribute.kind)),
+    };
+  }, [rows]);
+}
+
+/**
+ * Per-row expansion state for a classified attribute. `isExpandable` reflects
+ * whether the attribute renders in the code editor at all; rows that are not
+ * expandable simply ignore the toggle.
+ *
+ * @param attribute - The classified attribute rendered in the row.
+ */
+export function useAttributeExpansion(attribute: ClassifiedAttribute): {
+  isExpandable: boolean;
+  isExpanded: boolean;
+  toggleExpanded: () => void;
+} {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  return {
+    isExpandable: isEditorKind(attribute.kind),
+    isExpanded,
+    toggleExpanded: () => setIsExpanded((prev) => !prev),
+  };
+}
+
+/**
+ * The leading expand-toggle cell for a table that has expandable rows. Rows
+ * whose value is not expandable render an empty cell so columns stay aligned.
+ *
+ * @param isExpandable - Whether this row's value can be expanded.
+ * @param rowIndex - The row's index, required by PatternFly for the toggle.
+ * @param isExpanded - Whether the expansion row is currently open.
+ * @param onToggle - Toggles the expansion row.
+ */
+export const AttributeExpandTd: React.FC<{
+  isExpandable: boolean;
+  rowIndex: number;
+  isExpanded: boolean;
+  onToggle: () => void;
+}> = ({ isExpandable, rowIndex, isExpanded, onToggle }) => (
+  <Td expand={isExpandable ? { rowIndex, isExpanded, onToggle } : undefined} />
+);
+
+/**
+ * The content of a value cell. Expandable kinds (JSON, XML, multiline code)
+ * show a truncated preview button that toggles the expansion row; everything
+ * else renders inline via {@link AttributeValue} (copyable text, file block, ...).
+ *
+ * @param value - The raw value, shown truncated in the preview button.
+ * @param attribute - The classified attribute.
+ * @param isExpanded - Whether the expansion row is currently open.
+ * @param onToggle - Toggles the expansion row.
+ */
+export const AttributeValueCell: React.FC<{
+  value: string;
+  attribute: ClassifiedAttribute;
+  isExpanded: boolean;
+  onToggle: () => void;
+}> = ({ value, attribute, isExpanded, onToggle }) =>
+  isEditorKind(attribute.kind) ? (
+    <Button variant="link" isInline onClick={onToggle} aria-expanded={isExpanded}>
+      <Truncate
+        content={value}
+        maxCharsDisplayed={30}
+        tooltipProps={{ isVisible: false, trigger: "manual" }}
+      />
+    </Button>
+  ) : (
+    <AttributeValue attribute={attribute} />
+  );
+
+/**
+ * The full-width row revealed when an expandable value is opened, rendering the
+ * value in the read-only code editor.
+ *
+ * @param isExpanded - Whether the row is open.
+ * @param colSpan - The number of columns the row should span.
+ * @param attribute - The classified attribute to render.
+ */
+export const AttributeExpansionRow: React.FC<{
+  isExpanded: boolean;
+  colSpan: number;
+  attribute: ClassifiedAttribute;
+}> = ({ isExpanded, colSpan, attribute }) => (
+  <Tr isExpanded={isExpanded}>
+    <Td colSpan={colSpan}>
+      <ExpandableRowContent>
+        <AttributeValue attribute={attribute} />
+      </ExpandableRowContent>
+    </Td>
+  </Tr>
+);

--- a/src/UI/Components/AttributeList/index.ts
+++ b/src/UI/Components/AttributeList/index.ts
@@ -1,2 +1,3 @@
 export * from "./AttributeList";
+export * from "./ExpandableAttributeValue";
 export * from "./helpers";


### PR DESCRIPTION
# Description

So essentially Guillaume asked to extend the functionality of the facts table row (value row) to also be available for the parameters and the resource details facts table.
So what I did was made a file (ExpandableAttributeValue.tsx) which is the single source of truth for all of these 3 tables so it's uniform and easily adjustable as well into the future.
Some test additions were made as well.

closes https://github.com/inmanta/web-console/issues/7048

<img width="1283" height="425" alt="Screenshot 2026-07-07 at 09 44 40" src="https://github.com/user-attachments/assets/2d715506-b4ed-449f-8436-6425c340bdcf" />

<img width="1455" height="474" alt="Screenshot 2026-07-07 at 09 44 48" src="https://github.com/user-attachments/assets/56a36939-0d35-4e14-ab8e-cf7a79c53f6c" />