### PR TITLE
Moved the Facts page filters (name, resource id) from the inline tool into a side-panel drawer

### DIFF
--- a/changelogs/unreleased/6780-facts-filter-drawer.yml
+++ b/changelogs/unreleased/6780-facts-filter-drawer.yml
@@ -1,0 +1,6 @@
+description: The Facts page filters (name, resource id) have been moved from the inline toolbar into a side-panel drawer, opened from a filter toggle button that shows the number of active filters, matching the Resources page.
+issue-nr: 6780
+change-type: patch
+destination-branches: [master]
+sections:
+  minor-improvement: "{{description}}"

--- a/src/Data/Queries/Slices/Facts/GetFacts/useGetFacts.ts
+++ b/src/Data/Queries/Slices/Facts/GetFacts/useGetFacts.ts
@@ -1,5 +1,5 @@
 import { useContext } from "react";
-import { UseQueryResult, useQuery } from "@tanstack/react-query";
+import { UseQueryResult, keepPreviousData, useQuery } from "@tanstack/react-query";
 import { PageSize, Pagination, Sort } from "@/Core/Domain";
 import { Handlers, Links } from "@/Core/Domain/Pagination/Pagination";
 import { CurrentPage } from "@/Data/Common/UrlState/useUrlStateWithCurrentPage";
@@ -74,6 +74,7 @@ export const useGetFacts = (params: GetFactsParams): GetFacts => {
           handlers: getPaginationHandlers(data.links, data.metadata),
         }),
         refetchInterval: (query) => (query.state.error ? false : REFETCH_INTERVAL),
+        placeholderData: keepPreviousData,
       }),
   };
 };

--- a/src/Slices/Facts/UI/FilterWidget/ConnectedFilterWidget.tsx
+++ b/src/Slices/Facts/UI/FilterWidget/ConnectedFilterWidget.tsx
@@ -1,0 +1,30 @@
+import React, { memo } from "react";
+import { useUrlStateWithFilter } from "@/Data";
+import { Filter } from "@/Slices/Facts/Core/Types";
+import { FilterWidgetComponent } from "./FilterWidgetComponent";
+
+interface Props {
+  onClose: () => void;
+}
+
+/**
+ * Memoized wrapper around FilterWidgetComponent that owns its filter state
+ * via URL state management. By managing the filter state internally, this component
+ * avoids re-rendering when the parent page re-renders due to other state changes.
+ * Only the table area needs to respond to filter changes; the filter widget itself
+ * preserves its UI state (typed input) across filter updates.
+ *
+ * @Props {Props} - Component props.
+ *  @prop {() => void} onClose - Callback executed when the filter drawer should be closed.
+ *
+ * @returns {React.ReactElement} The rendered filter widget.
+ */
+export const ConnectedFilterWidget: React.FC<Props> = memo(({ onClose }) => {
+  const [filter, setFilter] = useUrlStateWithFilter<Filter>({
+    route: "Facts",
+  });
+
+  return <FilterWidgetComponent filter={filter} setFilter={setFilter} onClose={onClose} />;
+});
+
+ConnectedFilterWidget.displayName = "ConnectedFilterWidget";

--- a/src/Slices/Facts/UI/FilterWidget/FilterWidgetComponent.tsx
+++ b/src/Slices/Facts/UI/FilterWidget/FilterWidgetComponent.tsx
@@ -1,0 +1,87 @@
+import React from "react";
+import { Divider, Form, Stack, StackItem } from "@patternfly/react-core";
+import { Filter } from "@/Slices/Facts/Core/Types";
+import {
+  ActiveFilterGroup,
+  ActiveFilters,
+  AddableTextInput,
+  FilterDrawerPanelContent,
+  getFilterActions,
+} from "@/UI/Components";
+import { words } from "@/UI/words";
+
+interface Props {
+  filter: Filter;
+  setFilter: (filter: Filter) => void;
+  onClose: () => void;
+}
+
+/**
+ * The FilterWidgetComponent for the Facts page.
+ *
+ * Renders the side-panel drawer content with a free-text name filter and a free-text
+ * resource id filter, followed by an active filters chip section.
+ *
+ * @Props {Props} - Component props.
+ *  @prop {Filter} filter - Current filter state supplied by the parent.
+ *  @prop {(filter: Filter) => void} setFilter - Setter to persist filter changes upstream.
+ *  @prop {() => void} onClose - Callback executed when the filter drawer should be closed.
+ *
+ * @returns {React.ReactElement} The rendered filter widget.
+ */
+export const FilterWidgetComponent: React.FC<Props> = ({ filter, setFilter, onClose }) => {
+  const { addString, removeStringChip, clearStringGroup } = getFilterActions(filter, setFilter);
+
+  const hasActiveFilters = (filter.name?.length ?? 0) > 0 || (filter.resource_id?.length ?? 0) > 0;
+
+  return (
+    <FilterDrawerPanelContent title={words("facts.filters")} onClose={onClose}>
+      <Stack hasGutter>
+        <Form onSubmit={(e) => e.preventDefault()}>
+          <StackItem>
+            <AddableTextInput
+              label={words("facts.column.name")}
+              placeholder={words("facts.filters.name.placeholder")}
+              onAdd={(value) => addString("name", value)}
+              type="search"
+            />
+          </StackItem>
+
+          <StackItem>
+            <AddableTextInput
+              label={words("facts.column.resourceId")}
+              placeholder={words("facts.filters.resourceId.placeholder")}
+              onAdd={(value) => addString("resource_id", value)}
+              type="search"
+            />
+          </StackItem>
+        </Form>
+
+        <Divider />
+
+        <ActiveFilters hasActiveFilters={hasActiveFilters} onClear={() => setFilter({})}>
+          {(filter.name?.length ?? 0) > 0 && (
+            <StackItem>
+              <ActiveFilterGroup
+                title={words("facts.column.name")}
+                values={filter.name}
+                onRemove={(value) => removeStringChip("name", value)}
+                onRemoveGroup={() => clearStringGroup("name")}
+              />
+            </StackItem>
+          )}
+          {(filter.resource_id?.length ?? 0) > 0 && (
+            <StackItem>
+              <ActiveFilterGroup
+                title={words("facts.column.resourceId")}
+                values={filter.resource_id}
+                onRemove={(value) => removeStringChip("resource_id", value)}
+                onRemoveGroup={() => clearStringGroup("resource_id")}
+              />
+            </StackItem>
+          )}
+        </ActiveFilters>
+      </Stack>
+    </FilterDrawerPanelContent>
+  );
+};

--- a/src/Slices/Facts/UI/FilterWidget/index.ts
+++ b/src/Slices/Facts/UI/FilterWidget/index.ts
@@ -1,0 +1,2 @@
+export * from "./ConnectedFilterWidget";
+export * from "./FilterWidgetComponent";

--- a/src/Slices/Facts/UI/Page.test.tsx
+++ b/src/Slices/Facts/UI/Page.test.tsx
@@ -139,6 +139,8 @@ describe("FactsPage", () => {
 
       expect(await screen.findAllByRole("row", { name: "FactsRow" })).toHaveLength(10);
 
+      await userEvent.click(screen.getByRole("button", { name: /Filters/, pressed: false }));
+
       const input = await screen.findByPlaceholderText(placeholderText);
 
       await userEvent.type(input, `${filterValue}{enter}`);

--- a/src/Slices/Facts/UI/Page.tsx
+++ b/src/Slices/Facts/UI/Page.tsx
@@ -1,4 +1,5 @@
-import React from "react";
+import React, { useCallback, useMemo, useState } from "react";
+import { Drawer, DrawerContent, DrawerContentBody, Stack, StackItem } from "@patternfly/react-core";
 import { usePaginatedTable } from "@/Data";
 import { useGetFacts } from "@/Data/Queries";
 import { Filter, SortKey } from "@/Slices/Facts/Core/Types";
@@ -8,18 +9,32 @@ import {
   LoadingView,
   PageContainer,
   PaginationWidget,
+  countActiveFilters,
 } from "@/UI/Components";
 import { words } from "@/UI/words";
 import { FactsTable } from "./FactsTable";
 import { FactsTablePresenter } from "./FactsTablePresenter";
+import { ConnectedFilterWidget } from "./FilterWidget";
 import { TableControls } from "./TableControls";
 
+/**
+ * Page component for the Facts View.
+ *
+ * @returns {React.FC} A React component that displays a list of facts
+ */
 export const Page: React.FC = () => {
-  const { currentPage, setCurrentPage, pageSize, setPageSize, filter, setFilter, sort, setSort } =
+  const [isDrawerExpanded, setIsDrawerExpanded] = useState(false);
+  const { currentPage, setCurrentPage, pageSize, setPageSize, filter, sort, setSort } =
     usePaginatedTable<Filter, SortKey>({
       route: "Facts",
       defaultSort: { name: "name", order: "asc" },
     });
+
+  const activeFilterCount = useMemo(() => countActiveFilters(filter), [filter]);
+
+  const onCloseFilterWidget = useCallback(() => {
+    setIsDrawerExpanded(false);
+  }, []);
 
   const { data, isSuccess, isError, error, refetch } = useGetFacts({
     pageSize,
@@ -40,10 +55,11 @@ export const Page: React.FC = () => {
 
   if (isSuccess) {
     return (
-      <PageContainer pageTitle={words("facts.title")}>
+      <PageContainer
+        pageTitle={words("facts.title")}
+        style={{ display: "flex", flexDirection: "column", flex: "1 1 auto", minHeight: 0 }}
+      >
         <TableControls
-          filter={filter}
-          setFilter={setFilter}
           paginationWidget={
             <PaginationWidget
               data={data}
@@ -52,18 +68,42 @@ export const Page: React.FC = () => {
               setCurrentPage={setCurrentPage}
             />
           }
+          onToggleFilters={() => setIsDrawerExpanded((prev) => !prev)}
+          isDrawerExpanded={isDrawerExpanded}
+          activeFilterCount={activeFilterCount}
         />
-        {data.data.length <= 0 ? (
-          <EmptyView message={words("facts.empty.message")} aria-label="FactsView-Empty" />
-        ) : (
-          <FactsTable
-            aria-label="Facts-Success"
-            rows={tablePresenter.createRows(data.data)}
-            tablePresenter={tablePresenter}
-            sort={sort}
-            setSort={setSort}
-          />
-        )}
+        <Drawer
+          isExpanded={isDrawerExpanded}
+          isInline
+          style={{ display: "flex", flexDirection: "column", flex: "1 1 auto" }}
+        >
+          <DrawerContent panelContent={<ConnectedFilterWidget onClose={onCloseFilterWidget} />}>
+            <DrawerContentBody
+              style={{
+                display: "flex",
+                flexDirection: "column",
+                flex: "1 1 auto",
+                minHeight: 0,
+              }}
+            >
+              {data.data.length <= 0 ? (
+                <EmptyView message={words("facts.empty.message")} aria-label="FactsView-Empty" />
+              ) : (
+                <Stack hasGutter style={{ flex: "1 1 auto", minHeight: 0, height: "100%" }}>
+                  <StackItem isFilled style={{ minHeight: 0, height: "100%", overflow: "auto" }}>
+                    <FactsTable
+                      aria-label="Facts-Success"
+                      rows={tablePresenter.createRows(data.data)}
+                      tablePresenter={tablePresenter}
+                      sort={sort}
+                      setSort={setSort}
+                    />
+                  </StackItem>
+                </Stack>
+              )}
+            </DrawerContentBody>
+          </DrawerContent>
+        </Drawer>
       </PageContainer>
     );
   }

--- a/src/Slices/Facts/UI/TableControls.tsx
+++ b/src/Slices/Facts/UI/TableControls.tsx
@@ -1,39 +1,46 @@
 import React from "react";
-import { Toolbar, ToolbarItem, ToolbarContent } from "@patternfly/react-core";
-import { Filter } from "@/Slices/Facts/Core/Types";
-import { FreeTextFilter } from "@/UI/Components";
+import { Toolbar, ToolbarContent, ToolbarItem } from "@patternfly/react-core";
+import { FilterToggleButton } from "@/UI/Components";
 import { words } from "@/UI/words";
 
 interface Props {
-  filter: Filter;
-  setFilter: (filter: Filter) => void;
   paginationWidget: React.ReactNode;
+  onToggleFilters: () => void;
+  isDrawerExpanded: boolean;
+  activeFilterCount: number;
 }
 
-export const TableControls: React.FC<Props> = ({ filter, setFilter, paginationWidget }) => {
-  const updateName = (names: string[]) =>
-    setFilter({ ...filter, name: names.length > 0 ? names : undefined });
-
-  const updateResourceId = (ids: string[]) =>
-    setFilter({ ...filter, resource_id: ids.length > 0 ? ids : undefined });
-
-  return (
-    <Toolbar clearAllFilters={() => setFilter({})} collapseListedFiltersBreakpoint="xl">
-      <ToolbarContent>
-        <FreeTextFilter
-          filterPropertyName={"Name"}
-          searchEntries={filter.name}
-          update={updateName}
-          placeholder={words("facts.filters.name.placeholder")}
+/**
+ * The TableControls component for the Facts page.
+ *
+ * Renders the toolbar with the pagination widget and the filter toggle button
+ * that opens the side-panel filter drawer.
+ *
+ * @Props {Props} - Component props.
+ *  @prop {React.ReactNode} paginationWidget - The pagination widget.
+ *  @prop {() => void} onToggleFilters - The function to toggle the filter drawer.
+ *  @prop {boolean} isDrawerExpanded - Whether the filter drawer is expanded.
+ *  @prop {number} activeFilterCount - The number of active filters.
+ *
+ * @returns {React.ReactElement} The rendered table controls.
+ */
+export const TableControls: React.FC<Props> = ({
+  paginationWidget,
+  onToggleFilters,
+  isDrawerExpanded,
+  activeFilterCount,
+}) => (
+  <Toolbar>
+    <ToolbarContent>
+      <ToolbarItem variant="pagination">{paginationWidget}</ToolbarItem>
+      <ToolbarItem>
+        <FilterToggleButton
+          onClick={onToggleFilters}
+          isExpanded={isDrawerExpanded}
+          activeFilterCount={activeFilterCount}
+          label={words("facts.filters")}
         />
-        <FreeTextFilter
-          filterPropertyName={"Resource Id"}
-          searchEntries={filter.resource_id}
-          update={updateResourceId}
-          placeholder={words("facts.filters.resourceId.placeholder")}
-        />
-        <ToolbarItem variant="pagination">{paginationWidget}</ToolbarItem>
-      </ToolbarContent>
-    </Toolbar>
-  );
-};
+      </ToolbarItem>
+    </ToolbarContent>
+  </Toolbar>
+);

--- a/src/UI/words.tsx
+++ b/src/UI/words.tsx
@@ -884,6 +884,7 @@ const dict = {
 
   /** Facts */
   "facts.title": "Facts",
+  "facts.filters": "Filters",
   "facts.filters.name.placeholder": "Name...",
   "facts.filters.resourceId.placeholder": "Resource Id...",
   "facts.column.name": "Name",


### PR DESCRIPTION
# Description

- Migrating the facts page filters to the side-pandel drawer

closes https://github.com/inmanta/web-console/issues/6780

https://github.com/user-attachments/assets/5b4c641f-6a6a-4ff8-9df5-5c4cc6aad65f