### PR TITLE
resolve demo feedback

### DIFF
--- a/changelogs/unreleased/demo-fixes.yml
+++ b/changelogs/unreleased/demo-fixes.yml
@@ -1,0 +1,8 @@
+description: | 
+  - Default the create-token form in the Settings page to a revocable token
+    - Don't allow the user to make a non-revocable token in the web-console.
+  - Default the create-token form in the Settings page to a 7-day expiry
+  - Use proper date formatting, consitent with the rest of the web-console for the token table.
+  - Use service_identity_attribute_value for the service instance in the order details rows.
+change-type: minor
+destination-branches: [master, iso9]

--- a/src/Slices/OrderDetails/UI/OrderDependencies.test.tsx
+++ b/src/Slices/OrderDetails/UI/OrderDependencies.test.tsx
@@ -32,7 +32,21 @@ test("GIVEN OrderDependencies WHEN the matching order item has no service identi
   expect(screen.getByText(dependencyItem.instance_id)).toBeVisible();
 });
 
-test("GIVEN OrderDependencies WHEN the matching order item has a service_identity_display_name THEN it is shown instead of the raw instance_id", () => {
+test("GIVEN OrderDependencies WHEN the matching order item has a service_identity_attribute_value THEN it is shown instead of the raw instance_id", () => {
+  const item: ServiceOrderItem = {
+    ...dependencyItem,
+    status: { ...dependencyItem.status, service_identity_attribute_value: "attribute-value" },
+  };
+
+  render(
+    <OrderDependencies dependencies={{ [item.instance_id]: "completed" }} orderItems={[item]} />
+  );
+
+  expect(screen.getByText("attribute-value")).toBeVisible();
+  expect(screen.queryByText(item.instance_id)).not.toBeInTheDocument();
+});
+
+test("GIVEN OrderDependencies WHEN the matching order item only has a service_identity_display_name THEN the raw instance_id is shown, not the display name (regression)", () => {
   const item: ServiceOrderItem = {
     ...dependencyItem,
     status: { ...dependencyItem.status, service_identity_display_name: "Parent 1" },
@@ -42,8 +56,8 @@ test("GIVEN OrderDependencies WHEN the matching order item has a service_identit
     <OrderDependencies dependencies={{ [item.instance_id]: "completed" }} orderItems={[item]} />
   );
 
-  expect(screen.getByText("Parent 1")).toBeVisible();
-  expect(screen.queryByText(item.instance_id)).not.toBeInTheDocument();
+  expect(screen.getByText(item.instance_id)).toBeVisible();
+  expect(screen.queryByText("Parent 1")).not.toBeInTheDocument();
 });
 
 test("GIVEN OrderDependencies WHEN no order item matches the dependency's instance_id THEN the raw instance_id is shown", () => {
@@ -54,10 +68,10 @@ test("GIVEN OrderDependencies WHEN no order item matches the dependency's instan
   expect(screen.getByText("unknown-instance-id")).toBeVisible();
 });
 
-test("GIVEN OrderDependencies WHEN a display name is set THEN copy to clipboard offers both the display name and the raw instance_id", async () => {
+test("GIVEN OrderDependencies WHEN an attribute value is set THEN copy to clipboard offers both the attribute value and the raw instance_id", async () => {
   const item: ServiceOrderItem = {
     ...dependencyItem,
-    status: { ...dependencyItem.status, service_identity_display_name: "Parent 1" },
+    status: { ...dependencyItem.status, service_identity_attribute_value: "attribute-value" },
   };
 
   render(
@@ -66,6 +80,6 @@ test("GIVEN OrderDependencies WHEN a display name is set THEN copy to clipboard 
 
   await userEvent.click(screen.getByRole("button", { name: "Copy to clipboard" }));
 
-  expect(await screen.findByRole("menuitem", { name: "Parent 1" })).toBeVisible();
+  expect(await screen.findByRole("menuitem", { name: "attribute-value" })).toBeVisible();
   expect(await screen.findByRole("menuitem", { name: item.instance_id })).toBeVisible();
 });

--- a/src/Slices/OrderDetails/UI/OrderDependencies.tsx
+++ b/src/Slices/OrderDetails/UI/OrderDependencies.tsx
@@ -21,13 +21,13 @@ interface Props {
  *
  * Dependencies contain the ID of the instance and their matching status.
  * The instance_id only refers to an instance being part of the Order, so the matching
- * service_order_item is looked up in orderItems to resolve its display name, same as
+ * service_order_item is looked up in orderItems to resolve its attribute value, same as
  * the OrderInstanceLink cell.
  *
  * Clicking a dependency row expands and focuses the matching row in the order details table.
  *
  * @param dependencies ServiceOrderItemDependencies
- * @param orderItems all service_order_items of the order, used to resolve the display name of each dependency
+ * @param orderItems all service_order_items of the order, used to resolve the attribute value of each dependency
  * @param expandInstanceOrderDetailsRow callback invoked with the instanceId of the clicked dependency
  * @returns ReactNode
  */

--- a/src/Slices/OrderDetails/UI/OrderDetailsRow.tsx
+++ b/src/Slices/OrderDetails/UI/OrderDetailsRow.tsx
@@ -62,7 +62,7 @@ export const OrderDetailsRow: React.FC<Props> = ({
         <Td>
           <Toggle expanded={isExpanded} onToggle={onToggle} aria-label={"Toggle-DetailsRow"} />
         </Td>
-        <Td width={35} dataLabel={words("orders.column.instanceId")}>
+        <Td width={35} dataLabel={words("orders.column.instance")}>
           <OrderInstanceLink row={row} />
         </Td>
         <Td width={25} dataLabel={words("orders.column.serviceEntity")}>

--- a/src/Slices/OrderDetails/UI/OrderDetailsTablePresenter.test.ts
+++ b/src/Slices/OrderDetails/UI/OrderDetailsTablePresenter.test.ts
@@ -10,14 +10,14 @@ test("Rows should have two items", () => {
 });
 
 test("TablePresenter converts column index to name correctly", () => {
-  expect(presenter.getColumnNameForIndex(0)).toEqual("instance_id");
+  expect(presenter.getColumnNameForIndex(0)).toEqual("instance");
   expect(presenter.getColumnNameForIndex(1)).toEqual("service_entity");
   expect(presenter.getColumnNameForIndex(-1)).toBeUndefined();
   expect(presenter.getColumnNameForIndex(10)).toBeUndefined();
 });
 
 test("TablePresenter converts column name to index correctly", () => {
-  expect(presenter.getIndexForColumnName("instance_id")).toEqual(0);
+  expect(presenter.getIndexForColumnName("instance")).toEqual(0);
   expect(presenter.getIndexForColumnName("service_entity")).toEqual(1);
   expect(presenter.getIndexForColumnName(undefined)).toEqual(-1);
 });

--- a/src/Slices/OrderDetails/UI/OrderDetailsTablePresenter.ts
+++ b/src/Slices/OrderDetails/UI/OrderDetailsTablePresenter.ts
@@ -19,8 +19,8 @@ export class OrderDetailsTablePresenter implements TablePresenter<
   constructor() {
     this.columnHeads = [
       {
-        displayName: words("orders.column.instanceId"),
-        apiName: "instance_id",
+        displayName: words("orders.column.instance"),
+        apiName: "instance",
       },
       {
         displayName: words("orders.column.serviceEntity"),

--- a/src/Slices/OrderDetails/UI/OrderInstanceLink.test.tsx
+++ b/src/Slices/OrderDetails/UI/OrderInstanceLink.test.tsx
@@ -39,7 +39,7 @@ test("GIVEN OrderInstanceLink WHEN no service identity is set THEN the raw insta
   expect(screen.getByRole("button", { name: baseRow.instance_id })).toBeVisible();
 });
 
-test("GIVEN OrderInstanceLink WHEN service_identity_display_name is set THEN it is shown instead of the raw instance_id", () => {
+test("GIVEN OrderInstanceLink WHEN only service_identity_display_name is set THEN the raw instance_id is shown, not the display name (regression)", () => {
   const row: ServiceOrderItem = {
     ...baseRow,
     status: { ...baseRow.status, service_identity_display_name: "Parent 1" },
@@ -47,8 +47,8 @@ test("GIVEN OrderInstanceLink WHEN service_identity_display_name is set THEN it 
 
   render(setup(row));
 
-  expect(screen.getByRole("button", { name: "Parent 1" })).toBeVisible();
-  expect(screen.queryByText(row.instance_id)).not.toBeInTheDocument();
+  expect(screen.getByRole("button", { name: row.instance_id })).toBeVisible();
+  expect(screen.queryByText("Parent 1")).not.toBeInTheDocument();
 });
 
 test("GIVEN OrderInstanceLink WHEN only service_identity_attribute_value is set THEN it is shown instead of the raw instance_id", () => {
@@ -62,7 +62,7 @@ test("GIVEN OrderInstanceLink WHEN only service_identity_attribute_value is set 
   expect(screen.getByRole("button", { name: "attribute-value" })).toBeVisible();
 });
 
-test("GIVEN OrderInstanceLink WHEN both service_identity_display_name and service_identity_attribute_value are set THEN the display name takes priority", () => {
+test("GIVEN OrderInstanceLink WHEN both service_identity_display_name and service_identity_attribute_value are set THEN the attribute value is used, not the display name", () => {
   const row: ServiceOrderItem = {
     ...baseRow,
     status: {
@@ -74,37 +74,37 @@ test("GIVEN OrderInstanceLink WHEN both service_identity_display_name and servic
 
   render(setup(row));
 
-  expect(screen.getByRole("button", { name: "Display Name" })).toBeVisible();
-  expect(screen.queryByText("attribute-value")).not.toBeInTheDocument();
+  expect(screen.getByRole("button", { name: "attribute-value" })).toBeVisible();
+  expect(screen.queryByText("Display Name")).not.toBeInTheDocument();
 });
 
-test("GIVEN OrderInstanceLink WHEN a create order item failed before the instance was created THEN the display name is shown as plain text with a warning icon, not a link", () => {
+test("GIVEN OrderInstanceLink WHEN a create order item failed before the instance was created THEN the attribute value is shown as plain text with a warning icon, not a link", () => {
   const row: ServiceOrderItem = {
     ...baseRow,
     action: "create",
     status: {
       ...baseRow.status,
       failure_type: "INVALID_ORDER_ITEM",
-      service_identity_display_name: "Parent 1",
+      service_identity_attribute_value: "attribute-value",
     },
   };
 
   render(setup(row));
 
-  expect(screen.queryByRole("button", { name: "Parent 1" })).not.toBeInTheDocument();
-  expect(screen.getByText("Parent 1")).toBeVisible();
+  expect(screen.queryByRole("button", { name: "attribute-value" })).not.toBeInTheDocument();
+  expect(screen.getByText("attribute-value")).toBeVisible();
 });
 
-test("GIVEN OrderInstanceLink WHEN a display name is set THEN copy to clipboard offers both the display name and the raw instance_id", async () => {
+test("GIVEN OrderInstanceLink WHEN an attribute value is set THEN copy to clipboard offers both the attribute value and the raw instance_id", async () => {
   const row: ServiceOrderItem = {
     ...baseRow,
-    status: { ...baseRow.status, service_identity_display_name: "Parent 1" },
+    status: { ...baseRow.status, service_identity_attribute_value: "attribute-value" },
   };
 
   render(setup(row));
 
   await userEvent.click(screen.getByRole("button", { name: "Copy to clipboard" }));
 
-  expect(await screen.findByRole("menuitem", { name: "Parent 1" })).toBeVisible();
+  expect(await screen.findByRole("menuitem", { name: "attribute-value" })).toBeVisible();
   expect(await screen.findByRole("menuitem", { name: row.instance_id })).toBeVisible();
 });

--- a/src/Slices/OrderDetails/UI/OrderInstanceLink.tsx
+++ b/src/Slices/OrderDetails/UI/OrderInstanceLink.tsx
@@ -15,7 +15,7 @@ interface Props {
 
 /**
  * Displays the instance_id of a service_order_item, or its service identity
- * display name/attribute value when the status provides one, same as the Instance rows
+ * attribute value when the status provides one, same as the Instance rows
  * on the Service Inventory table.
  *
  * Navigates to the instance details page when clicked. If the order item is a create action

--- a/src/Slices/OrderDetails/UI/getInstanceDisplayName.test.ts
+++ b/src/Slices/OrderDetails/UI/getInstanceDisplayName.test.ts
@@ -1,0 +1,58 @@
+import { ServiceOrderItem } from "@/Slices/Orders/Core/Types";
+import { getInstanceDisplayName } from "./getInstanceDisplayName";
+
+const baseRow: ServiceOrderItem = {
+  instance_id: "3fa85f64-5717-4562-b3fc-2c963f66afa",
+  service_entity: "basic-service",
+  config: {},
+  action: "create",
+  status: {
+    state: "completed",
+    failure_type: null,
+    reason: null,
+    direct_dependencies: {},
+    validation_compile_id: null,
+    instance_state_label: null,
+    service_identity_attribute_value: null,
+    service_identity_display_name: null,
+  },
+};
+
+test("GIVEN getInstanceDisplayName WHEN row is undefined THEN it returns null", () => {
+  expect(getInstanceDisplayName(undefined)).toBeNull();
+});
+
+test("GIVEN getInstanceDisplayName WHEN neither service identity field is set THEN it returns null", () => {
+  expect(getInstanceDisplayName(baseRow)).toBeNull();
+});
+
+test("GIVEN getInstanceDisplayName WHEN service_identity_attribute_value is set THEN it returns the attribute value", () => {
+  const row: ServiceOrderItem = {
+    ...baseRow,
+    status: { ...baseRow.status, service_identity_attribute_value: "attribute-value" },
+  };
+
+  expect(getInstanceDisplayName(row)).toBe("attribute-value");
+});
+
+test("GIVEN getInstanceDisplayName WHEN only service_identity_display_name is set THEN it returns null, not the display name (regression)", () => {
+  const row: ServiceOrderItem = {
+    ...baseRow,
+    status: { ...baseRow.status, service_identity_display_name: "Parent 1" },
+  };
+
+  expect(getInstanceDisplayName(row)).toBeNull();
+});
+
+test("GIVEN getInstanceDisplayName WHEN both service_identity_display_name and service_identity_attribute_value are set THEN it returns the attribute value, not the display name (regression)", () => {
+  const row: ServiceOrderItem = {
+    ...baseRow,
+    status: {
+      ...baseRow.status,
+      service_identity_display_name: "Display Name",
+      service_identity_attribute_value: "attribute-value",
+    },
+  };
+
+  expect(getInstanceDisplayName(row)).toBe("attribute-value");
+});

--- a/src/Slices/OrderDetails/UI/getInstanceDisplayName.ts
+++ b/src/Slices/OrderDetails/UI/getInstanceDisplayName.ts
@@ -9,5 +9,5 @@ export function getInstanceDisplayName(row: ServiceOrderItem | undefined): strin
     return null;
   }
 
-  return row.status.service_identity_display_name || row.status.service_identity_attribute_value;
+  return row.status.service_identity_attribute_value;
 }

--- a/src/Slices/Settings/UI/Tabs/Token/ExpiryInput.tsx
+++ b/src/Slices/Settings/UI/Tabs/Token/ExpiryInput.tsx
@@ -11,19 +11,28 @@ import {
 import styled from "styled-components";
 import { words } from "@/UI/words";
 
-// Preset token lifetimes in seconds; the empty default means no explicit expiry.
+const ONE_MINUTE_SECONDS = 60;
+const ONE_HOUR_SECONDS = 60 * ONE_MINUTE_SECONDS;
+const ONE_DAY_SECONDS = 24 * ONE_HOUR_SECONDS;
+const THIRTY_DAYS_SECONDS = 30 * ONE_DAY_SECONDS;
+const ONE_YEAR_SECONDS = 365 * ONE_DAY_SECONDS;
+
+// The default preselected lifetime for newly created tokens.
+export const DEFAULT_EXPIRY_SECONDS = 7 * ONE_DAY_SECONDS;
+
+// Preset token lifetimes in seconds; the empty option means no explicit expiry.
 const EXPIRY_OPTIONS: { seconds: number; label: string }[] = [
-  { seconds: 3600, label: "1 hour" },
-  { seconds: 86400, label: "1 day" },
-  { seconds: 604800, label: "7 days" },
-  { seconds: 2592000, label: "30 days" },
-  { seconds: 31536000, label: "1 year" },
+  { seconds: ONE_HOUR_SECONDS, label: "1 hour" },
+  { seconds: ONE_DAY_SECONDS, label: "1 day" },
+  { seconds: DEFAULT_EXPIRY_SECONDS, label: "7 days" },
+  { seconds: THIRTY_DAYS_SECONDS, label: "30 days" },
+  { seconds: ONE_YEAR_SECONDS, label: "1 year" },
 ];
 
 const CUSTOM_UNITS: { unit: string; seconds: number }[] = [
-  { unit: "minutes", seconds: 60 },
-  { unit: "hours", seconds: 3600 },
-  { unit: "days", seconds: 86400 },
+  { unit: "minutes", seconds: ONE_MINUTE_SECONDS },
+  { unit: "hours", seconds: ONE_HOUR_SECONDS },
+  { unit: "days", seconds: ONE_DAY_SECONDS },
 ];
 
 interface Props {
@@ -38,7 +47,7 @@ interface Props {
  * @returns {React.FC<Props>} The expiry input.
  */
 export const ExpiryInput: React.FC<Props> = ({ onChange, isDisabled }) => {
-  const [choice, setChoice] = useState("");
+  const [choice, setChoice] = useState(String(DEFAULT_EXPIRY_SECONDS));
   const [customAmount, setCustomAmount] = useState("");
   const [customUnit, setCustomUnit] = useState("days");
 

--- a/src/Slices/Settings/UI/Tabs/Token/Tab.test.tsx
+++ b/src/Slices/Settings/UI/Tabs/Token/Tab.test.tsx
@@ -7,6 +7,7 @@ import { setupServer } from "msw/node";
 import { MockedDependencyProvider } from "@/Test";
 import { testClient } from "@/Test/Utils/react-query-setup";
 import { words } from "@/UI";
+import { DEFAULT_EXPIRY_SECONDS } from "./ExpiryInput";
 import { Tab } from "./Tab";
 
 function setup() {
@@ -97,7 +98,7 @@ describe("Token Tab", () => {
     await waitFor(() => expect(requestBody).toMatchObject({ client_types: ["agent"] }));
   });
 
-  test("GIVEN the default form (revocable checked) WHEN generate is clicked THEN idempotent is false", async () => {
+  test("GIVEN the default form WHEN generate is clicked THEN idempotent is false", async () => {
     let requestBody: Record<string, unknown> | null = null;
     server.use(
       http.post("/api/v2/environment_auth", async ({ request }) => {
@@ -111,15 +112,20 @@ describe("Token Tab", () => {
 
     render(component);
 
-    expect(screen.getByRole("switch", { name: "RevocableOption" })).toBeChecked();
     await userEvent.click(
       screen.getByRole("button", { name: words("settings.tabs.token.generate") })
     );
 
-    await waitFor(() => expect(requestBody).toEqual({ client_types: ["api"], idempotent: false }));
+    await waitFor(() =>
+      expect(requestBody).toEqual({
+        client_types: ["api"],
+        idempotent: false,
+        expire: DEFAULT_EXPIRY_SECONDS,
+      })
+    );
   });
 
-  test("GIVEN the revocable switch is unchecked WHEN generate is clicked THEN idempotent is true", async () => {
+  test("GIVEN a token with an expiry WHEN generate is clicked THEN expire is sent", async () => {
     let requestBody: Record<string, unknown> | null = null;
     server.use(
       http.post("/api/v2/environment_auth", async ({ request }) => {
@@ -132,34 +138,6 @@ describe("Token Tab", () => {
     const { component } = setup();
 
     render(component);
-
-    await userEvent.click(screen.getByRole("switch", { name: "RevocableOption" }));
-    await userEvent.click(
-      screen.getByRole("button", { name: words("settings.tabs.token.generate") })
-    );
-
-    await waitFor(() => expect(requestBody).toEqual({ client_types: ["api"], idempotent: true }));
-  });
-
-  test("GIVEN a revocable token with an expiry WHEN generate is clicked THEN expire is sent", async () => {
-    let requestBody: Record<string, unknown> | null = null;
-    server.use(
-      http.post("/api/v2/environment_auth", async ({ request }) => {
-        requestBody = (await request.json()) as Record<string, unknown>;
-
-        return HttpResponse.json({ data: "tokenstring123" });
-      })
-    );
-
-    const { component } = setup();
-
-    render(component);
-
-    // Make the revocable state explicit so this test is independent of the form's default.
-    const revocable: HTMLInputElement = screen.getByRole("switch", { name: "RevocableOption" });
-    if (!revocable.checked) {
-      await userEvent.click(revocable);
-    }
 
     await userEvent.selectOptions(
       screen.getByRole("combobox", { name: words("settings.tabs.token.expiry") }),
@@ -187,12 +165,6 @@ describe("Token Tab", () => {
     const { component } = setup();
 
     render(component);
-
-    // Make the revocable state explicit so this test is independent of the form's default.
-    const revocable: HTMLInputElement = screen.getByRole("switch", { name: "RevocableOption" });
-    if (!revocable.checked) {
-      await userEvent.click(revocable);
-    }
 
     await userEvent.selectOptions(
       screen.getByRole("combobox", { name: words("settings.tabs.token.expiry") }),
@@ -226,12 +198,6 @@ describe("Token Tab", () => {
 
     render(component);
 
-    // Make the revocable state explicit so this test is independent of the form's default.
-    const revocable: HTMLInputElement = screen.getByRole("switch", { name: "RevocableOption" });
-    if (!revocable.checked) {
-      await userEvent.click(revocable);
-    }
-
     await userEvent.selectOptions(
       screen.getByRole("combobox", { name: words("settings.tabs.token.expiry") }),
       "custom"
@@ -241,37 +207,6 @@ describe("Token Tab", () => {
     );
 
     await waitFor(() => expect(requestBody).toEqual({ client_types: ["api"], idempotent: false }));
-  });
-
-  test("GIVEN a non-revocable token THEN the expiry input is hidden and expire is not sent", async () => {
-    let requestBody: Record<string, unknown> | null = null;
-    server.use(
-      http.post("/api/v2/environment_auth", async ({ request }) => {
-        requestBody = (await request.json()) as Record<string, unknown>;
-
-        return HttpResponse.json({ data: "tokenstring123" });
-      })
-    );
-
-    const { component } = setup();
-
-    render(component);
-
-    // Make the revocable state explicit so this test is independent of the form's default.
-    const revocable: HTMLInputElement = screen.getByRole("switch", { name: "RevocableOption" });
-    if (revocable.checked) {
-      await userEvent.click(revocable);
-    }
-
-    expect(
-      screen.queryByRole("combobox", { name: words("settings.tabs.token.expiry") })
-    ).toBeNull();
-
-    await userEvent.click(
-      screen.getByRole("button", { name: words("settings.tabs.token.generate") })
-    );
-
-    await waitFor(() => expect(requestBody).toEqual({ client_types: ["api"], idempotent: true }));
   });
 
   test("GIVEN TokenTab WHEN generate fails THEN the error is shown", async () => {

--- a/src/Slices/Settings/UI/Tabs/Token/Tab.tsx
+++ b/src/Slices/Settings/UI/Tabs/Token/Tab.tsx
@@ -4,6 +4,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { ClientType, toggleValueInList } from "@/Core";
 import { getTokensKey, useGenerateToken } from "@/Data/Queries";
 import { words } from "@/UI/words";
+import { DEFAULT_EXPIRY_SECONDS } from "./ExpiryInput";
 import { TokenForm } from "./TokenForm";
 import { TokenTable } from "./TokenTable";
 
@@ -18,8 +19,7 @@ import { TokenTable } from "./TokenTable";
 export const Tab: React.FC = () => {
   const client = useQueryClient();
   const [clientTypes, setClientTypes] = useState<ClientType[]>(["api"]);
-  const [isRevocable, setIsRevocable] = useState(true);
-  const [expire, setExpire] = useState<number | null>(null);
+  const [expire, setExpire] = useState<number | null>(DEFAULT_EXPIRY_SECONDS);
   const [isBusy, setIsBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [token, setToken] = useState<string | null>(null);
@@ -51,11 +51,10 @@ export const Tab: React.FC = () => {
     setError(null);
     setToken(null);
     setIsBusy(true);
-    // Only revocable (non-idempotent) tokens can carry an expiry.
     mutate({
       client_types: clientTypes,
-      idempotent: !isRevocable,
-      ...(isRevocable && expire !== null ? { expire } : {}),
+      idempotent: false,
+      ...(expire !== null ? { expire } : {}),
     });
 
     setIsBusy(false);
@@ -68,8 +67,6 @@ export const Tab: React.FC = () => {
         onErrorClose={() => setError(null)}
         getClientTypeSelector={getClientTypeSelector}
         isClientTypeSelected={isClientTypeSelected}
-        isRevocable={isRevocable}
-        onRevocableChange={setIsRevocable}
         onExpireChange={setExpire}
         token={token}
         error={error}

--- a/src/Slices/Settings/UI/Tabs/Token/TokenForm.tsx
+++ b/src/Slices/Settings/UI/Tabs/Token/TokenForm.tsx
@@ -5,7 +5,6 @@ import {
   Form,
   FormGroup,
   InputGroup,
-  Switch,
   TextInput,
   Title,
   ToggleGroup,
@@ -82,8 +81,6 @@ interface Props {
   onErrorClose(): void;
   getClientTypeSelector(clientType: ClientType): (selected: boolean) => void;
   isClientTypeSelected(clientType: ClientType): boolean;
-  isRevocable: boolean;
-  onRevocableChange(value: boolean): void;
   onExpireChange(value: number | null): void;
   token: string | null;
   error: string | null;
@@ -94,8 +91,6 @@ export const TokenForm: React.FC<Props> = ({
   onGenerate,
   getClientTypeSelector,
   isClientTypeSelected,
-  isRevocable,
-  onRevocableChange,
   onExpireChange,
   token,
   error,
@@ -107,18 +102,7 @@ export const TokenForm: React.FC<Props> = ({
       {words("settings.tabs.token.title")}
     </Title>
     <Description>{words("settings.tabs.token.description")}</Description>
-    <StyledFormGroup label={words("settings.tabs.token.revocable")}>
-      <Switch
-        id="token-revocable"
-        aria-label="RevocableOption"
-        isChecked={isRevocable}
-        isDisabled={isBusy}
-        onChange={(_event, checked) => onRevocableChange(checked)}
-      />
-    </StyledFormGroup>
-
-    {/* An idempotent (non-revocable) token carries no time-based claims, so it cannot expire. */}
-    {isRevocable && <ExpiryInput onChange={onExpireChange} isDisabled={isBusy} />}
+    <ExpiryInput onChange={onExpireChange} isDisabled={isBusy} />
     <AdvancedSection
       toggleText={words("settings.tabs.token.advanced")}
       getClientTypeSelector={getClientTypeSelector}

--- a/src/Slices/Settings/UI/Tabs/Token/TokenTable.test.tsx
+++ b/src/Slices/Settings/UI/Tabs/Token/TokenTable.test.tsx
@@ -8,7 +8,10 @@ import { Token } from "@/Core/Domain";
 import { MockedDependencyProvider } from "@/Test";
 import { words } from "@/UI";
 import { ModalProvider } from "@/UI/Root/Components/ModalProvider";
+import { CustomDatePresenter } from "@/UI/Utils";
 import { TokenTable } from "./TokenTable";
+
+const datePresenter = new CustomDatePresenter();
 
 const makeToken = (overrides: Partial<Token> = {}): Token => ({
   jti: "11111111-1111-1111-1111-111111111111",
@@ -76,12 +79,12 @@ describe("TokenTable", () => {
     expect(within(activeRow).getByText("alice")).toBeVisible();
     expect(within(activeRow).getByText("api, compiler")).toBeVisible();
     expect(within(activeRow).getByText(words("settings.tabs.token.status.active"))).toBeVisible();
-    expect(within(activeRow).getByText(new Date(expiresAt).toLocaleString())).toBeVisible();
+    expect(within(activeRow).getByText(datePresenter.getFull(expiresAt))).toBeVisible();
 
     const revokedRow = screen.getByLabelText("token-row-bbb");
     expect(within(revokedRow).getByText(words("settings.tabs.token.status.revoked"))).toBeVisible();
     // The revocation moment is shown for revoked tokens.
-    expect(within(revokedRow).getByText(new Date(revokedAt).toLocaleString())).toBeVisible();
+    expect(within(revokedRow).getByText(datePresenter.getFull(revokedAt))).toBeVisible();
     // An already-revoked token cannot be revoked again.
     expect(within(revokedRow).getByRole("button", { name: "revoke-bbb" })).toBeDisabled();
   });

--- a/src/Slices/Settings/UI/Tabs/Token/TokenTable.tsx
+++ b/src/Slices/Settings/UI/Tabs/Token/TokenTable.tsx
@@ -2,12 +2,9 @@ import React, { useContext } from "react";
 import { Button, Label } from "@patternfly/react-core";
 import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
 import { useGetTokens, useRevokeToken } from "@/Data/Queries";
-import { EmptyView, ErrorView, LoadingView } from "@/UI/Components";
+import { DateWithTooltip, EmptyView, ErrorView, LoadingView } from "@/UI/Components";
 import { ModalContext } from "@/UI/Root/Components/ModalProvider";
 import { words } from "@/UI/words";
-
-const formatDate = (value: string | null): string =>
-  value ? new Date(value).toLocaleString() : "-";
 
 /**
  * Lists the registered (revocable) tokens of the current environment and allows revoking them.
@@ -84,9 +81,13 @@ export const TokenTable: React.FC = () => {
             <Tr key={token.jti} aria-label={`token-row-${token.jti}`}>
               <Td>{token.created_by ?? "-"}</Td>
               <Td>{token.client_types.join(", ")}</Td>
-              <Td>{formatDate(token.issued_at)}</Td>
-              <Td>{formatDate(token.expires_at)}</Td>
-              <Td>{formatDate(token.last_used)}</Td>
+              <Td>
+                <DateWithTooltip timestamp={token.issued_at} />
+              </Td>
+              <Td>
+                {token.expires_at ? <DateWithTooltip timestamp={token.expires_at} isFull /> : "-"}
+              </Td>
+              <Td>{token.last_used ? <DateWithTooltip timestamp={token.last_used} /> : "-"}</Td>
               <Td>
                 {isRevoked ? (
                   <Label color="red">{words("settings.tabs.token.status.revoked")}</Label>
@@ -94,7 +95,9 @@ export const TokenTable: React.FC = () => {
                   <Label color="green">{words("settings.tabs.token.status.active")}</Label>
                 )}
               </Td>
-              <Td>{formatDate(token.revoked_at)}</Td>
+              <Td>
+                {token.revoked_at ? <DateWithTooltip timestamp={token.revoked_at} isFull /> : "-"}
+              </Td>
               <Td isActionCell>
                 <Button
                   variant="danger"

--- a/src/UI/words.tsx
+++ b/src/UI/words.tsx
@@ -829,7 +829,7 @@ const dict = {
   "settings.tabs.token.empty": "No revocable tokens have been created for this environment.",
   "settings.tabs.token.column.createdBy": "Created by",
   "settings.tabs.token.column.clientTypes": "Client types",
-  "settings.tabs.token.column.issuedAt": "Issued at",
+  "settings.tabs.token.column.issuedAt": "Issued",
   "settings.tabs.token.column.expiresAt": "Expires at",
   "settings.tabs.token.column.lastUsed": "Last used",
   "settings.tabs.token.column.status": "Status",

--- a/src/UI/words.tsx
+++ b/src/UI/words.tsx
@@ -423,7 +423,7 @@ const dict = {
   "orders.column.option": "Options",
   "orders.column.action": "Action",
   "orders.column.serviceEntity": "Service Entity",
-  "orders.column.instanceId": "Instance Id",
+  "orders.column.instance": "Instance",
   "orders.row.dependencies": "Dependencies",
   "orders.row.config": "Config",
   "orders.row.state": "State",
@@ -817,7 +817,6 @@ const dict = {
   "settings.tabs.token.description.details":
     "Most tokens only need API access. The agent and compiler types are only required for connecting an externally hosted agent or a remote compiler to this environment.",
   "settings.tabs.token.generate": "Generate",
-  "settings.tabs.token.revocable": "Create a revocable token",
   "settings.tabs.token.expiry": "Expires after",
   "settings.tabs.token.expiry.never": "Never",
   "settings.tabs.token.expiry.custom": "Custom",


### PR DESCRIPTION
# Description

  - Default the create-token form in the Settings page to a revocable token
    - Don't allow the user to make a non-revocable token in the web-console.
  - Default the create-token form in the Settings page to a 7-day expiry
  - Use proper date formatting, consitent with the rest of the web-console for the token table.
    - revoked at, and expires at, use full timestamp
    - last used, and issued at use the relative date presentations with the full timestamp in the tooltip.
  - Use service_identity_attribute_value for the service instance in the order details rows.
  - Table header now only displays instance instead of instance id.

<img width="1387" height="843" alt="image" src="https://github.com/user-attachments/assets/83bcde43-06cc-44c8-84c1-6ba6551a28b1" />


<img width="1394" height="821" alt="image" src="https://github.com/user-attachments/assets/5006c193-ac5b-4b87-b961-190ef4d132da" />
