### PR TITLE
Make deploying spinner label toggle the isDeploying filter

### DIFF
--- a/changelogs/unreleased/6993-deploying-filter.yml
+++ b/changelogs/unreleased/6993-deploying-filter.yml
@@ -1,0 +1,6 @@
+description: The deploying spinner label on the Resources page is now clickable when resources are deploying, toggling the isDeploying filter on and off.
+issue-nr: 6993
+change-type: minor
+destination-branches: [master, iso9]
+sections:
+  minor-improvement: "{{description}}"

--- a/src/Slices/Resource/UI/ResourcesPage/Page.test.tsx
+++ b/src/Slices/Resource/UI/ResourcesPage/Page.test.tsx
@@ -30,6 +30,7 @@ interface GqlVariables {
     agent?: { contains?: string[] };
     resourceIdValue?: { contains?: string[] };
     isOrphan?: boolean;
+    isDeploying?: boolean;
   };
   first?: number;
   after?: string;
@@ -715,6 +716,59 @@ describe("ResourcesPage", () => {
     const label = screen.getByTestId("deploying-label");
 
     expect(label).toHaveTextContent("3");
+  });
+
+  test("clicking the deploying label toggles the isDeploying filter on and off", async () => {
+    let lastVariables: GqlVariables | undefined;
+
+    server.use(
+      queryLink.query("GetResources", ({ variables }: { variables: GqlVariables }) => {
+        lastVariables = variables;
+
+        return HttpResponse.json({
+          data: toGqlResponse({
+            ...BASE_DATA,
+            resourceSummary: createMockResourceSummary({ isDeploying: { true: 3, false: 3 } }),
+          }),
+        });
+      })
+    );
+
+    const { component } = setup();
+
+    render(component);
+
+    await screen.findByRole("grid", { name: "ResourcesPage-Success" });
+
+    // First click adds the isDeploying filter
+    await userEvent.click(within(screen.getByTestId("deploying-label")).getByRole("button"));
+    await waitFor(() => expect(lastVariables?.filter?.isDeploying).toBe(true));
+
+    // Second click removes it again
+    await userEvent.click(within(screen.getByTestId("deploying-label")).getByRole("button"));
+    await waitFor(() => expect(lastVariables?.filter?.isDeploying).toBeUndefined());
+  });
+
+  test("deploying label is not clickable when nothing is deploying", async () => {
+    server.use(
+      queryLink.query("GetResources", () =>
+        HttpResponse.json({
+          data: toGqlResponse({
+            ...BASE_DATA,
+            resourceSummary: createMockResourceSummary({ isDeploying: { true: 0, false: 6 } }),
+          }),
+        })
+      )
+    );
+
+    const { component } = setup();
+
+    render(component);
+
+    await screen.findByRole("grid", { name: "ResourcesPage-Success" });
+
+    // Without an onClick, PatternFly renders the label as plain content, not a button
+    expect(within(screen.getByTestId("deploying-label")).queryByRole("button")).not.toBeInTheDocument();
   });
 
   test("toolbar stays visible and updates after navigating to next page", async () => {

--- a/src/Slices/Resource/UI/ResourcesPage/Page.test.tsx
+++ b/src/Slices/Resource/UI/ResourcesPage/Page.test.tsx
@@ -768,7 +768,9 @@ describe("ResourcesPage", () => {
     await screen.findByRole("grid", { name: "ResourcesPage-Success" });
 
     // Without an onClick, PatternFly renders the label as plain content, not a button
-    expect(within(screen.getByTestId("deploying-label")).queryByRole("button")).not.toBeInTheDocument();
+    expect(
+      within(screen.getByTestId("deploying-label")).queryByRole("button")
+    ).not.toBeInTheDocument();
   });
 
   test("toolbar stays visible and updates after navigating to next page", async () => {

--- a/src/Slices/Resource/UI/ResourcesPage/Page.tsx
+++ b/src/Slices/Resource/UI/ResourcesPage/Page.tsx
@@ -71,6 +71,18 @@ export const Page: React.FC = () => {
   const updateFilter = (updater: (filter: Resource.Filter) => Resource.Filter): void =>
     setFilter(updater(filterWithDefaults));
 
+  const onDeployingClick = (): void => {
+    updateFilter((filter) => {
+      const current = filter.status ?? [];
+
+      if (current.includes("isDeploying")) {
+        return { ...filter, status: current.filter((status) => status !== "isDeploying") };
+      }
+
+      return { ...filter, status: [...current, "isDeploying"] };
+    });
+  };
+
   const rows = useMemo(() => createRows(data?.resources ?? []), [data?.resources]);
 
   if (isError) {
@@ -111,6 +123,7 @@ export const Page: React.FC = () => {
                 variant="outline"
                 color="blue"
                 data-testid="deploying-label"
+                onClick={deployingCount > 0 ? onDeployingClick : undefined}
               >
                 <span style={{ display: "inline-flex", alignItems: "center", gap: "2px" }}>
                   {deployingCount > 0 && (

--- a/src/UI/words.tsx
+++ b/src/UI/words.tsx
@@ -557,7 +557,9 @@ const dict = {
   "resources.empty.filterMessage":
     "The given combination of filters didn't match any existing resources, please edit your filter values.",
   "resources.deploying.popover": (count: number) =>
-    `${count} ${count === 1 ? "resource is" : "resources are"} currently deploying`,
+    `${count} ${count === 1 ? "resource is" : "resources are"} currently deploying${
+      count > 0 ? ", click to filter" : ""
+    }`,
   "resources.discovery.disabled":
     "Your licence doesn't give you access to the Resource Discovery Feature, please contact support for more details.",
   "discoveredResourceDetails.title": "Discovered Resource Details",


### PR DESCRIPTION
# Description

Made the resources deploying spinner/tag clickable as a button whenever there is at least 1 resource deploying.
This will add the isDeploying filter then as a sort of quick filter button.
Clicking it again will remove the fillter.

closes https://github.com/inmanta/web-console/issues/6993

<img width="312" height="115" alt="Screenshot 2026-07-13 at 11 54 31" src="https://github.com/user-attachments/assets/adf46631-c336-4471-9142-a94a29322685" />
