### PR TITLE
Fix flaky version-row click in basic-service e2e scenario

### DIFF
--- a/changelogs/unreleased/fix-flaky-version-row-click-e2e.yml
+++ b/changelogs/unreleased/fix-flaky-version-row-click-e2e.yml
@@ -1,0 +1,3 @@
+description: Stabilize the flaky version selection in the basic-service e2e scenario (click the version cell directly instead of double-triggering a raw click on the row).
+change-type: patch
+destination-branches: [master, iso9, iso8]

--- a/cypress/e2e/scenario-2.1-basic-service.cy.js
+++ b/cypress/e2e/scenario-2.1-basic-service.cy.js
@@ -129,9 +129,9 @@ if (isIso) {
       cy.get('[aria-label="History-Row"]').eq(0).should("contain", "up");
 
       // Selecting a version in the table should change the tags in the heading of the page.
-      cy.get('[id="version-2"]').trigger("click");
-      cy.wait(1000);
-      cy.get('[id="version-2"]').trigger("click");
+      cy.get('[id="version-2"]').within(() => {
+        cy.get('[data-label="version"]').click();
+      });
 
       cy.get('[data-testid="selected-version"]', { timeout: 30000 }).should(
         "have.text",


### PR DESCRIPTION
# Description

There was a small flake I noticed the past week:
`Timed out retrying after 30000ms: Expected to find element: [data-testid="selected-version"], but never found it.`

I believe the selection sometimes was somewhat off so I made it more consistent now.

