### PR TITLE
Stabilize flaky IncludeExcludeSelect unit test

### DIFF
--- a/changelogs/unreleased/fix-flaky-include-exclude-select.yml
+++ b/changelogs/unreleased/fix-flaky-include-exclude-select.yml
@@ -1,0 +1,3 @@
+description: Stabilize the flaky IncludeExcludeSelect unit test (wait for the dropdown to open before asserting visibility).
+change-type: patch
+destination-branches: [master, iso9]

--- a/src/UI/Components/IncludeExcludeSelect/IncludeExcludeSelect.test.tsx
+++ b/src/UI/Components/IncludeExcludeSelect/IncludeExcludeSelect.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { invertFilter } from "@/Core";
@@ -37,10 +37,14 @@ describe("IncludeExcludeSelect", () => {
       const toggle = screen.getByRole("button", { name: `${label}-toggle` });
       await userEvent.click(toggle);
 
-      expect(screen.getByRole("grid")).toBeVisible();
-      expect(screen.getByText("blocked")).toBeVisible();
-      expect(screen.getByText("not_blocked")).toBeVisible();
-      expect(screen.getByText("temporarily_blocked")).toBeVisible();
+      // The PatternFly Select menu opens asynchronously, so wait for it to
+      // settle before asserting visibility instead of checking synchronously.
+      await waitFor(() => {
+        expect(screen.getByRole("grid")).toBeVisible();
+        expect(screen.getByText("blocked")).toBeVisible();
+        expect(screen.getByText("not_blocked")).toBeVisible();
+        expect(screen.getByText("temporarily_blocked")).toBeVisible();
+      });
     });
 
     it("closes the dropdown when the toggle is clicked again", async () => {
@@ -50,7 +54,9 @@ describe("IncludeExcludeSelect", () => {
       await userEvent.click(toggle);
       await userEvent.click(toggle);
 
-      expect(screen.queryByRole("grid")).not.toBeInTheDocument();
+      await waitFor(() => {
+        expect(screen.queryByRole("grid")).not.toBeInTheDocument();
+      });
     });
   });
 
@@ -61,7 +67,7 @@ describe("IncludeExcludeSelect", () => {
 
       const toggle = screen.getByRole("button", { name: `${label}-toggle` });
       await userEvent.click(toggle);
-      const menuToggle = screen.getByRole("button", { name: "blocked-include-toggle" });
+      const menuToggle = await screen.findByRole("button", { name: "blocked-include-toggle" });
       await userEvent.click(menuToggle);
 
       expect(onOptionClick).toHaveBeenCalledWith("blocked");
@@ -74,7 +80,7 @@ describe("IncludeExcludeSelect", () => {
       const toggle = screen.getByRole("button", { name: `${label}-toggle` });
       await userEvent.click(toggle);
 
-      expect(screen.getByLabelText("blocked-include-active")).toBeInTheDocument();
+      expect(await screen.findByLabelText("blocked-include-active")).toBeInTheDocument();
       expect(screen.getByLabelText("not_blocked-include-inactive")).toBeInTheDocument();
     });
   });
@@ -86,7 +92,7 @@ describe("IncludeExcludeSelect", () => {
 
       const toggle = screen.getByRole("button", { name: `${label}-toggle` });
       await userEvent.click(toggle);
-      await userEvent.click(screen.getByRole("button", { name: "blocked-exclude-toggle" }));
+      await userEvent.click(await screen.findByRole("button", { name: "blocked-exclude-toggle" }));
 
       expect(onOptionClick).toHaveBeenCalledWith(invertFilter("blocked"));
       expect(onOptionClick).toHaveBeenCalledTimes(1);
@@ -98,7 +104,7 @@ describe("IncludeExcludeSelect", () => {
       const toggle = screen.getByRole("button", { name: `${label}-toggle` });
       await userEvent.click(toggle);
 
-      expect(screen.getByLabelText("blocked-exclude-active")).toBeInTheDocument();
+      expect(await screen.findByLabelText("blocked-exclude-active")).toBeInTheDocument();
       expect(screen.getByLabelText("blocked-include-inactive")).toBeInTheDocument();
     });
   });
@@ -115,7 +121,7 @@ describe("IncludeExcludeSelect", () => {
       const toggle = screen.getByRole("button", { name: `${label}-toggle` });
       await userEvent.click(toggle);
 
-      expect(screen.getByLabelText("blocked-include-active")).toBeInTheDocument();
+      expect(await screen.findByLabelText("blocked-include-active")).toBeInTheDocument();
       expect(screen.getByLabelText("not_blocked-exclude-active")).toBeInTheDocument();
       expect(screen.getByLabelText("temporarily_blocked-include-inactive")).toBeInTheDocument();
       expect(screen.getByLabelText("temporarily_blocked-exclude-inactive")).toBeInTheDocument();


### PR DESCRIPTION
> Note: This PR is opened by Claude on behalf of Bart.

# Description

- Test-only de-flake of `IncludeExcludeSelect.test.tsx`. No component change.

The tests click the PatternFly `Select` toggle and then asserted synchronously that the menu (`role="grid"`) and its options were visible/present. The PatternFly v6 `Select` menu opens asynchronously, so the assertion could run before the menu had settled, producing an intermittent `expect(element).toBeVisible()` failure in CI (same class of flake as the earlier `DesiredStateCompare` test).

The `IncludeExcludeSelect` component is unchanged and works correctly; only the assertions were made resilient to the menu-open timing:

- Wrap the open/close visibility assertions in `waitFor(...)` so they retry until the menu settles.
- Use `findByRole` / `findByLabelText` for elements that appear after the menu opens, instead of the synchronous `getBy*` variants.

The test intent is identical.

Verification: ran the single file 15x in a loop, all 15 runs passed (9 tests each). `yarn lint` and `prettier --check` on the changed file are clean.

closes ~~_Add ticket reference here_~~ (no ticket; flaky-test fix)

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Code is clear and sufficiently documented
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

🤖 Generated with [Claude Code](https://claude.com/claude-code)