### PR TITLE
Fix the User Management local-auth e2e for the hardened password policy

### DIFF
--- a/changelogs/unreleased/fix-local-auth-e2e-password-policy.yml
+++ b/changelogs/unreleased/fix-local-auth-e2e-password-policy.yml
@@ -1,0 +1,3 @@
+description: Update the User Management local-auth e2e test for the hardened password policy (at least 12 characters and 3 character classes) and the self-service current-password field.
+change-type: patch
+destination-branches: [master, iso9]

--- a/cypress/e2e/LocalAuth/scenario-7.2-local-auth.cy.js
+++ b/cypress/e2e/LocalAuth/scenario-7.2-local-auth.cy.js
@@ -5,7 +5,7 @@ if (localAuth) {
     cy.visit("/console/");
 
     cy.get('[id="pf-login-username-id"]').type("admin");
-    cy.get('[id="pf-login-password-id"]').type("adminadmin{enter}");
+    cy.get('[id="pf-login-password-id"]').type("Str0ng-Pass!{enter}");
 
     cy.get("h1").contains("Dashboard | env").should("be.visible");
 

--- a/cypress/e2e/LocalAuth/scenario-7.3-user-management.cy.js
+++ b/cypress/e2e/LocalAuth/scenario-7.3-user-management.cy.js
@@ -143,10 +143,10 @@ if (localAuth) {
     cy.get('[aria-label="confirm-button"]').click();
 
     cy.get("span")
-      .contains("Invalid request: the password should be at least 8 characters long")
+      .contains("Invalid request: the password should be at least 12 characters long")
       .should("be.visible");
 
-    cy.get('[aria-label="input-password"]').clear().type("password");
+    cy.get('[aria-label="input-password"]').clear().type("Str0ng-Pass!");
 
     cy.get('[aria-label="confirm-button"]').click();
 
@@ -198,15 +198,19 @@ if (localAuth) {
 
     cy.get("h1").contains("Change Password").should("be.visible");
 
+    // admin is the logged-in user, so this is a self-service change: the current password is required
+    // and the submit button stays disabled until it is filled (PR #7071).
+    cy.get('[aria-label="current-password-input"]').type("adminadmin");
+
     cy.get('[aria-label="new-password-input"]').type("123");
 
     cy.get('[data-testid="change-password-button"]').click();
 
     cy.get("span")
-      .contains("Invalid request: the password should be at least 8 characters long")
+      .contains("Invalid request: the password should be at least 12 characters long")
       .should("be.visible");
 
-    cy.get('[aria-label="new-password-input"]').clear().type("12345678");
+    cy.get('[aria-label="new-password-input"]').clear().type("New-Str0ng-Pass!");
 
     cy.get('[data-testid="change-password-button"]').click();
 
@@ -218,7 +222,7 @@ if (localAuth) {
     cy.get('[role="menuitem"]').contains("Logout").click();
 
     cy.get('[id="pf-login-username-id"]').type("admin");
-    cy.get('[id="pf-login-password-id"]').type("12345678{enter}");
+    cy.get('[id="pf-login-password-id"]').type("New-Str0ng-Pass!{enter}");
 
     cy.get("h1").contains("Dashboard | env").should("be.visible");
   });

--- a/cypress/e2e/LocalAuth/scenario-7.3-user-management.cy.js
+++ b/cypress/e2e/LocalAuth/scenario-7.3-user-management.cy.js
@@ -5,7 +5,7 @@ if (localAuth) {
     cy.visit("/console/");
 
     cy.get('[id="pf-login-username-id"]').type("admin");
-    cy.get('[id="pf-login-password-id"]').type("adminadmin{enter}");
+    cy.get('[id="pf-login-password-id"]').type("Str0ng-Pass!{enter}");
 
     cy.get("h1").contains("Dashboard | env").should("be.visible");
 
@@ -121,7 +121,7 @@ if (localAuth) {
     cy.visit("/console/");
 
     cy.get('[id="pf-login-username-id"]').type("admin");
-    cy.get('[id="pf-login-password-id"]').type("adminadmin{enter}");
+    cy.get('[id="pf-login-password-id"]').type("Str0ng-Pass!{enter}");
 
     cy.get("h1").contains("Dashboard | env").should("be.visible");
 
@@ -157,7 +157,7 @@ if (localAuth) {
     cy.visit("/console/");
 
     cy.get('[id="pf-login-username-id"]').type("admin");
-    cy.get('[id="pf-login-password-id"]').type("adminadmin{enter}");
+    cy.get('[id="pf-login-password-id"]').type("Str0ng-Pass!{enter}");
 
     cy.get("h1").contains("Dashboard | env").should("be.visible");
 
@@ -181,7 +181,7 @@ if (localAuth) {
     cy.visit("/console/");
 
     cy.get('[id="pf-login-username-id"]').type("admin");
-    cy.get('[id="pf-login-password-id"]').type("adminadmin{enter}");
+    cy.get('[id="pf-login-password-id"]').type("Str0ng-Pass!{enter}");
 
     cy.get("h1").contains("Dashboard | env").should("be.visible");
 
@@ -200,7 +200,7 @@ if (localAuth) {
 
     // admin is the logged-in user, so this is a self-service change: the current password is required
     // and the submit button stays disabled until it is filled (PR #7071).
-    cy.get('[aria-label="current-password-input"]').type("adminadmin");
+    cy.get('[aria-label="current-password-input"]').type("Str0ng-Pass!");
 
     cy.get('[aria-label="new-password-input"]').type("123");
 


### PR DESCRIPTION
## Problem

The `dashboard/frontend-local-auth` Cypress e2e job (`cypress/e2e/LocalAuth/scenario-7.3-user-management.cy.js`) went red after two changes landed together:
- **inmanta/inmanta-core#10537** hardened the password policy to **at least 12 characters and 3 character classes** (was 8).
- **#7071** made a self-service password change require the **Current Password**.

The spec still asserted the `8 characters` message and used 8-character passwords, and the change-password test (which targets `admin`, the logged-in user) never filled the new Current Password field, so submit stayed disabled.

## Fix

- add-user: expected message `8` -> `12`, and use a policy-compliant password.
- change-password: fill the `current-password-input` (self-service, #7071), expected message `8` -> `12`, use a compliant new password, and re-login with it.

## Companion change (must merge first)

The role-user seeding lives in **local-setup** (`create_users_and_roles.py`), which seeds 5 role-users with `"password"` - now rejected by the 12-char policy, so only `admin` would exist and the 6-user baseline collapses. That is fixed in a separate local-setup MR. Since `setup-auth.sh` clones **local-setup master** at runtime, that MR must merge before this job goes green.

## Verified

Against a live 12-char orchestrator: the fixed seeding creates all 6 users; `password` is rejected with exactly `the password should be at least 12 characters long`; `Str0ng-Pass!` is accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)