### PR TITLE
Default the create-token form to a revocable token

### DIFF
--- a/changelogs/unreleased/default-revocable-token.yml
+++ b/changelogs/unreleased/default-revocable-token.yml
@@ -1,0 +1,4 @@
+description: Default the create-token form in the Settings page to a revocable token
+issue-nr: 7102
+change-type: minor
+destination-branches: [master, iso9]

--- a/src/Slices/Settings/UI/Tabs/Token/Tab.test.tsx
+++ b/src/Slices/Settings/UI/Tabs/Token/Tab.test.tsx
@@ -90,7 +90,7 @@ describe("Token Tab", () => {
     });
   });
 
-  test("GIVEN the revocable checkbox is checked WHEN generate is clicked THEN idempotent is false", async () => {
+  test("GIVEN the default form (revocable checked) WHEN generate is clicked THEN idempotent is false", async () => {
     let requestBody: Record<string, unknown> | null = null;
     server.use(
       http.post("/api/v2/environment_auth", async ({ request }) => {
@@ -104,7 +104,7 @@ describe("Token Tab", () => {
 
     render(component);
 
-    await userEvent.click(screen.getByRole("checkbox", { name: "RevocableOption" }));
+    expect(screen.getByRole("checkbox", { name: "RevocableOption" })).toBeChecked();
     await userEvent.click(
       screen.getByRole("button", { name: words("settings.tabs.token.generate") })
     );
@@ -126,6 +126,7 @@ describe("Token Tab", () => {
 
     render(component);
 
+    await userEvent.click(screen.getByRole("checkbox", { name: "RevocableOption" }));
     await userEvent.click(
       screen.getByRole("button", { name: words("settings.tabs.token.generate") })
     );

--- a/src/Slices/Settings/UI/Tabs/Token/Tab.tsx
+++ b/src/Slices/Settings/UI/Tabs/Token/Tab.tsx
@@ -18,7 +18,7 @@ import { TokenTable } from "./TokenTable";
 export const Tab: React.FC = () => {
   const client = useQueryClient();
   const [clientTypes, setClientTypes] = useState<ClientType[]>([]);
-  const [isRevocable, setIsRevocable] = useState(false);
+  const [isRevocable, setIsRevocable] = useState(true);
   const [isBusy, setIsBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [token, setToken] = useState<string | null>(null);


### PR DESCRIPTION
# Description

Claude here, on behalf of @bartv.

Follow-up to the token registry work, from the demo-session feedback: the revocable checkbox in the Settings > Token form now starts checked, so newly generated tokens are registered and can be revoked unless the user explicitly opts out. The form always sends `idempotent` explicitly, so this is independent of the server-side default flip (inmanta/inmanta-core#10577).

closes #7102

🤖 Generated with [Claude Code](https://claude.com/claude-code)